### PR TITLE
Pass audit log params

### DIFF
--- a/src/juju/api.test.ts
+++ b/src/juju/api.test.ts
@@ -1476,6 +1476,24 @@ describe("Juju API", () => {
       expect(response).toMatchObject(events);
     });
 
+    it("fetches audit events with supplied params", async () => {
+      const events = { events: [] };
+      const conn = {
+        facades: {
+          jimM: {
+            findAuditEvents: jest.fn().mockReturnValue(events),
+          },
+        },
+      } as unknown as Connection;
+      const response = await findAuditEvents(conn, {
+        "user-tag": "user-eggman@external",
+      });
+      expect(conn.facades.jimM.findAuditEvents).toHaveBeenCalledWith({
+        "user-tag": "user-eggman@external",
+      });
+      expect(response).toMatchObject(events);
+    });
+
     it("handles errors", async () => {
       const error = new Error("Request failed");
       const conn = {

--- a/src/juju/api.ts
+++ b/src/juju/api.ts
@@ -46,7 +46,7 @@ import type { RootState, Store } from "store/store";
 
 import { getModelByUUID } from "../store/juju/selectors";
 
-import type { AuditEvents } from "./jimm-facade";
+import type { AuditEvents, FindAuditEventsRequest } from "./jimm-facade";
 import type {
   AllWatcherDelta,
   ApplicationInfo,
@@ -774,11 +774,14 @@ export async function getCharmsURLFromApplications(
 /**
   Fetch audit events via the JIMM facade on the given controller connection.
  */
-export function findAuditEvents(conn: ConnectionWithFacades) {
+export function findAuditEvents(
+  conn: ConnectionWithFacades,
+  params?: FindAuditEventsRequest
+) {
   return new Promise<AuditEvents>(async (resolve, reject) => {
     if (conn?.facades?.jimM) {
       try {
-        const events = await conn.facades.jimM.findAuditEvents();
+        const events = await conn.facades.jimM.findAuditEvents(params);
         resolve(events);
       } catch (e) {
         reject(e);

--- a/src/store/middleware/model-poller.test.ts
+++ b/src/store/middleware/model-poller.test.ts
@@ -404,7 +404,10 @@ describe("model poller", () => {
       wsControllerURL: "wss://example.com",
     });
     await middleware(next)(action);
-    expect(jujuModule.findAuditEvents).toHaveBeenCalled();
+    expect(jujuModule.findAuditEvents).toHaveBeenCalledWith(
+      expect.any(Object),
+      { "user-tag": "user-eggman@external" }
+    );
     expect(next).toHaveBeenCalledWith(action);
     expect(fakeStore.dispatch).toHaveBeenCalledWith(
       jujuActions.updateAuditEvents(events.events)

--- a/src/store/middleware/model-poller.ts
+++ b/src/store/middleware/model-poller.ts
@@ -181,14 +181,15 @@ export const modelPollerMiddleware: Middleware<
       // Intercept fetchAuditEvents actions and fetch and store audit events via the
       // controller connection.
 
+      const { wsControllerURL, ...params } = action.payload;
       // Immediately pass the action along so that it can be handled by the
       // reducer to update the loading state.
       next(action);
-      const conn = controllers.get(action.payload.wsControllerURL);
+      const conn = controllers.get(wsControllerURL);
       if (!conn) {
         return;
       }
-      const auditEvents = await findAuditEvents(conn);
+      const auditEvents = await findAuditEvents(conn, params);
       reduxStore.dispatch(jujuActions.updateAuditEvents(auditEvents.events));
       // The action has already been passed to the next middleware at the top of
       // this handler.


### PR DESCRIPTION
## Done

- Pass audit log params to the API call.

## QA

- Open `AuditLogsTable.tsx`.
- Find the line `dispatch(jujuActions.fetchAuditEvents({ wsControllerURL }));` and add `limit: 5` to the object.
- Load the Logs page and the audit logs should only have five entries.
