### PR TITLE
WD-5004 - fix: Broken docs links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,9 +39,7 @@ While we try to QA the dashboard as much as we can there are always combinations
 of Juju environments, browsers, devices etc. that we haven't tested or don't
 have access to.
 
-We have some [QA
-instructions](/docs/RELEASING.md#qa)
-to help you get started.
+We have some [QA instructions](/RELEASING.md#qa) to help you get started.
 
 ### Write docs
 
@@ -88,7 +86,7 @@ Some solutions might require some input from our in-house design team.
 
 #### Setting up for development
 
-Take a look at our [HACKING doc](/docs/HACKING.md) to find out how to get the
+Take a look at our [HACKING doc](/HACKING.md) to find out how to get the
 dashboard codebase set up, overview of the codebase and guides on setting up
 Juju environments.
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -5,7 +5,7 @@ Juju Dashboard is a JavaScript application built with [React](https://github.com
 [TypeScript](https://github.com/microsoft/TypeScript). Being familiar with those
 tools will help when developing the dashboard.
 
-If you haven't already read the [contribution guide](/docs/CONTRIBUTING.md) then
+If you haven't already read the [contribution guide](/CONTRIBUTING.md) then
 that is a good place to start as it will give you an overview of how to
 contribute and what kinds of contributions are welcome.
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ bugs for the relevant codebase will help the issue to be seen by the right team:
 ## Contributing
 
 Juju Dashboard is [open source](#licence) and we welcome contributions. Take
-a look at the [contribution guide](/docs/CONTRIBUTING.md) guide to find out how
+a look at the [contribution guide](/CONTRIBUTING.md) guide to find out how
 to contribute to the project.
 
 ## Development
@@ -115,11 +115,11 @@ Framework](https://github.com/canonical/vanilla-framework), [Vanilla React
 Components](https://github.com/canonical/react-components) and last but not
 least [Juju](https://github.com/juju/juju).
 
-To get started working on the dashboard take a look at our [development guide](/docs/HACKING.md).
+To get started working on the dashboard take a look at our [development guide](/HACKING.md).
 
 ## Release
 
-Check out the [release guide](/docs/RELEASING.md) for details about how to
+Check out the [release guide](/RELEASING.md) for details about how to
 release Juju Dashboard and its dependencies.
 
 ## Licence

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -56,7 +56,7 @@ confirm these work with the dashboard.
 
 #### Local machine controller
 
-If you don't already have a local controller you will need [to set one up](https://github.com/canonical/juju-dashboard/tree/main/docs/HACKING.md#juju-controllers-in-multipass).
+If you don't already have a local controller you will need [to set one up](https://github.com/canonical/juju-dashboard/tree/main/HACKING.md#juju-controllers-in-multipass).
 
 Clone the [juju-dashboard-charm
 repo](https://github.com/canonical/juju-dashboard-charm).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -56,7 +56,7 @@ confirm these work with the dashboard.
 
 #### Local machine controller
 
-If you don't already have a local controller you will need [to set one up](https://github.com/canonical/juju-dashboard/tree/main/HACKING.md#juju-controllers-in-multipass).
+If you don't already have a local controller you will need [to set one up](/HACKING.md#juju-controllers-in-multipass).
 
 Clone the [juju-dashboard-charm
 repo](https://github.com/canonical/juju-dashboard-charm).


### PR DESCRIPTION
## Done

- Fix links pointing to CONTRIBUTING.md, HACKING.md and RELEASING.md in the docs files.

## Details

Fixes: #1511 
https://warthogs.atlassian.net/browse/WD-5004
