### PR TITLE
WD-5746 - fix: Fix pagination navigating to new blank page

### DIFF
--- a/src/components/AuditLogsTable/AuditLogsTable.tsx
+++ b/src/components/AuditLogsTable/AuditLogsTable.tsx
@@ -76,6 +76,7 @@ const AuditLogsTable = () => {
   });
   const page = Number(queryParams.page);
   const hasNextPage = (auditLogs?.length ?? 0) > auditLogsLimit;
+  const hasPrevPage = page > Number(DEFAULT_PAGE);
 
   useEffect(() => {
     fetchAuditEvents();
@@ -131,7 +132,7 @@ const AuditLogsTable = () => {
           emptyMsg={emptyMsg}
         />
       )}
-      {auditLogsLoaded && (hasNextPage || page > Number(DEFAULT_PAGE)) ? (
+      {!auditLogsLoading && auditLogsLoaded && (hasNextPage || hasPrevPage) ? (
         <AuditLogsTablePagination />
       ) : null}
     </>

--- a/src/components/AuditLogsTable/AuditLogsTablePagination/AuditLogsTablePagination.test.tsx
+++ b/src/components/AuditLogsTable/AuditLogsTablePagination/AuditLogsTablePagination.test.tsx
@@ -85,4 +85,18 @@ describe("AuditLogsTablePagination", () => {
     );
     expect(window.location.search).toEqual("");
   });
+
+  it("shouldn't be possible to navigate to next page if audit logs are loading", () => {
+    state.juju.auditEvents.items = auditEventFactory.buildList(51);
+    state.juju.auditEvents.loading = true;
+    renderComponent(<AuditLogsTablePagination />, { state });
+    expect(screen.getByRole("button", { name: "Next page" })).toBeDisabled();
+  });
+
+  it("shouldn't be possible to navigate to next page if audit logs haven't loaded", () => {
+    state.juju.auditEvents.items = auditEventFactory.buildList(51);
+    state.juju.auditEvents.loaded = false;
+    renderComponent(<AuditLogsTablePagination />, { state });
+    expect(screen.getByRole("button", { name: "Next page" })).toBeDisabled();
+  });
 });

--- a/src/components/AuditLogsTable/AuditLogsTablePagination/AuditLogsTablePagination.tsx
+++ b/src/components/AuditLogsTable/AuditLogsTablePagination/AuditLogsTablePagination.tsx
@@ -56,6 +56,7 @@ const AuditLogsTablePagination = ({
   });
   const limit = useAppSelector(getAuditEventsLimit);
   const page = Number(queryParams.page);
+  const hasNextPage = (auditLogs?.length ?? 0) > limit;
   const hasPrevPage = page > Number(DEFAULT_PAGE);
 
   const handleChangeSelect = useCallback(
@@ -101,11 +102,7 @@ const AuditLogsTablePagination = ({
           scrollToTop();
         }}
         // No further pages if couldn't fetch (limit + 1) entries.
-        forwardDisabled={
-          auditLogsLoading ||
-          !auditLogsLoaded ||
-          (auditLogs?.length ?? 0) <= limit
-        }
+        forwardDisabled={auditLogsLoading || !auditLogsLoaded || !hasNextPage}
         backDisabled={!hasPrevPage}
       />
     </div>

--- a/src/components/AuditLogsTable/AuditLogsTablePagination/AuditLogsTablePagination.tsx
+++ b/src/components/AuditLogsTable/AuditLogsTablePagination/AuditLogsTablePagination.tsx
@@ -5,7 +5,12 @@ import { useCallback, type HTMLProps, type OptionHTMLAttributes } from "react";
 
 import { useQueryParams } from "hooks/useQueryParams";
 import { actions as jujuActions } from "store/juju";
-import { getAuditEvents, getAuditEventsLimit } from "store/juju/selectors";
+import {
+  getAuditEvents,
+  getAuditEventsLimit,
+  getAuditEventsLoaded,
+  getAuditEventsLoading,
+} from "store/juju/selectors";
 import { useAppDispatch, useAppSelector } from "store/store";
 
 import { DEFAULT_LIMIT_VALUE, DEFAULT_PAGE } from "../consts";
@@ -40,6 +45,8 @@ const AuditLogsTablePagination = ({
 }: Props) => {
   const dispatch = useAppDispatch();
   const auditLogs = useAppSelector(getAuditEvents);
+  const auditLogsLoaded = useAppSelector(getAuditEventsLoaded);
+  const auditLogsLoading = useAppSelector(getAuditEventsLoading);
   const [queryParams, setQueryParams] = useQueryParams<{
     panel: string | null;
     page: string | null;
@@ -49,6 +56,7 @@ const AuditLogsTablePagination = ({
   });
   const limit = useAppSelector(getAuditEventsLimit);
   const page = Number(queryParams.page);
+  const hasPrevPage = page > Number(DEFAULT_PAGE);
 
   const handleChangeSelect = useCallback(
     (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -72,7 +80,7 @@ const AuditLogsTablePagination = ({
       ) : null}
       <Button
         className="u-no-margin--right"
-        disabled={page === Number(DEFAULT_PAGE)}
+        disabled={!hasPrevPage}
         hasIcon
         onClick={() => {
           setQueryParams({ page: null });
@@ -93,8 +101,12 @@ const AuditLogsTablePagination = ({
           scrollToTop();
         }}
         // No further pages if couldn't fetch (limit + 1) entries.
-        forwardDisabled={(auditLogs?.length ?? 0) <= limit}
-        backDisabled={page === 1}
+        forwardDisabled={
+          auditLogsLoading ||
+          !auditLogsLoaded ||
+          (auditLogs?.length ?? 0) <= limit
+        }
+        backDisabled={!hasPrevPage}
       />
     </div>
   );


### PR DESCRIPTION
## Done

- Fixed pagination navigating to new blank page by temporarily disabling the next page button until the audit logs are fetched.
- _Note: I was unable to reproduce the issue where, if navigating to the next page slowly so that it manages to refresh, we can navigate to a blank page. Maybe it somehow managed to get fixed in the latest pull requests?_

## Details

https://warthogs.atlassian.net/browse/WD-5746
