### PR TITLE
WD-5216 - feat: Hide audit log views when not using JAAS

### DIFF
--- a/src/components/LogIn/LogIn.tsx
+++ b/src/components/LogIn/LogIn.tsx
@@ -15,6 +15,7 @@ import {
   getLoginError,
   getWSControllerURL,
   isLoggedIn,
+  getIsJuju,
 } from "store/general/selectors";
 import type { RootState } from "store/store";
 import { useAppDispatch } from "store/store";
@@ -37,7 +38,7 @@ type Props = { children: ReactNode };
 
 export default function LogIn({ children }: Props) {
   const config = useSelector(getConfig);
-  const isJuju = useSelector(getConfig)?.isJuju;
+  const isJuju = useSelector(getIsJuju);
 
   const controllerConnections = useSelector(getControllerConnections) || {};
   const wsControllerURLs = Object.keys(controllerConnections);

--- a/src/components/Logo/Logo.tsx
+++ b/src/components/Logo/Logo.tsx
@@ -4,12 +4,12 @@ import { useSelector } from "react-redux";
 import jaasText from "static/images/logo/jaas-text.svg";
 import jujuText from "static/images/logo/juju-text.svg";
 import logoMark from "static/images/logo/logo-mark.svg";
-import { getConfig } from "store/general/selectors";
+import { getIsJuju } from "store/general/selectors";
 
 import "./_logo.scss";
 
 export default function Logo() {
-  const isJuju = useSelector(getConfig)?.isJuju;
+  const isJuju = useSelector(getIsJuju);
 
   return (
     <a href={isJuju ? "https://juju.is" : "https://jaas.ai"} className="logo">

--- a/src/components/PrimaryNav/PrimaryNav.test.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.test.tsx
@@ -173,4 +173,20 @@ describe("Primary Nav", () => {
     expect(navigationButtons[2]).toHaveTextContent("Logs");
     expect(navigationButtons[3]).toHaveTextContent("Report a bug");
   });
+
+  it("should not show LogsLink navigation button under Juju", () => {
+    const state = rootStateFactory.build({
+      general: generalStateFactory.build({
+        config: configFactory.build({
+          isJuju: true,
+        }),
+      }),
+    });
+    renderComponent(<PrimaryNav />, { state });
+    const navigationButtons = document.querySelectorAll(".p-list__link");
+    expect(navigationButtons).toHaveLength(3);
+    expect(navigationButtons[0]).toHaveTextContent("Models");
+    expect(navigationButtons[1]).toHaveTextContent("Controllers");
+    expect(navigationButtons[2]).toHaveTextContent("Report a bug");
+  });
 });

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -5,7 +5,7 @@ import { useSelector } from "react-redux";
 
 import Logo from "components/Logo/Logo";
 import UserMenu from "components/UserMenu/UserMenu";
-import { getAppVersion } from "store/general/selectors";
+import { getAppVersion, getConfig } from "store/general/selectors";
 import {
   getControllerData,
   getGroupedModelStatusCounts,
@@ -67,6 +67,8 @@ const PrimaryNav = () => {
   const [updateAvailable, setUpdateAvailable] = useState(false);
   const versionRequested = useRef(false);
 
+  const isJuju = useSelector(getConfig)?.isJuju;
+
   useEffect(() => {
     if (appVersion && !versionRequested.current) {
       dashboardUpdateAvailable(appVersion || "")
@@ -93,9 +95,11 @@ const PrimaryNav = () => {
         <li className="p-list__item">
           <ControllersLink />
         </li>
-        <li className="p-list__item">
-          <LogsLink />
-        </li>
+        {!isJuju && (
+          <li className="p-list__item">
+            <LogsLink />
+          </li>
+        )}
       </ul>
       <hr className="p-primary-nav__divider hide-collapsed" />
       <div className="p-primary-nav__bottom hide-collapsed">

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -5,7 +5,7 @@ import { useSelector } from "react-redux";
 
 import Logo from "components/Logo/Logo";
 import UserMenu from "components/UserMenu/UserMenu";
-import { getAppVersion, getConfig } from "store/general/selectors";
+import { getAppVersion, getIsJuju } from "store/general/selectors";
 import {
   getControllerData,
   getGroupedModelStatusCounts,
@@ -67,7 +67,7 @@ const PrimaryNav = () => {
   const [updateAvailable, setUpdateAvailable] = useState(false);
   const versionRequested = useRef(false);
 
-  const isJuju = useSelector(getConfig)?.isJuju;
+  const isJuju = useSelector(getIsJuju);
 
   useEffect(() => {
     if (appVersion && !versionRequested.current) {

--- a/src/components/Routes/Routes.tsx
+++ b/src/components/Routes/Routes.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { useSelector } from "react-redux";
 import {
   Navigate,
   Route,
@@ -14,6 +15,7 @@ import ModelDetails from "pages/ModelDetails/ModelDetails";
 import ModelsIndex from "pages/ModelsIndex/ModelsIndex";
 import PageNotFound from "pages/PageNotFound/PageNotFound";
 import Settings from "pages/Settings/Settings";
+import { getConfig } from "store/general/selectors";
 import urls from "urls";
 
 export type EntityDetailsRoute = {
@@ -27,6 +29,8 @@ export type EntityDetailsRoute = {
 export function Routes() {
   const sendAnalytics = useAnalytics();
   const location = useLocation();
+
+  const isJuju = useSelector(getConfig)?.isJuju;
 
   useEffect(() => {
     // Send an analytics event when the URL changes.
@@ -71,14 +75,16 @@ export function Routes() {
         }
       />
       <Route path="*" element={<PageNotFound />} />
-      <Route
-        path={urls.logs}
-        element={
-          <Login>
-            <Logs />
-          </Login>
-        }
-      />
+      {!isJuju && (
+        <Route
+          path={urls.logs}
+          element={
+            <Login>
+              <Logs />
+            </Login>
+          }
+        />
+      )}
     </ReactRouterRoutes>
   );
 }

--- a/src/components/Routes/Routes.tsx
+++ b/src/components/Routes/Routes.tsx
@@ -15,7 +15,7 @@ import ModelDetails from "pages/ModelDetails/ModelDetails";
 import ModelsIndex from "pages/ModelsIndex/ModelsIndex";
 import PageNotFound from "pages/PageNotFound/PageNotFound";
 import Settings from "pages/Settings/Settings";
-import { getConfig } from "store/general/selectors";
+import { getIsJuju } from "store/general/selectors";
 import urls from "urls";
 
 export type EntityDetailsRoute = {
@@ -30,7 +30,7 @@ export function Routes() {
   const sendAnalytics = useAnalytics();
   const location = useLocation();
 
-  const isJuju = useSelector(getConfig)?.isJuju;
+  const isJuju = useSelector(getIsJuju);
 
   useEffect(() => {
     // Send an analytics event when the URL changes.

--- a/src/pages/EntityDetails/EntityDetails.test.tsx
+++ b/src/pages/EntityDetails/EntityDetails.test.tsx
@@ -320,4 +320,26 @@ describe("Entity Details Container", () => {
     });
     expect(document.querySelector(".entity-details__unit")).toBeInTheDocument();
   });
+
+  it("should navigate correctly when pressing Action Logs tab under Juju", () => {
+    state.general.config = configFactory.build({
+      isJuju: true,
+    });
+    renderComponent(<EntityDetails />, { path, url, state });
+    const viewSelector = screen.getByTestId("view-selector");
+    const scrollIntoView = jest.fn();
+    fireEvent.click(within(viewSelector).getByText("Action Logs"), {
+      target: {
+        scrollIntoView,
+      },
+    });
+    expect(scrollIntoView.mock.calls[0]).toEqual([
+      {
+        behavior: "smooth",
+        block: "end",
+        inline: "nearest",
+      },
+    ]);
+    expect(window.location.search).toEqual("?activeView=logs");
+  });
 });

--- a/src/pages/EntityDetails/EntityDetails.tsx
+++ b/src/pages/EntityDetails/EntityDetails.tsx
@@ -15,7 +15,7 @@ import { useEntityDetailsParams } from "components/hooks";
 import { useQueryParams } from "hooks/useQueryParams";
 import useWindowTitle from "hooks/useWindowTitle";
 import BaseLayout from "layout/BaseLayout/BaseLayout";
-import { getConfig, getUserPass } from "store/general/selectors";
+import { getIsJuju, getUserPass } from "store/general/selectors";
 import {
   getControllerDataByUUID,
   getModelInfo,
@@ -50,7 +50,7 @@ const EntityDetails = () => {
   const modelInfo = useSelector(getModelInfo(modelUUID));
   const { isNestedEntityPage } = useEntityDetailsParams();
 
-  const isJuju = useSelector(getConfig)?.isJuju;
+  const isJuju = useSelector(getIsJuju);
 
   const [query] = useQueryParams({
     panel: null,

--- a/src/pages/EntityDetails/EntityDetails.tsx
+++ b/src/pages/EntityDetails/EntityDetails.tsx
@@ -15,7 +15,7 @@ import { useEntityDetailsParams } from "components/hooks";
 import { useQueryParams } from "hooks/useQueryParams";
 import useWindowTitle from "hooks/useWindowTitle";
 import BaseLayout from "layout/BaseLayout/BaseLayout";
-import { getUserPass } from "store/general/selectors";
+import { getConfig, getUserPass } from "store/general/selectors";
 import {
   getControllerDataByUUID,
   getModelInfo,
@@ -49,6 +49,8 @@ const EntityDetails = () => {
   const modelUUID = useSelector(getModelUUIDFromList(modelName, userName));
   const modelInfo = useSelector(getModelInfo(modelUUID));
   const { isNestedEntityPage } = useEntityDetailsParams();
+
+  const isJuju = useSelector(getConfig)?.isJuju;
 
   const [query] = useQueryParams({
     panel: null,
@@ -127,7 +129,7 @@ const EntityDetails = () => {
       },
       {
         active: activeView === "logs",
-        label: "Logs",
+        label: isJuju ? "Action Logs" : "Logs",
         onClick: (e: MouseEvent) => handleNavClick(e),
         to: urls.model.tab({ userName, modelName, tab: "logs" }),
         component: Link,

--- a/src/pages/EntityDetails/Model/Logs/Logs.test.tsx
+++ b/src/pages/EntityDetails/Model/Logs/Logs.test.tsx
@@ -1,5 +1,8 @@
 import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
+import { rootStateFactory } from "testing/factories";
+import { configFactory, generalStateFactory } from "testing/factories/general";
 import { renderComponent } from "testing/utils";
 
 import Logs from "./Logs";
@@ -33,5 +36,42 @@ describe("Model", () => {
     expect(
       document.querySelector(".entity-details__audit-logs")
     ).toBeInTheDocument();
+  });
+
+  it("should not render navigation tabs and Audit Logs page on Juju", () => {
+    const state = rootStateFactory.build({
+      general: generalStateFactory.build({
+        config: configFactory.build({
+          isJuju: true,
+        }),
+      }),
+    });
+    renderComponent(<Logs />, {
+      url: "/models/eggman@external/test1?activeView=logs&tableView=audit-logs",
+      path: "/models/:userName/:modelName",
+      state,
+    });
+
+    expect(
+      screen.queryByRole("tab", { name: "Action logs" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("tab", { name: "Audit logs" })
+    ).not.toBeInTheDocument();
+    expect(
+      document.querySelector(".entity-details__audit-logs")
+    ).not.toBeInTheDocument();
+  });
+
+  it("should navigate from Action Logs to Audit Logs", async () => {
+    renderComponent(<Logs />, {
+      url: "/models/eggman@external/test1?activeView=logs&tableView=action-logs",
+      path: "/models/:userName/:modelName",
+    });
+    const auditLogsTab = screen.getByRole("tab", { name: "Audit logs" });
+    await userEvent.click(auditLogsTab);
+    expect(window.location.search).toBe(
+      "?activeView=logs&tableView=audit-logs"
+    );
   });
 });

--- a/src/pages/EntityDetails/Model/Logs/Logs.tsx
+++ b/src/pages/EntityDetails/Model/Logs/Logs.tsx
@@ -1,5 +1,8 @@
+import { useSelector } from "react-redux";
+
 import SegmentedControl from "components/SegmentedControl";
 import { useQueryParams } from "hooks/useQueryParams";
+import { getConfig } from "store/general/selectors";
 
 import "./_logs.scss";
 import ActionLogs from "./ActionLogs";
@@ -16,6 +19,7 @@ const BUTTON_DETAILS = [
 ];
 
 const Logs = () => {
+  const isJuju = useSelector(getConfig)?.isJuju;
   const [{ tableView }, setQueryParams] = useQueryParams<{
     activeView: string | null;
     tableView: string;
@@ -25,18 +29,20 @@ const Logs = () => {
   });
   return (
     <div className="logs-tab">
-      <SegmentedControl
-        buttons={BUTTON_DETAILS.map(({ title, url }) => ({
-          children: title,
-          key: url,
-          onClick: () => {
-            setQueryParams({ tableView: url });
-          },
-        }))}
-        activeButton={tableView}
-      />
+      {!isJuju && (
+        <SegmentedControl
+          buttons={BUTTON_DETAILS.map(({ title, url }) => ({
+            children: title,
+            key: url,
+            onClick: () => {
+              setQueryParams({ tableView: url });
+            },
+          }))}
+          activeButton={tableView}
+        />
+      )}
       {tableView === "action-logs" && <ActionLogs />}
-      {tableView === "audit-logs" && <AuditLogs />}
+      {!isJuju && tableView === "audit-logs" && <AuditLogs />}
     </div>
   );
 };

--- a/src/pages/EntityDetails/Model/Logs/Logs.tsx
+++ b/src/pages/EntityDetails/Model/Logs/Logs.tsx
@@ -2,7 +2,7 @@ import { useSelector } from "react-redux";
 
 import SegmentedControl from "components/SegmentedControl";
 import { useQueryParams } from "hooks/useQueryParams";
-import { getConfig } from "store/general/selectors";
+import { getIsJuju } from "store/general/selectors";
 
 import "./_logs.scss";
 import ActionLogs from "./ActionLogs";
@@ -19,7 +19,7 @@ const BUTTON_DETAILS = [
 ];
 
 const Logs = () => {
-  const isJuju = useSelector(getConfig)?.isJuju;
+  const isJuju = useSelector(getIsJuju);
   const [{ tableView }, setQueryParams] = useQueryParams<{
     activeView: string | null;
     tableView: string;

--- a/src/store/general/selectors.test.ts
+++ b/src/store/general/selectors.test.ts
@@ -19,6 +19,7 @@ import {
   isLoggedIn,
   getActiveUserControllerAccess,
   getConnectionError,
+  getIsJuju,
 } from "./selectors";
 
 describe("selectors", () => {
@@ -33,6 +34,20 @@ describe("selectors", () => {
         })
       )
     ).toStrictEqual(config);
+  });
+
+  it("getIsJuju", () => {
+    expect(
+      getIsJuju(
+        rootStateFactory.build({
+          general: generalStateFactory.build({
+            config: configFactory.build({
+              isJuju: true,
+            }),
+          }),
+        })
+      )
+    ).toStrictEqual(true);
   });
 
   it("getUserPass", () => {

--- a/src/store/general/selectors.ts
+++ b/src/store/general/selectors.ts
@@ -15,6 +15,17 @@ export const getConfig = createSelector(
 );
 
 /**
+  Determines if Juju is used based on config value from state.
+  @param state The application state.
+  @returns true if Juju is used, false if Juju isn't used or
+    undefined if config is undefined.
+ */
+export const getIsJuju = createSelector(
+  [slice],
+  (sliceState) => sliceState?.config?.isJuju
+);
+
+/**
   Fetches the username and password from state.
   @param state The application state.
   @param wsControllerURL The fully qualified wsController URL to


### PR DESCRIPTION
## Done

- Hid audit log views when not using JAAS.

## TODO

- Add tests.

## Details

https://warthogs.atlassian.net/browse/WD-5216

## Screenshots

Using JAAS:
<img width="1280" alt="Screenshot 2023-07-28 at 18 20 37" src="https://github.com/canonical/juju-dashboard/assets/108150922/73f1f90d-87dc-4ab0-aa00-fe4c4aac6497">

Using local controller:
<img width="1280" alt="Screenshot 2023-07-28 at 18 21 07" src="https://github.com/canonical/juju-dashboard/assets/108150922/98c965f9-6e3b-4185-9332-b50192e69d38">
