### PR TITLE
Rename demos

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -1,3 +1,3 @@
-domain: jaas-dashboard.demos.haus
-image: prod-web-team-demos.docker-registry.canonical.com/jaas-dashboard.demos.haus
+domain: juju-dashboard.demos.haus
+image: prod-web-team-demos.docker-registry.canonical.com/juju-dashboard.demos.haus
 readinessPath: "/"


### PR DESCRIPTION
## Done

- Rename demos to juju-dashboard

## QA

- Go to the demo URL in the comment below.
- Check that the subdomain is juju-dashboard.
- Check that the dashboard loads.

## Details

https://warthogs.atlassian.net/browse/WD-3991