### PR TITLE
WD-5039 - fix: Short panels don't stretch

### DIFF
--- a/src/panels/ConfigPanel/_config-panel.scss
+++ b/src/panels/ConfigPanel/_config-panel.scss
@@ -10,6 +10,10 @@ $panel-padding: 1.5rem;
 }
 
 .config-panel {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+
   &__modal-button-row-hint {
     font-size: #{map-get($font-sizes, small)}rem;
     margin-bottom: 1.5rem;
@@ -83,6 +87,19 @@ $panel-padding: 1.5rem;
 
   &__list {
     padding-right: $sph--large * 2;
+  }
+
+  .p-panel__content {
+    flex: 1;
+
+    .aside-split-col {
+      display: flex;
+      flex-direction: column;
+
+      .config-panel__list {
+        flex: 1;
+      }
+    }
   }
 
   &__list-header {


### PR DESCRIPTION
## Done

- Short panels stretch vertically until the bottom of the page and the buttons appear at the bottom of the page.

## Details

Fixes: #1505 
https://warthogs.atlassian.net/browse/WD-5039

## Screenshots
<img width="1280" alt="Screenshot 2023-07-10 at 13 07 55" src="https://github.com/canonical/juju-dashboard/assets/108150922/3c6b0205-93ab-4a2d-9650-3fc425f80ee7">

