### PR TITLE
WD-2833 - Sort action logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "@types/node": "18.16.18",
     "@types/react": "18.2.0",
     "@types/react-dom": "18.2.0",
+    "@types/react-table": "7.7.14",
     "@types/redux-mock-store": "1.0.3",
     "@typescript-eslint/eslint-plugin": "5.59.11",
     "@typescript-eslint/parser": "5.59.11",

--- a/src/pages/EntityDetails/Model/Logs/ActionLogs/_action-logs.scss
+++ b/src/pages/EntityDetails/Model/Logs/ActionLogs/_action-logs.scss
@@ -4,8 +4,15 @@
 @mixin action-logs {
   .entity-details__action-logs {
     table {
+      // Operation ID column
+      th:nth-child(2) {
+        width: 15%;
+      }
+
       // log messages column
       th:nth-child(5),
+      // Completion time column.
+      th:nth-child(6),
       // control buttons column
       th:nth-child(7) {
         width: 20%;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10135,6 +10135,7 @@ __metadata:
     "@types/node": 18.16.18
     "@types/react": 18.2.0
     "@types/react-dom": 18.2.0
+    "@types/react-table": 7.7.14
     "@types/redux-mock-store": 1.0.3
     "@typescript-eslint/eslint-plugin": 5.59.11
     "@typescript-eslint/parser": 5.59.11


### PR DESCRIPTION
## Done

- Sort action logs by default and add sorting to other columns.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- If you don't have any action logs go to a model -> click on an app -> tick some units and click the run action button.
- Go to the model's action logs tab.
- Check that the most recent logs are first.
- Check that you can sort the table using the headers.

## Details

Fixes: #1033.
https://warthogs.atlassian.net/browse/WD-2833

## Screenshots

<img width="1039" alt="Screenshot 2023-06-01 at 9 36 00 am" src="https://github.com/canonical/juju-dashboard/assets/361637/469b4467-d759-47a3-a4c8-400f6b71826b">

