### PR TITLE
WD-3994 - Update new issues links

### DIFF
--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,13 +1,15 @@
 import {
-  Notification,
-  Strip,
   CodeSnippet,
   CodeSnippetBlockAppearance,
+  Notification,
+  Strip,
 } from "@canonical/react-components";
 import * as Sentry from "@sentry/browser";
 import type { Extras } from "@sentry/types";
-import { Component } from "react";
 import type { PropsWithChildren } from "react";
+import { Component } from "react";
+
+import { externalURLs } from "urls";
 
 type Props = PropsWithChildren;
 
@@ -44,7 +46,9 @@ export default class ErrorBoundary extends Component<Props, State> {
     const body = encodeURIComponent(
       `\`\`\`\n${error?.stack ?? "No stack track"}\n\`\`\``
     );
-    const url = `https://github.com/canonical-web-and-design/jaas-dashboard/issues/new?assignees=&labels=&template=bug_report.md&title=Dashboard error: ${encodeURIComponent(
+    const url = `${
+      externalURLs.new_issue
+    }?assignees=&labels=&template=bug_report.md&title=Dashboard error: ${encodeURIComponent(
       error?.message ?? "No error"
     )}&body=${body}`;
     if (hasError) {

--- a/src/components/ErrorBoundary/__snapshots__/ErrorBoundary.test.tsx.snap
+++ b/src/components/ErrorBoundary/__snapshots__/ErrorBoundary.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`Error Boundary renders without crashing and matches snapshot 1`] = `
               Something has gone wrong. If this issue persists,
                
               <a
-                href="https://github.com/canonical-web-and-design/jaas-dashboard/issues/new?assignees=&labels=&template=bug_report.md&title=Dashboard error: Oh%20noes!&body=%60%60%60%0AStack%20trace%20output%0A%60%60%60"
+                href="https://github.com/canonical/juju-dashboard/issues/new?assignees=&labels=&template=bug_report.md&title=Dashboard error: Oh%20noes!&body=%60%60%60%0AStack%20trace%20output%0A%60%60%60"
                 rel="noopener noreferrer"
                 target="_blank"
               >

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -13,7 +13,7 @@ import {
   getGroupedModelStatusCounts,
 } from "store/juju/selectors";
 import type { Controllers } from "store/juju/types";
-import urls from "urls";
+import urls, { externalURLs } from "urls";
 import "./_primary-nav.scss";
 
 const ModelsLink = () => {
@@ -110,7 +110,7 @@ const PrimaryNav = () => {
           <li className="p-list__item">
             <a
               className="p-list__link"
-              href="https://github.com/canonical-web-and-design/jaas-dashboard/issues/new"
+              href={externalURLs.new_issue}
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/src/urls.ts
+++ b/src/urls.ts
@@ -48,4 +48,8 @@ const urls = {
   settings: "/settings",
 };
 
+export const externalURLs = {
+  new_issue: "https://github.com/canonical/juju-dashboard/issues/new",
+};
+
 export default urls;


### PR DESCRIPTION
## Done

- - Update new issues links to point to new repo URL.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- In the sidebar click the link to report a bug.
- Check that it takes you to the juju-dashboard repo.

## Details

https://warthogs.atlassian.net/browse/WD-3994