### PR TITLE
WD-5050 - fix: Clicking outside action confirmation has error

### DIFF
--- a/src/panels/ActionsPanel/ActionsPanel.tsx
+++ b/src/panels/ActionsPanel/ActionsPanel.tsx
@@ -362,6 +362,7 @@ function SubmitConfirmation(
           </Button>
         </div>
       }
+      onClose={cancelFunction}
     >
       <div>
         <h4>Run {actionName}?</h4>

--- a/src/panels/ActionsPanel/CharmActionsPanel.tsx
+++ b/src/panels/ActionsPanel/CharmActionsPanel.tsx
@@ -263,6 +263,7 @@ function SubmitConfirmation(
           </Button>
         </div>
       }
+      onClose={cancelFunction}
     >
       <div>
         <h4>Run {actionName}?</h4>

--- a/src/panels/ConfigPanel/ConfigPanel.tsx
+++ b/src/panels/ConfigPanel/ConfigPanel.tsx
@@ -559,6 +559,7 @@ function SaveConfirmation(
           </div>
         </div>
       }
+      onClose={cancelFunction}
     >
       <h4>{Label.SAVE_CONFIRM}</h4>
       <p>


### PR DESCRIPTION
## Done

- Clicking outside action confirmation will close the action confirmation screen

## Details

Fixes: #1499 
https://warthogs.atlassian.net/browse/WD-5050
