### PR TITLE
WD-5221- Fetch when filters change

### DIFF
--- a/src/components/AuditLogsTable/AuditLogsTable.tsx
+++ b/src/components/AuditLogsTable/AuditLogsTable.tsx
@@ -17,7 +17,9 @@ import {
 import { useAppDispatch } from "store/store";
 import getUserName from "utils/getUserName";
 
+import type { AuditLogFilters } from "./AuditLogsTableFilters/AuditLogsTableFilters";
 import AuditLogsTableFilters from "./AuditLogsTableFilters/AuditLogsTableFilters";
+import { DEFAULT_AUDIT_LOG_FILTERS } from "./AuditLogsTableFilters/AuditLogsTableFilters";
 import { DEFAULT_LIMIT_VALUE } from "./consts";
 import { useFetchAuditEvents } from "./hooks";
 
@@ -58,8 +60,12 @@ const AuditLogsTable = ({ showModel = false }: Props) => {
   const auditLogs = useSelector(getAuditEvents);
   const auditLogsLoaded = useSelector(getAuditEventsLoaded);
   const auditLogsLoading = useSelector(getAuditEventsLoading);
+  const [filters] = useQueryParams<AuditLogFilters>(DEFAULT_AUDIT_LOG_FILTERS);
+  const hasFilters = Object.values(filters).some((filter) => !!filter);
   const additionalEmptyMsg = showModel ? "" : ` for ${modelName}`;
-  const emptyMsg = `There are no audit logs available yet${additionalEmptyMsg}!`;
+  const emptyMsg = hasFilters
+    ? "No audit logs found. Try changing the filters."
+    : `There are no audit logs available yet${additionalEmptyMsg}!`;
   const columnData = COLUMN_DATA.filter(
     (column) => showModel || column.accessor !== "model"
   );

--- a/src/components/AuditLogsTable/AuditLogsTableActions/AuditLogsTableActions.test.tsx
+++ b/src/components/AuditLogsTable/AuditLogsTableActions/AuditLogsTableActions.test.tsx
@@ -71,7 +71,7 @@ describe("AuditLogsTableActions", () => {
     await userEvent.click(screen.getByRole("button", { name: "Next page" }));
     expect(window.location.search).toEqual("?page=2");
     await userEvent.click(screen.getByRole("button", { name: "Refresh" }));
-    expect(window.location.search).toEqual("?page=1");
+    expect(window.location.search).toEqual("");
   });
 
   it("should navigate to next page and then to previous page", async () => {
@@ -101,6 +101,6 @@ describe("AuditLogsTableActions", () => {
     await userEvent.click(dropdownMenu);
     await userEvent.selectOptions(dropdownMenu, "100/page");
     expect(dropdownMenu).toHaveTextContent("100/page");
-    expect(window.location.search).toEqual("?limit=100&page=1");
+    expect(window.location.search).toEqual("?limit=100");
   });
 });

--- a/src/components/AuditLogsTable/AuditLogsTableActions/AuditLogsTableActions.tsx
+++ b/src/components/AuditLogsTable/AuditLogsTableActions/AuditLogsTableActions.tsx
@@ -11,7 +11,7 @@ import { useSelector } from "react-redux";
 import { useQueryParams } from "hooks/useQueryParams";
 import { getAuditEvents } from "store/juju/selectors";
 
-import { DEFAULT_LIMIT_VALUE } from "../consts";
+import { DEFAULT_LIMIT_VALUE, DEFAULT_PAGE } from "../consts";
 import { useFetchAuditEvents } from "../hooks";
 
 import "./_audit-logs-table-actions.scss";
@@ -36,7 +36,7 @@ const AuditLogsTableActions = () => {
   }>({
     limit: null,
     panel: null,
-    page: "1",
+    page: DEFAULT_PAGE,
   });
   const limit = Number(queryParams.limit);
   const page = Number(queryParams.page);
@@ -47,7 +47,7 @@ const AuditLogsTableActions = () => {
         <Button
           hasIcon
           onClick={() => {
-            setQueryParams({ page: "1" }, { replace: true });
+            setQueryParams({ page: null }, { replace: true });
             fetchAuditEvents();
           }}
         >
@@ -67,7 +67,7 @@ const AuditLogsTableActions = () => {
           options={LIMIT_OPTIONS}
           onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
             setQueryParams(
-              { limit: e.target.value, page: "1" },
+              { limit: e.target.value, page: null },
               { replace: true }
             );
           }}

--- a/src/components/AuditLogsTable/AuditLogsTableFilters/AuditLogsTableFilters.tsx
+++ b/src/components/AuditLogsTable/AuditLogsTableFilters/AuditLogsTableFilters.tsx
@@ -46,10 +46,11 @@ export const generateFilters = (
   }, []);
 
 const AuditLogsTableFilters = () => {
-  const [filters, setFilters] = useQueryParams<AuditLogFilters>({
-    // Spread so that the default doesn't get updated when the filters change.
-    ...DEFAULT_AUDIT_LOG_FILTERS,
-  });
+  const [queryParams, setQueryParams] = useQueryParams<
+    AuditLogFilters & { page: string | null }
+  >({ ...DEFAULT_AUDIT_LOG_FILTERS, page: null });
+  // Extract just the filters so that they can be looped over.
+  const { page, ...filters } = queryParams;
   const hasFilters = Object.values(filters).some((filter) => !!filter);
   return hasFilters ? (
     <ActionBar>
@@ -57,13 +58,15 @@ const AuditLogsTableFilters = () => {
         <Button
           appearance="base"
           hasIcon
-          onClick={() => setFilters(DEFAULT_AUDIT_LOG_FILTERS)}
+          onClick={() =>
+            setQueryParams({ ...DEFAULT_AUDIT_LOG_FILTERS, page: null })
+          }
           className="u-no-margin"
         >
           <Icon name="close">Clear</Icon>
         </Button>
       </Tooltip>{" "}
-      <span>{generateFilters(filters, setFilters)}</span>
+      <span>{generateFilters(filters, setQueryParams)}</span>
     </ActionBar>
   ) : null;
 };

--- a/src/components/AuditLogsTable/consts.ts
+++ b/src/components/AuditLogsTable/consts.ts
@@ -1,1 +1,2 @@
 export const DEFAULT_LIMIT_VALUE = 50;
+export const DEFAULT_PAGE = "1";

--- a/src/components/AuditLogsTable/hooks.test.tsx
+++ b/src/components/AuditLogsTable/hooks.test.tsx
@@ -1,8 +1,6 @@
 import { renderHook } from "@testing-library/react";
-import { format } from "date-fns";
 import configureStore from "redux-mock-store";
 
-import { DATETIME_LOCAL } from "panels/AuditLogsFilterPanel/Fields/Fields";
 import { actions as jujuActions } from "store/juju";
 import type { RootState } from "store/store";
 import { rootStateFactory } from "testing/factories";
@@ -70,7 +68,7 @@ describe("useFetchAuditEvents", () => {
     changeURL(`/?${queryParams.toString()}`);
     const { result } = renderHook(() => useFetchAuditEvents(), {
       wrapper: (props) => (
-        <ComponentProviders {...props} path="*" store={store} />
+        <ComponentProviders {...props} path="" store={store} />
       ),
     });
     // Call the returned callback:
@@ -95,7 +93,7 @@ describe("useFetchAuditEvents", () => {
     const store = mockStore(state);
     const { result } = renderHook(() => useFetchAuditEvents(), {
       wrapper: (props) => (
-        <ComponentProviders {...props} path="*" store={store} />
+        <ComponentProviders {...props} path="" store={store} />
       ),
     });
     // Call the returned callback:
@@ -115,7 +113,7 @@ describe("useFetchAuditEvents", () => {
     const store = mockStore(state);
     const { result } = renderHook(() => useFetchAuditEvents(), {
       wrapper: (props) => (
-        <ComponentProviders {...props} path="*" store={store} />
+        <ComponentProviders {...props} path="" store={store} />
       ),
     });
     // Call the returned callback:

--- a/src/components/AuditLogsTable/hooks.ts
+++ b/src/components/AuditLogsTable/hooks.ts
@@ -9,7 +9,9 @@ import {
 import { actions as jujuActions } from "store/juju";
 import { useAppDispatch, useAppSelector } from "store/store";
 
-import { DEFAULT_LIMIT_VALUE } from "./consts";
+import type { AuditLogFilters } from "./AuditLogsTableFilters/AuditLogsTableFilters";
+import { DEFAULT_AUDIT_LOG_FILTERS } from "./AuditLogsTableFilters/AuditLogsTableFilters";
+import { DEFAULT_LIMIT_VALUE, DEFAULT_PAGE } from "./consts";
 
 export const useFetchAuditEvents = () => {
   const dispatch = useAppDispatch();
@@ -18,12 +20,15 @@ export const useFetchAuditEvents = () => {
     getControllerConnection(state, wsControllerURL)
   );
 
-  const [queryParams] = useQueryParams<{
-    page: string;
-    limit: string;
-  }>({
-    page: "1",
+  const [queryParams] = useQueryParams<
+    {
+      page: string;
+      limit: string;
+    } & AuditLogFilters
+  >({
+    page: DEFAULT_PAGE,
     limit: DEFAULT_LIMIT_VALUE.toString(),
+    ...DEFAULT_AUDIT_LOG_FILTERS,
   });
   const limit = Number(queryParams.limit);
   const page = Number(queryParams.page);
@@ -37,7 +42,32 @@ export const useFetchAuditEvents = () => {
         // Fetch an extra entry in order to check if there are more pages.
         limit: limit + 1,
         offset: (page - 1) * limit,
+        // Pass undefined to the API if the filters haven't been set.
+        after: queryParams.after
+          ? new Date(queryParams.after).toISOString()
+          : undefined,
+        before: queryParams.before
+          ? new Date(queryParams.before).toISOString()
+          : undefined,
+        // Convert the username to a user tag:
+        "user-tag": queryParams.user ? `user-${queryParams.user}` : undefined,
+        model: queryParams.model ?? undefined,
+        method: queryParams.method ?? undefined,
       })
     );
-  }, [dispatch, hasControllerConnection, limit, page, wsControllerURL]);
+  }, [
+    dispatch,
+    hasControllerConnection,
+    limit,
+    page,
+    wsControllerURL,
+    // Pass individual params so that this hook will only run if a specific
+    // param changes as opposed to the queryParams object which will change
+    // reference on each rerender.
+    queryParams.after,
+    queryParams.before,
+    queryParams.user,
+    queryParams.model,
+    queryParams.method,
+  ]);
 };

--- a/src/hooks/useQueryParams.test.tsx
+++ b/src/hooks/useQueryParams.test.tsx
@@ -75,6 +75,20 @@ describe("useQueryParams", () => {
     expect(searchParams.panels).toStrictEqual(["config", "actions"]);
   });
 
+  it("should not mutate the initial params", () => {
+    window.history.pushState({}, "", "?panels=config,actions");
+    const initial = { panels: [] };
+    const { result } = renderHook(
+      () => useQueryParams<{ panels: string[] }>(initial),
+      {
+        wrapper: generateContainer,
+      }
+    );
+    const [searchParams] = result.current;
+    expect(searchParams.panels).toStrictEqual(["config", "actions"]);
+    expect(initial).toStrictEqual({ panels: [] });
+  });
+
   it("can set string params", () => {
     const { result } = renderHook(
       () => useQueryParams<{ panel: string | null }>({ panel: null }),

--- a/src/hooks/useQueryParams.ts
+++ b/src/hooks/useQueryParams.ts
@@ -1,3 +1,4 @@
+import cloneDeep from "clone-deep";
 import { useCallback } from "react";
 import type { NavigateOptions } from "react-router-dom";
 import { useSearchParams } from "react-router-dom";
@@ -10,8 +11,10 @@ export type SetParams<P> = (
 export type QueryParams = Record<string, null | string | string[]>;
 
 export const useQueryParams = <P extends QueryParams>(
-  params: P
+  initialParams: P
 ): [P, SetParams<P>] => {
+  // Clone the params to prevent updating via reference.
+  const params = cloneDeep(initialParams);
   const [searchParams, setSearchParams] = useSearchParams();
 
   const setParam = useCallback(

--- a/src/panels/AuditLogsFilterPanel/AuditLogsFilterPanel.test.tsx
+++ b/src/panels/AuditLogsFilterPanel/AuditLogsFilterPanel.test.tsx
@@ -5,13 +5,13 @@ import { format } from "date-fns";
 import { renderComponent } from "testing/utils";
 
 import AuditLogsFilterPanel, { Label } from "./AuditLogsFilterPanel";
-import { Label as FieldLabel } from "./Fields/Fields";
+import { DATETIME_LOCAL, Label as FieldLabel } from "./Fields/Fields";
 
 describe("AuditLogsFilterPanel", () => {
   it("restores the filter values from the URL", async () => {
     const params = {
-      after: format(new Date(), "yyyy-MM-dd'T'hh:mm"),
-      before: format(new Date(), "yyyy-MM-dd'T'hh:mm"),
+      after: format(new Date(), DATETIME_LOCAL),
+      before: format(new Date(), DATETIME_LOCAL),
       user: "user-eggman",
       model: "model1",
       facade: "Admin",
@@ -64,10 +64,17 @@ describe("AuditLogsFilterPanel", () => {
     };
     const queryParams = new URLSearchParams(params);
     renderComponent(<AuditLogsFilterPanel />, {
-      url: `/?${queryParams.toString()}`,
+      url: `/?${queryParams.toString()}&page=4`,
     });
     await userEvent.click(screen.getByRole("button", { name: Label.CLEAR }));
     expect(window.location.search).toBe("");
+  });
+
+  it("disables the clear button if there are no filters", async () => {
+    renderComponent(<AuditLogsFilterPanel />, {
+      url: "/",
+    });
+    expect(screen.getByRole("button", { name: Label.CLEAR })).toBeDisabled();
   });
 
   it("can update the filters", async () => {
@@ -81,7 +88,7 @@ describe("AuditLogsFilterPanel", () => {
       version: "4",
     };
     renderComponent(<AuditLogsFilterPanel />, {
-      url: "/?panel=audit-log-filters",
+      url: "/?panel=audit-log-filters&page=4",
     });
     const after = document.querySelector<HTMLInputElement>(
       `input#${FieldLabel.AFTER}`

--- a/src/panels/AuditLogsFilterPanel/AuditLogsFilterPanel.tsx
+++ b/src/panels/AuditLogsFilterPanel/AuditLogsFilterPanel.tsx
@@ -32,11 +32,15 @@ const AuditLogsFilterPanel = (): JSX.Element => {
   // These params are handled separately from the values in usePanelQueryParams
   // as they shouldn't be cleared when the panel closes.
   const [queryParams, setQueryParams] = useQueryParams<
-    AuditLogFilters & { panel: string | null }
+    AuditLogFilters & { page: string | null; panel: string | null }
   >({
     ...DEFAULT_AUDIT_LOG_FILTERS,
+    page: null,
     panel: null,
   });
+  // Extract just the filters so that they can be looped over.
+  const { page, panel, ...filters } = queryParams;
+  const hasFilters = Object.values(filters).some((filter) => !!filter);
   return (
     <>
       <Panel
@@ -44,9 +48,11 @@ const AuditLogsFilterPanel = (): JSX.Element => {
         drawer={
           <>
             <Button
+              disabled={!hasFilters}
               onClick={() => {
                 setQueryParams({
                   ...DEFAULT_AUDIT_LOG_FILTERS,
+                  page: null,
                   panel: undefined,
                 });
               }}
@@ -93,6 +99,7 @@ const AuditLogsFilterPanel = (): JSX.Element => {
             // Set the filters and close the panel.
             setQueryParams({
               ...filters,
+              page: null,
               panel: undefined,
             });
           }}

--- a/src/panels/AuditLogsFilterPanel/Fields/Fields.test.tsx
+++ b/src/panels/AuditLogsFilterPanel/Fields/Fields.test.tsx
@@ -9,6 +9,7 @@ import {
   modelListInfoFactory,
   modelDataFactory,
   modelDataInfoFactory,
+  controllerFactory,
 } from "testing/factories/juju/juju";
 import { renderComponent } from "testing/utils";
 
@@ -80,22 +81,30 @@ describe("Fields", () => {
   it("should suggest model options", async () => {
     state.juju.auditEvents.items = [
       auditEventFactory.build({
-        model: "testmodel1",
+        model: "controller1/testmodel1",
       }),
       auditEventFactory.build({
-        model: "testmodel1",
+        model: "controller1/testmodel1",
       }),
       auditEventFactory.build({
-        model: "testmodel2",
+        model: "controller2/testmodel2",
       }),
     ];
     state.juju.models = {
       abc123: modelListInfoFactory.build({
         name: "testmodel1",
+        wsControllerURL: "wss://example.com/api",
       }),
       def456: modelListInfoFactory.build({
         name: "testmodel3",
+        wsControllerURL: "wss://test.com/api",
       }),
+    };
+    state.juju.controllers = {
+      "wss://example.com/api": [
+        controllerFactory.build({ name: "controller1" }),
+      ],
+      "wss://test.com/api": [controllerFactory.build({ name: "controller3" })],
     };
     renderComponent(
       <Formik initialValues={{}} onSubmit={jest.fn()}>
@@ -104,16 +113,16 @@ describe("Fields", () => {
       { state }
     );
     expect(
-      document.querySelector("option[value='testmodel1']")
+      document.querySelector("option[value='controller1/testmodel1']")
     ).toBeInTheDocument();
     expect(
-      document.querySelectorAll("option[value='testmodel1']")
+      document.querySelectorAll("option[value='controller1/testmodel1']")
     ).toHaveLength(1);
     expect(
-      document.querySelector("option[value='testmodel2']")
+      document.querySelector("option[value='controller2/testmodel2']")
     ).toBeInTheDocument();
     expect(
-      document.querySelector("option[value='testmodel3']")
+      document.querySelector("option[value='controller3/testmodel3']")
     ).toBeInTheDocument();
   });
 

--- a/src/panels/AuditLogsFilterPanel/Fields/Fields.tsx
+++ b/src/panels/AuditLogsFilterPanel/Fields/Fields.tsx
@@ -25,7 +25,7 @@ export enum Label {
   VERSION = "Version",
 }
 
-export const DATETIME_LOCAL = "yyyy-MM-dd'T'hh:mm";
+export const DATETIME_LOCAL = "yyyy-MM-dd'T'HH:mm";
 
 const Fields = (): JSX.Element => {
   const auditEventUsers = useSelector(getAuditEventsUsers);

--- a/src/panels/AuditLogsFilterPanel/Fields/Fields.tsx
+++ b/src/panels/AuditLogsFilterPanel/Fields/Fields.tsx
@@ -1,4 +1,5 @@
 import { Input } from "@canonical/react-components";
+import { format } from "date-fns";
 import { Field, useFormikContext } from "formik";
 import { useSelector } from "react-redux";
 
@@ -8,7 +9,7 @@ import {
   getAuditEventsMethods,
   getAuditEventsUsers,
   getAuditEventsModels,
-  getModelNames,
+  getFullModelNames,
   getUsers,
 } from "store/juju/selectors";
 
@@ -24,13 +25,15 @@ export enum Label {
   VERSION = "Version",
 }
 
+export const DATETIME_LOCAL = "yyyy-MM-dd'T'hh:mm";
+
 const Fields = (): JSX.Element => {
   const auditEventUsers = useSelector(getAuditEventsUsers);
   const jujuUsers = useSelector(getUsers);
   // Get the unique users from the logs and models returned from Juju.
   const users = Array.from(new Set([...auditEventUsers, ...jujuUsers]));
   const auditEventModels = useSelector(getAuditEventsModels);
-  const jujuModels = useSelector(getModelNames);
+  const jujuModels = useSelector(getFullModelNames);
   // Get the unique model names from the logs and models returned from Juju.
   const models = Array.from(new Set([...auditEventModels, ...jujuModels]));
   const facades = useSelector(getAuditEventsFacades);
@@ -45,8 +48,9 @@ const Fields = (): JSX.Element => {
         // https://github.com/canonical/react-components/issues/957
         id={Label.AFTER}
         label={Label.AFTER}
-        // Prevent this field from choosing a date after the 'Before' date.
-        max={values.before}
+        // Prevent this field from choosing a date after the 'Before' date or in
+        // the future.
+        max={values.before ? values.before : format(new Date(), DATETIME_LOCAL)}
         name="after"
         as={Input}
       />
@@ -58,6 +62,8 @@ const Fields = (): JSX.Element => {
         label={Label.BEFORE}
         // Prevent this field from choosing a date before the 'After' date.
         min={values.after}
+        // Prevent this field from choosing a date in the future.
+        max={format(new Date(), DATETIME_LOCAL)}
         name="before"
         as={Input}
       />

--- a/src/store/juju/selectors.test.ts
+++ b/src/store/juju/selectors.test.ts
@@ -78,7 +78,7 @@ import {
   getAuditEventsModels,
   getAuditEventsFacades,
   getAuditEventsMethods,
-  getModelNames,
+  getFullModelNames,
   getUsers,
 } from "./selectors";
 
@@ -848,24 +848,34 @@ describe("selectors", () => {
     ).toStrictEqual(models);
   });
 
-  it("getModelNames", () => {
+  it("getFullModelNames", () => {
     const models = {
       abc123: modelListInfoFactory.build({
         name: "model1",
+        wsControllerURL: "wss://example.com/api",
       }),
       def456: modelListInfoFactory.build({
         name: "model2",
+        wsControllerURL: "wss://test.com/api",
       }),
     };
     expect(
-      getModelNames(
+      getFullModelNames(
         rootStateFactory.build({
           juju: jujuStateFactory.build({
             models,
+            controllers: {
+              "wss://example.com/api": [
+                controllerFactory.build({ name: "controller1" }),
+              ],
+              "wss://test.com/api": [
+                controllerFactory.build({ name: "controller2" }),
+              ],
+            },
           }),
         })
       )
-    ).toStrictEqual(["model1", "model2"]);
+    ).toStrictEqual(["controller1/model1", "controller2/model2"]);
   });
 
   it("getModelByUUID", () => {

--- a/src/store/juju/selectors.ts
+++ b/src/store/juju/selectors.ts
@@ -152,8 +152,20 @@ export const getModelList = createSelector(
 /**
   Get the names of all models.
 */
-export const getModelNames = createSelector([getModelList], (modelList) =>
-  Object.values(modelList)?.map(({ name }) => name)
+export const getFullModelNames = createSelector(
+  [getModelList, getControllerData],
+  (modelList, controllers) =>
+    controllers
+      ? Object.values(modelList)?.reduce<string[]>((modelNames, model) => {
+          const controller =
+            model.wsControllerURL in controllers &&
+            controllers[model.wsControllerURL][0];
+          if (controller && "name" in controller) {
+            modelNames.push(`${controller.name}/${model.name}`);
+          }
+          return modelNames;
+        }, [])
+      : []
 );
 
 /**

--- a/src/store/juju/types.ts
+++ b/src/store/juju/types.ts
@@ -16,6 +16,7 @@ export type ControllerLocation = {
 export type Controller = {
   additionalController?: boolean;
   location?: ControllerLocation;
+  name?: string;
   path: string;
   Public?: boolean;
   uuid: string;


### PR DESCRIPTION
## Done

- Refetch the audit logs when the filters change.

## QA

- Connect to staging.
- Go to the logs page.
- Open the filters panel and enter some filters (note: facade name and version aren't currently supported - I've added a Jira task for this - and the facade method does not appear to be changing anything in the response from the API).
- Click Filter and the logs should reload.

## Details

https://warthogs.atlassian.net/browse/WD-5221