### PR TITLE
Revert to the older beta of the jujulib as beta7 only supports Juju 3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@canonical/jaaslib": "0.6.1",
-    "@canonical/jujulib": "2.0.0-beta.7",
+    "@canonical/jujulib": "2.0.0-beta.6",
     "@canonical/macaroon-bakery": "1.0.0",
     "@canonical/react-components": "0.23.0",
     "@sentry/browser": "6.13.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1851,10 +1851,10 @@
   resolved "https://registry.yarnpkg.com/@canonical/jaaslib/-/jaaslib-0.6.1.tgz#11eb43ba05e6e0c69e44a6947bd66fa1397ecefb"
   integrity sha512-Ts7TziwN3ZkB7bNpAnPoiSJQaDr9becHHx5AXaTl1uq/WKvscO0vtoa1QsBtksh5QMMuFlWn3Z2PmnfT4IVwmg==
 
-"@canonical/jujulib@2.0.0-beta.7":
-  version "2.0.0-beta.7"
-  resolved "https://registry.yarnpkg.com/@canonical/jujulib/-/jujulib-2.0.0-beta.7.tgz#e7a88b1c1d3786974e8abb1c4fe1755bf154371d"
-  integrity sha512-1cITL3RJn/SwniIEh/wTXoetFjbiOXe594/5cRFe0aTfhicmICPXHn1FjtI30p/WgDWt42IMe0wTVQ1lCvCe3Q==
+"@canonical/jujulib@2.0.0-beta.6":
+  version "2.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@canonical/jujulib/-/jujulib-2.0.0-beta.6.tgz#b3ba9c83278a9abca98a7f20245736409505710b"
+  integrity sha512-TLY9t8gi4n+BihAgk4LAF3gJ4JRKDUZPURB940sujeZs6fyvy7ovm+izElGKJGLWawFnJARuOe4SJKzht5WqtA==
   dependencies:
     "@canonical/macaroon-bakery" "0.3.0"
     btoa "1.2.1"


### PR DESCRIPTION
## Done

The previous renovate update bumped the jujulib version. That version only supports Juju 3.0 so we had to roll it back to beta6.

## QA

- The app should continue to work as expected.

