### PR TITLE
WD-5811 - feat: Add page component, route and side nav link

### DIFF
--- a/src/components/PrimaryNav/PrimaryNav.test.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.test.tsx
@@ -174,7 +174,7 @@ describe("Primary Nav", () => {
     expect(navigationButtons[3]).toHaveTextContent("Report a bug");
   });
 
-  it("should not show LogsLink navigation button under Juju", () => {
+  it("should not show Advanced search navigation button under Juju", () => {
     const state = rootStateFactory.build({
       general: generalStateFactory.build({
         config: configFactory.build({

--- a/src/components/PrimaryNav/PrimaryNav.test.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.test.tsx
@@ -163,4 +163,30 @@ describe("Primary Nav", () => {
     );
     expect(notification).not.toBeInTheDocument();
   });
+
+  it("should have all navigation buttons", () => {
+    renderComponent(<PrimaryNav />);
+    const navigationButtons = document.querySelectorAll(".p-list__link");
+    expect(navigationButtons).toHaveLength(4);
+    expect(navigationButtons[0]).toHaveTextContent("Models");
+    expect(navigationButtons[1]).toHaveTextContent("Controllers");
+    expect(navigationButtons[2]).toHaveTextContent("Advanced search");
+    expect(navigationButtons[3]).toHaveTextContent("Report a bug");
+  });
+
+  it("should not show LogsLink navigation button under Juju", () => {
+    const state = rootStateFactory.build({
+      general: generalStateFactory.build({
+        config: configFactory.build({
+          isJuju: true,
+        }),
+      }),
+    });
+    renderComponent(<PrimaryNav />, { state });
+    const navigationButtons = document.querySelectorAll(".p-list__link");
+    expect(navigationButtons).toHaveLength(3);
+    expect(navigationButtons[0]).toHaveTextContent("Models");
+    expect(navigationButtons[1]).toHaveTextContent("Controllers");
+    expect(navigationButtons[2]).toHaveTextContent("Report a bug");
+  });
 });

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -1,38 +1,29 @@
 import { dashboardUpdateAvailable } from "@canonical/jujulib/dist/api/versions";
 import { Icon, StatusLabel, Tooltip } from "@canonical/react-components";
-import classNames from "classnames";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useSelector } from "react-redux";
-import { NavLink } from "react-router-dom";
 
 import Logo from "components/Logo/Logo";
 import UserMenu from "components/UserMenu/UserMenu";
-import { getAppVersion } from "store/general/selectors";
+import { getAppVersion, getIsJuju } from "store/general/selectors";
 import {
   getControllerData,
   getGroupedModelStatusCounts,
 } from "store/juju/selectors";
 import type { Controllers } from "store/juju/types";
 import urls, { externalURLs } from "urls";
+
 import "./_primary-nav.scss";
+import PrimaryNavLink from "./PrimaryNavLink";
 
 const ModelsLink = () => {
   const { blocked: blockedModels } = useSelector(getGroupedModelStatusCounts);
   return (
-    <NavLink
-      className={({ isActive }) =>
-        classNames("p-list__link", {
-          "is-selected": isActive,
-        })
-      }
-      to={urls.models.index}
-    >
-      <i className={`p-icon--models is-light`}></i>
-      <span className="hide-collapsed">Models</span>
+    <PrimaryNavLink to={urls.models.index} iconName="models" title="Models">
       {blockedModels > 0 && (
         <span className="entity-count is-negative">{blockedModels}</span>
       )}
-    </NavLink>
+    </PrimaryNavLink>
   );
 };
 
@@ -40,42 +31,48 @@ const ControllersLink = () => {
   const controllers: Controllers | null = useSelector(getControllerData);
 
   const controllersUpdateCount = useMemo(() => {
-    if (!controllers) return 0;
-    let count = 0;
-    Object.values(controllers).forEach((controller) => {
-      controller.forEach((controller) => {
-        if ("version" in controller && controller.updateAvailable) {
-          count += 1;
-        }
-      });
-    });
-    return count;
+    if (!controllers) {
+      return 0;
+    }
+    return Object.values(controllers).reduce(
+      (controllersCount, controllerArray) =>
+        controllersCount +
+        controllerArray.reduce(
+          (count, controller) =>
+            "version" in controller && controller.updateAvailable
+              ? count + 1
+              : count,
+          0
+        ),
+      0
+    );
   }, [controllers]);
 
   return (
-    <NavLink
-      className={({ isActive }) =>
-        classNames("p-list__link", {
-          "is-selected": isActive,
-        })
-      }
+    <PrimaryNavLink
       to={urls.controllers}
+      iconName="controllers"
+      title="Controllers"
     >
-      <i className={`p-icon--controllers is-light`}></i>
-      <span className="hide-collapsed">Controllers</span>
       {controllersUpdateCount > 0 && (
         <span className="entity-count is-caution">
           {controllersUpdateCount}
         </span>
       )}
-    </NavLink>
+    </PrimaryNavLink>
   );
 };
+
+const AdvancedSearchLink = () => (
+  <PrimaryNavLink to={urls.search} iconName="search" title="Advanced search" />
+);
 
 const PrimaryNav = () => {
   const appVersion = useSelector(getAppVersion);
   const [updateAvailable, setUpdateAvailable] = useState(false);
   const versionRequested = useRef(false);
+
+  const isJuju = useSelector(getIsJuju);
 
   useEffect(() => {
     if (appVersion && !versionRequested.current) {
@@ -103,6 +100,11 @@ const PrimaryNav = () => {
         <li className="p-list__item">
           <ControllersLink />
         </li>
+        {!isJuju && (
+          <li className="p-list__item">
+            <AdvancedSearchLink />
+          </li>
+        )}
       </ul>
       <hr className="p-primary-nav__divider hide-collapsed" />
       <div className="p-primary-nav__bottom hide-collapsed">

--- a/src/components/PrimaryNav/PrimaryNavLink/PrimaryNavLink.test.tsx
+++ b/src/components/PrimaryNav/PrimaryNavLink/PrimaryNavLink.test.tsx
@@ -1,0 +1,30 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { renderComponent } from "testing/utils";
+
+import PrimaryNavLink, { TestId } from "./PrimaryNavLink";
+
+describe("PrimayNavLink", () => {
+  const to = "/models";
+  const iconName = "models";
+  const title = "Models";
+
+  it("should render successfully", () => {
+    renderComponent(
+      <PrimaryNavLink to={to} iconName={iconName} title={title} />
+    );
+    expect(document.querySelector(".p-icon--models")).toBeVisible();
+    expect(document.querySelector(".hide-collapsed")).toHaveTextContent(
+      "Models"
+    );
+  });
+
+  it("should navigate to url after pressing the button", async () => {
+    renderComponent(
+      <PrimaryNavLink to={to} iconName={iconName} title={title} />
+    );
+    await userEvent.click(screen.getByTestId(TestId.PRIMARY_NAV_LINK));
+    expect(window.location.pathname).toBe("/models");
+  });
+});

--- a/src/components/PrimaryNav/PrimaryNavLink/PrimaryNavLink.tsx
+++ b/src/components/PrimaryNav/PrimaryNavLink/PrimaryNavLink.tsx
@@ -1,0 +1,37 @@
+import { Icon } from "@canonical/react-components";
+import classNames from "classnames";
+import { NavLink } from "react-router-dom";
+
+export enum TestId {
+  PRIMARY_NAV_LINK = "primary-nav-link",
+}
+
+type PrimaryNavLinkProps = {
+  children?: React.ReactNode;
+  to: string;
+  iconName: string;
+  title: string;
+};
+
+const PrimaryNavLink = ({
+  children,
+  to,
+  iconName,
+  title,
+}: PrimaryNavLinkProps) => (
+  <NavLink
+    className={({ isActive }) =>
+      classNames("p-list__link", {
+        "is-selected": isActive,
+      })
+    }
+    to={to}
+    data-testid={TestId.PRIMARY_NAV_LINK}
+  >
+    <Icon name={iconName} light />
+    <span className="hide-collapsed">{title}</span>
+    {children}
+  </NavLink>
+);
+
+export default PrimaryNavLink;

--- a/src/components/PrimaryNav/PrimaryNavLink/index.ts
+++ b/src/components/PrimaryNav/PrimaryNavLink/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./PrimaryNavLink";

--- a/src/components/Routes/Routes.tsx
+++ b/src/components/Routes/Routes.tsx
@@ -8,6 +8,7 @@ import {
 
 import Login from "components/LogIn/LogIn";
 import useAnalytics from "hooks/useAnalytics";
+import AdvancedSearch from "pages/AdvancedSearch/AdvancedSearch";
 import ControllersIndex from "pages/ControllersIndex/ControllersIndex";
 import ModelDetails from "pages/ModelDetails/ModelDetails";
 import ModelsIndex from "pages/ModelsIndex/ModelsIndex";
@@ -70,6 +71,14 @@ export function Routes() {
         }
       />
       <Route path="*" element={<PageNotFound />} />
+      <Route
+        path={urls.search}
+        element={
+          <Login>
+            <AdvancedSearch />
+          </Login>
+        }
+      />
     </ReactRouterRoutes>
   );
 }

--- a/src/components/Routes/Routes.tsx
+++ b/src/components/Routes/Routes.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { useSelector } from "react-redux";
 import {
   Navigate,
   Route,
@@ -14,6 +15,7 @@ import ModelDetails from "pages/ModelDetails/ModelDetails";
 import ModelsIndex from "pages/ModelsIndex/ModelsIndex";
 import PageNotFound from "pages/PageNotFound/PageNotFound";
 import Settings from "pages/Settings/Settings";
+import { getIsJuju } from "store/general/selectors";
 import urls from "urls";
 
 export type EntityDetailsRoute = {
@@ -27,6 +29,8 @@ export type EntityDetailsRoute = {
 export function Routes() {
   const sendAnalytics = useAnalytics();
   const location = useLocation();
+
+  const isJuju = useSelector(getIsJuju);
 
   useEffect(() => {
     // Send an analytics event when the URL changes.
@@ -71,14 +75,16 @@ export function Routes() {
         }
       />
       <Route path="*" element={<PageNotFound />} />
-      <Route
-        path={urls.search}
-        element={
-          <Login>
-            <AdvancedSearch />
-          </Login>
-        }
-      />
+      {!isJuju && (
+        <Route
+          path={urls.search}
+          element={
+            <Login>
+              <AdvancedSearch />
+            </Login>
+          }
+        />
+      )}
     </ReactRouterRoutes>
   );
 }

--- a/src/pages/AdvancedSearch/AdvancedSearch.test.tsx
+++ b/src/pages/AdvancedSearch/AdvancedSearch.test.tsx
@@ -2,7 +2,7 @@ import { renderComponent } from "testing/utils";
 
 import AdvancedSearch from "./AdvancedSearch";
 
-describe("Logs", () => {
+describe("AdvancedSearch", () => {
   it("should render the page", () => {
     renderComponent(<AdvancedSearch />);
     expect(document.querySelector("header")).toHaveTextContent(

--- a/src/pages/AdvancedSearch/AdvancedSearch.test.tsx
+++ b/src/pages/AdvancedSearch/AdvancedSearch.test.tsx
@@ -1,0 +1,12 @@
+import { renderComponent } from "testing/utils";
+
+import AdvancedSearch from "./AdvancedSearch";
+
+describe("Logs", () => {
+  it("should render the page", () => {
+    renderComponent(<AdvancedSearch />);
+    expect(document.querySelector("header")).toHaveTextContent(
+      "Advanced search"
+    );
+  });
+});

--- a/src/pages/AdvancedSearch/AdvancedSearch.tsx
+++ b/src/pages/AdvancedSearch/AdvancedSearch.tsx
@@ -1,0 +1,12 @@
+import Header from "components/Header/Header";
+import BaseLayout from "layout/BaseLayout/BaseLayout";
+
+const AdvancedSearch = (): JSX.Element => (
+  <BaseLayout>
+    <Header>
+      <b>Advanced search</b>
+    </Header>
+  </BaseLayout>
+);
+
+export default AdvancedSearch;

--- a/src/pages/AdvancedSearch/index.ts
+++ b/src/pages/AdvancedSearch/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AdvancedSearch";

--- a/src/store/general/selectors.test.ts
+++ b/src/store/general/selectors.test.ts
@@ -19,6 +19,7 @@ import {
   isLoggedIn,
   getActiveUserControllerAccess,
   getConnectionError,
+  getIsJuju,
 } from "./selectors";
 
 describe("selectors", () => {
@@ -33,6 +34,20 @@ describe("selectors", () => {
         })
       )
     ).toStrictEqual(config);
+  });
+
+  it("getIsJuju", () => {
+    expect(
+      getIsJuju(
+        rootStateFactory.build({
+          general: generalStateFactory.build({
+            config: configFactory.build({
+              isJuju: true,
+            }),
+          }),
+        })
+      )
+    ).toStrictEqual(true);
   });
 
   it("getUserPass", () => {

--- a/src/store/general/selectors.ts
+++ b/src/store/general/selectors.ts
@@ -15,6 +15,17 @@ export const getConfig = createSelector(
 );
 
 /**
+  Determines if Juju is used based on config value from state.
+  @param state The application state.
+  @returns true if Juju is used, false if Juju isn't used or
+    undefined if config is undefined.
+ */
+export const getIsJuju = createSelector(
+  [slice],
+  (sliceState) => sliceState?.config?.isJuju
+);
+
+/**
   Fetches the username and password from state.
   @param state The application state.
   @param wsControllerURL The fully qualified wsController URL to

--- a/src/urls.ts
+++ b/src/urls.ts
@@ -46,6 +46,7 @@ const urls = {
     }>("/models?groupedby=:groupedby"),
   },
   settings: "/settings",
+  search: "/search",
 };
 
 export const externalURLs = {


### PR DESCRIPTION
## Done

- Set up the page component with an “Advanced search“ header.
- Set up a “/search“ URL and route. Route is not accessible when using Juju controller.
- Added an “Advanced search“ link to the sidebar that is not shown when using Juju controller.

## Details

https://warthogs.atlassian.net/browse/WD-5811

## Screenshots

<img width="1280" alt="Screenshot 2023-08-18 at 00 09 42" src="https://github.com/canonical/juju-dashboard/assets/108150922/632186b2-aec4-4e2e-ac32-b4420f7e5160">
