### PR TITLE
WD-5215 - feat: Hide model column from table in model logs view

### DIFF
--- a/src/components/AuditLogsTable/AuditLogsTable.test.tsx
+++ b/src/components/AuditLogsTable/AuditLogsTable.test.tsx
@@ -3,8 +3,18 @@ import { renderComponent } from "testing/utils";
 import AuditLogsTable from "./AuditLogsTable";
 
 describe("AuditLogsTable", () => {
-  it("should have table data", () => {
-    renderComponent(<AuditLogsTable />);
+  it("should have model as second header when showing the model data", () => {
+    renderComponent(<AuditLogsTable showModel={true} />);
     expect(document.querySelector("table tr")).toBeVisible();
+    expect(document.querySelectorAll("table th")[1]).toHaveTextContent("model");
+  });
+
+  it("should not have model as header when not showing the model data", () => {
+    renderComponent(<AuditLogsTable showModel={false} />);
+    expect(document.querySelector("table tr")).toBeVisible();
+    const headers = document.querySelectorAll("table th");
+    headers.forEach((header) => {
+      expect(header).not.toHaveTextContent("model");
+    });
   });
 });

--- a/src/components/AuditLogsTable/AuditLogsTable.test.tsx
+++ b/src/components/AuditLogsTable/AuditLogsTable.test.tsx
@@ -9,6 +9,15 @@ describe("AuditLogsTable", () => {
     expect(document.querySelectorAll("table th")[1]).toHaveTextContent("model");
   });
 
+  it("should not have model as header when showModel param is not passed", () => {
+    renderComponent(<AuditLogsTable />);
+    expect(document.querySelector("table tr")).toBeVisible();
+    const headers = document.querySelectorAll("table th");
+    headers.forEach((header) => {
+      expect(header).not.toHaveTextContent("model");
+    });
+  });
+
   it("should not have model as header when not showing the model data", () => {
     renderComponent(<AuditLogsTable showModel={false} />);
     expect(document.querySelector("table tr")).toBeVisible();

--- a/src/components/AuditLogsTable/AuditLogsTable.tsx
+++ b/src/components/AuditLogsTable/AuditLogsTable.tsx
@@ -9,7 +9,7 @@ import { generateFakeAuditLogs } from "pages/Logs/audit-logs-fake-data";
 import getUserName from "utils/getUserName";
 
 type Props = {
-  showModel: boolean;
+  showModel?: boolean;
 };
 
 const COLUMN_DATA: Column[] = [
@@ -39,7 +39,7 @@ const COLUMN_DATA: Column[] = [
   },
 ];
 
-const AuditLogsTable = ({ showModel }: Props) => {
+const AuditLogsTable = ({ showModel = false }: Props) => {
   const { modelName } = useParams<EntityDetailsRoute>();
   const additionalEmptyMsg = showModel ? ` for ${modelName}` : "";
   const emptyMsg = `There are no audit logs available yet${additionalEmptyMsg}!`;

--- a/src/components/AuditLogsTable/AuditLogsTable.tsx
+++ b/src/components/AuditLogsTable/AuditLogsTable.tsx
@@ -8,6 +8,10 @@ import { formatFriendlyDateToNow } from "components/utils";
 import { generateFakeAuditLogs } from "pages/Logs/audit-logs-fake-data";
 import getUserName from "utils/getUserName";
 
+type Props = {
+  showModel: boolean;
+};
+
 const COLUMN_DATA: Column[] = [
   {
     Header: "user",
@@ -35,9 +39,13 @@ const COLUMN_DATA: Column[] = [
   },
 ];
 
-const AuditLogsTable = () => {
+const AuditLogsTable = ({ showModel }: Props) => {
   const { modelName } = useParams<EntityDetailsRoute>();
-  const emptyMsg = `There are no audit logs available yet for ${modelName}`;
+  const additionalEmptyMsg = showModel ? ` for ${modelName}` : "";
+  const emptyMsg = `There are no audit logs available yet${additionalEmptyMsg}!`;
+  const columnData = COLUMN_DATA.filter(
+    (column) => showModel || column.accessor !== "model"
+  );
 
   const fakeTableData = useMemo(() => {
     const auditLogsData = generateFakeAuditLogs();
@@ -68,7 +76,7 @@ const AuditLogsTable = () => {
 
   return (
     <ModularTable
-      columns={COLUMN_DATA}
+      columns={columnData}
       data={fakeTableData}
       emptyMsg={emptyMsg}
     />

--- a/src/pages/EntityDetails/Model/ApplicationsTab/ApplicationsTab.test.tsx
+++ b/src/pages/EntityDetails/Model/ApplicationsTab/ApplicationsTab.test.tsx
@@ -1,6 +1,5 @@
 import { screen } from "@testing-library/react";
 
-import { actions as jujuActions } from "store/juju";
 import type { RootState } from "store/store";
 import { jujuStateFactory, rootStateFactory } from "testing/factories";
 import { generalStateFactory } from "testing/factories/general";

--- a/src/pages/EntityDetails/Model/Logs/AuditLogs/AuditLogs.tsx
+++ b/src/pages/EntityDetails/Model/Logs/AuditLogs/AuditLogs.tsx
@@ -2,7 +2,7 @@ import AuditLogsTable from "components/AuditLogsTable";
 
 const AuditLogs = (): JSX.Element => (
   <div className="entity-details__audit-logs">
-    <AuditLogsTable showModel={false} />
+    <AuditLogsTable />
   </div>
 );
 

--- a/src/pages/EntityDetails/Model/Logs/AuditLogs/AuditLogs.tsx
+++ b/src/pages/EntityDetails/Model/Logs/AuditLogs/AuditLogs.tsx
@@ -2,7 +2,7 @@ import AuditLogsTable from "components/AuditLogsTable";
 
 const AuditLogs = (): JSX.Element => (
   <div className="entity-details__audit-logs">
-    <AuditLogsTable />
+    <AuditLogsTable showModel={false} />
   </div>
 );
 


### PR DESCRIPTION
## Done

- Updated the AuditLogsTable to take a prop to hide the Model column.
- Set the prop to hide the model column on the model level audit logs view.

## Details

https://warthogs.atlassian.net/browse/WD-5215