### PR TITLE
WD-5745 - Remove facade name and version filters

### DIFF
--- a/src/components/AuditLogsTable/AuditLogsTableFilters/AuditLogsTableFilters.tsx
+++ b/src/components/AuditLogsTable/AuditLogsTableFilters/AuditLogsTableFilters.tsx
@@ -10,9 +10,7 @@ export type AuditLogFilters = {
   before: string | null;
   user: string | null;
   model: string | null;
-  facade: string | null;
   method: string | null;
-  version: string | null;
 };
 
 export const DEFAULT_AUDIT_LOG_FILTERS = {
@@ -20,9 +18,7 @@ export const DEFAULT_AUDIT_LOG_FILTERS = {
   before: null,
   user: null,
   model: null,
-  facade: null,
   method: null,
-  version: null,
 };
 
 export const generateFilters = (

--- a/src/components/AuditLogsTable/hooks.test.tsx
+++ b/src/components/AuditLogsTable/hooks.test.tsx
@@ -66,9 +66,7 @@ describe("useFetchAuditEvents", () => {
       before: now,
       user: "eggman",
       model: "model1",
-      facade: "Admin",
       method: "Login",
-      version: "4",
     };
     const queryParams = new URLSearchParams(params);
     changeURL(`/?${queryParams.toString()}`);

--- a/src/panels/AuditLogsFilterPanel/AuditLogsFilterPanel.test.tsx
+++ b/src/panels/AuditLogsFilterPanel/AuditLogsFilterPanel.test.tsx
@@ -14,9 +14,7 @@ describe("AuditLogsFilterPanel", () => {
       before: format(new Date(), DATETIME_LOCAL),
       user: "user-eggman",
       model: "model1",
-      facade: "Admin",
       method: "Login",
-      version: "4",
       panel: "audit-log-filters",
     };
     const queryParams = new URLSearchParams(params);
@@ -38,17 +36,8 @@ describe("AuditLogsFilterPanel", () => {
       screen.getByRole("combobox", { name: FieldLabel.METHOD })
     ).toHaveValue(params.method);
     expect(
-      screen.getByRole("combobox", { name: FieldLabel.FACADE })
-    ).toHaveValue(params.facade);
-    expect(
       screen.getByRole("combobox", { name: FieldLabel.METHOD })
     ).toHaveValue(params.method);
-    expect(
-      screen.getByRole("spinbutton", { name: FieldLabel.VERSION })
-    ).toHaveValue(Number(params.version));
-    expect(
-      await screen.findByRole("spinbutton", { name: FieldLabel.VERSION })
-    ).toHaveValue(Number(params.version));
   });
 
   it("can clear the filters", async () => {
@@ -57,9 +46,7 @@ describe("AuditLogsFilterPanel", () => {
       before: new Date().toISOString(),
       user: "user-eggman",
       model: "model1",
-      facade: "Admin",
       method: "Login",
-      version: "4",
       panel: "audit-log-filters",
     };
     const queryParams = new URLSearchParams(params);
@@ -83,9 +70,7 @@ describe("AuditLogsFilterPanel", () => {
       before: format(new Date(), "yyyy-MM-dd'T'hh:mm"),
       user: "user-eggman",
       model: "model1",
-      facade: "Admin",
       method: "Login",
-      version: "4",
     };
     renderComponent(<AuditLogsFilterPanel />, {
       url: "/?panel=audit-log-filters&page=4",
@@ -113,16 +98,8 @@ describe("AuditLogsFilterPanel", () => {
       params.model
     );
     await userEvent.type(
-      screen.getByRole("combobox", { name: FieldLabel.FACADE }),
-      params.facade
-    );
-    await userEvent.type(
       screen.getByRole("combobox", { name: FieldLabel.METHOD }),
       params.method
-    );
-    await userEvent.type(
-      screen.getByRole("spinbutton", { name: FieldLabel.VERSION }),
-      params.version
     );
     await userEvent.click(screen.getByRole("button", { name: Label.FILTER }));
     const queryParams = new URLSearchParams(params);
@@ -134,17 +111,17 @@ describe("AuditLogsFilterPanel", () => {
       url: "/?panel=audit-log-filters",
     });
     await userEvent.type(
-      screen.getByRole("combobox", { name: FieldLabel.FACADE }),
-      "Admin"
+      screen.getByRole("combobox", { name: FieldLabel.METHOD }),
+      "Login"
     );
     await userEvent.click(screen.getByRole("button", { name: Label.FILTER }));
     // Only the facade was set, so no other filters should appear in the query string.
-    expect(window.location.search).toBe("?facade=Admin");
+    expect(window.location.search).toBe("?method=Login");
   });
 
   it("removes query params if the value was removed", async () => {
     renderComponent(<AuditLogsFilterPanel />, {
-      url: "/?panel=audit-log-filters&facade=Admin&method=Login",
+      url: "/?panel=audit-log-filters&user-tag=user-eggman@external&method=Login",
     });
     await userEvent.clear(
       screen.getByRole("combobox", { name: FieldLabel.METHOD })
@@ -152,6 +129,6 @@ describe("AuditLogsFilterPanel", () => {
     await userEvent.click(screen.getByRole("button", { name: Label.FILTER }));
     // The method value was cleared in the input so it should get removed from
     // the query string.
-    expect(window.location.search).toBe("?facade=Admin");
+    expect(window.location.search).toBe("?user-tag=user-eggman%40external");
   });
 });

--- a/src/panels/AuditLogsFilterPanel/AuditLogsFilterPanel.tsx
+++ b/src/panels/AuditLogsFilterPanel/AuditLogsFilterPanel.tsx
@@ -76,9 +76,7 @@ const AuditLogsFilterPanel = (): JSX.Element => {
             before: queryParams.before ?? "",
             user: queryParams.user ?? "",
             model: queryParams.model ?? "",
-            facade: queryParams.facade ?? "",
             method: queryParams.method ?? "",
-            version: queryParams.version ?? "",
           }}
           onSubmit={(values) => {
             // Replace empty strings with `null` so that the query params get

--- a/src/panels/AuditLogsFilterPanel/Fields/Fields.test.tsx
+++ b/src/panels/AuditLogsFilterPanel/Fields/Fields.test.tsx
@@ -163,31 +163,6 @@ describe("Fields", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("should suggest facade options", async () => {
-    state.juju.auditEvents.items = [
-      auditEventFactory.build({
-        "facade-name": "Admin",
-      }),
-      auditEventFactory.build({
-        "facade-name": "Admin",
-      }),
-      auditEventFactory.build({
-        "facade-name": "ModelManager",
-      }),
-    ];
-    renderComponent(
-      <Formik initialValues={{}} onSubmit={jest.fn()}>
-        <Fields />
-      </Formik>,
-      { state }
-    );
-    expect(document.querySelector("option[value='Admin']")).toBeInTheDocument();
-    expect(document.querySelectorAll("option[value='Admin']")).toHaveLength(1);
-    expect(
-      document.querySelector("option[value='ModelManager']")
-    ).toBeInTheDocument();
-  });
-
   it("should suggest method options", async () => {
     state.juju.auditEvents.items = [
       auditEventFactory.build({

--- a/src/panels/AuditLogsFilterPanel/Fields/Fields.tsx
+++ b/src/panels/AuditLogsFilterPanel/Fields/Fields.tsx
@@ -7,7 +7,6 @@ import { useParams } from "react-router-dom";
 import AutocompleteInput from "components/AutocompleteInput";
 import type { EntityDetailsRoute } from "components/Routes/Routes";
 import {
-  getAuditEventsFacades,
   getAuditEventsMethods,
   getAuditEventsUsers,
   getAuditEventsModels,
@@ -20,11 +19,9 @@ import type { FormFields } from "../types";
 export enum Label {
   AFTER = "After",
   BEFORE = "Before",
-  FACADE = "Facade",
   METHOD = "Method",
   MODEL = "Model",
   USER = "User",
-  VERSION = "Version",
 }
 
 export const DATETIME_LOCAL = "yyyy-MM-dd'T'HH:mm";
@@ -40,7 +37,6 @@ const Fields = (): JSX.Element => {
   const jujuModels = useSelector(getFullModelNames);
   // Get the unique model names from the logs and models returned from Juju.
   const models = Array.from(new Set([...auditEventModels, ...jujuModels]));
-  const facades = useSelector(getAuditEventsFacades);
   const methods = useSelector(getAuditEventsMethods);
   const { values } = useFormikContext<FormFields>();
 
@@ -98,30 +94,11 @@ const Fields = (): JSX.Element => {
         type="text"
         // Have to manually set the id until this issue has been fixed:
         // https://github.com/canonical/react-components/issues/957
-        id={Label.FACADE}
-        label={Label.FACADE}
-        name="facade"
-        as={AutocompleteInput}
-        options={facades}
-      />
-      <Field
-        type="text"
-        // Have to manually set the id until this issue has been fixed:
-        // https://github.com/canonical/react-components/issues/957
         id={Label.METHOD}
         label={Label.METHOD}
         name="method"
         as={AutocompleteInput}
         options={methods}
-      />
-      <Field
-        type="number"
-        // Have to manually set the id until this issue has been fixed:
-        // https://github.com/canonical/react-components/issues/957
-        id={Label.VERSION}
-        label={Label.VERSION}
-        name="version"
-        as={Input}
       />
     </>
   );

--- a/src/panels/AuditLogsFilterPanel/Fields/Fields.tsx
+++ b/src/panels/AuditLogsFilterPanel/Fields/Fields.tsx
@@ -19,7 +19,7 @@ import type { FormFields } from "../types";
 export enum Label {
   AFTER = "After",
   BEFORE = "Before",
-  METHOD = "Method",
+  METHOD = "Facade method",
   MODEL = "Model",
   USER = "User",
 }

--- a/src/panels/AuditLogsFilterPanel/types.ts
+++ b/src/panels/AuditLogsFilterPanel/types.ts
@@ -3,7 +3,5 @@ export type FormFields = {
   before: string;
   user: string;
   model: string;
-  facade: string;
   method: string;
-  version: string;
 };


### PR DESCRIPTION
## Done

- Remove the facade name and version filters as they are not supported by the API.

## QA

- Go to the logs page.
- Open the filter panel.
- See that the facade name and version inputs are no longer there.

## Details

https://warthogs.atlassian.net/browse/WD-5745