### PR TITLE
refactor: Add getIsJuju and refactor PrimaryNav

### DIFF
--- a/src/components/PrimaryNav/PrimaryNav.test.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.test.tsx
@@ -163,4 +163,13 @@ describe("Primary Nav", () => {
     );
     expect(notification).not.toBeInTheDocument();
   });
+
+  it("should have all navigation buttons", () => {
+    renderComponent(<PrimaryNav />);
+    const navigationButtons = document.querySelectorAll(".p-list__link");
+    expect(navigationButtons).toHaveLength(3);
+    expect(navigationButtons[0]).toHaveTextContent("Models");
+    expect(navigationButtons[1]).toHaveTextContent("Controllers");
+    expect(navigationButtons[2]).toHaveTextContent("Report a bug");
+  });
 });

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -1,9 +1,7 @@
 import { dashboardUpdateAvailable } from "@canonical/jujulib/dist/api/versions";
 import { Icon, StatusLabel, Tooltip } from "@canonical/react-components";
-import classNames from "classnames";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useSelector } from "react-redux";
-import { NavLink } from "react-router-dom";
 
 import Logo from "components/Logo/Logo";
 import UserMenu from "components/UserMenu/UserMenu";
@@ -14,25 +12,18 @@ import {
 } from "store/juju/selectors";
 import type { Controllers } from "store/juju/types";
 import urls, { externalURLs } from "urls";
+
 import "./_primary-nav.scss";
+import PrimaryNavLink from "./PrimaryNavLink";
 
 const ModelsLink = () => {
   const { blocked: blockedModels } = useSelector(getGroupedModelStatusCounts);
   return (
-    <NavLink
-      className={({ isActive }) =>
-        classNames("p-list__link", {
-          "is-selected": isActive,
-        })
-      }
-      to={urls.models.index}
-    >
-      <i className={`p-icon--models is-light`}></i>
-      <span className="hide-collapsed">Models</span>
+    <PrimaryNavLink to={urls.models.index} iconName="models" title="Models">
       {blockedModels > 0 && (
         <span className="entity-count is-negative">{blockedModels}</span>
       )}
-    </NavLink>
+    </PrimaryNavLink>
   );
 };
 
@@ -40,35 +31,35 @@ const ControllersLink = () => {
   const controllers: Controllers | null = useSelector(getControllerData);
 
   const controllersUpdateCount = useMemo(() => {
-    if (!controllers) return 0;
-    let count = 0;
-    Object.values(controllers).forEach((controller) => {
-      controller.forEach((controller) => {
-        if ("version" in controller && controller.updateAvailable) {
-          count += 1;
-        }
-      });
-    });
-    return count;
+    if (!controllers) {
+      return 0;
+    }
+    return Object.values(controllers).reduce(
+      (controllersCount, controllerArray) =>
+        controllersCount +
+        controllerArray.reduce(
+          (count, controller) =>
+            "version" in controller && controller.updateAvailable
+              ? count + 1
+              : count,
+          0
+        ),
+      0
+    );
   }, [controllers]);
 
   return (
-    <NavLink
-      className={({ isActive }) =>
-        classNames("p-list__link", {
-          "is-selected": isActive,
-        })
-      }
+    <PrimaryNavLink
       to={urls.controllers}
+      iconName="controllers"
+      title="Controllers"
     >
-      <i className={`p-icon--controllers is-light`}></i>
-      <span className="hide-collapsed">Controllers</span>
       {controllersUpdateCount > 0 && (
         <span className="entity-count is-caution">
           {controllersUpdateCount}
         </span>
       )}
-    </NavLink>
+    </PrimaryNavLink>
   );
 };
 

--- a/src/components/PrimaryNav/PrimaryNavLink/PrimaryNavLink.test.tsx
+++ b/src/components/PrimaryNav/PrimaryNavLink/PrimaryNavLink.test.tsx
@@ -1,0 +1,30 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { renderComponent } from "testing/utils";
+
+import PrimaryNavLink, { TestId } from "./PrimaryNavLink";
+
+describe("PrimayNavLink", () => {
+  const to = "/models";
+  const iconName = "models";
+  const title = "Models";
+
+  it("should render successfully", () => {
+    renderComponent(
+      <PrimaryNavLink to={to} iconName={iconName} title={title} />
+    );
+    expect(document.querySelector(".p-icon--models")).toBeVisible();
+    expect(document.querySelector(".hide-collapsed")).toHaveTextContent(
+      "Models"
+    );
+  });
+
+  it("should navigate to url after pressing the button", async () => {
+    renderComponent(
+      <PrimaryNavLink to={to} iconName={iconName} title={title} />
+    );
+    await userEvent.click(screen.getByTestId(TestId.PRIMARY_NAV_LINK));
+    expect(window.location.pathname).toBe("/models");
+  });
+});

--- a/src/components/PrimaryNav/PrimaryNavLink/PrimaryNavLink.tsx
+++ b/src/components/PrimaryNav/PrimaryNavLink/PrimaryNavLink.tsx
@@ -1,0 +1,37 @@
+import { Icon } from "@canonical/react-components";
+import classNames from "classnames";
+import { NavLink } from "react-router-dom";
+
+export enum TestId {
+  PRIMARY_NAV_LINK = "primary-nav-link",
+}
+
+type PrimaryNavLinkProps = {
+  children?: React.ReactNode;
+  to: string;
+  iconName: string;
+  title: string;
+};
+
+const PrimaryNavLink = ({
+  children,
+  to,
+  iconName,
+  title,
+}: PrimaryNavLinkProps) => (
+  <NavLink
+    className={({ isActive }) =>
+      classNames("p-list__link", {
+        "is-selected": isActive,
+      })
+    }
+    to={to}
+    data-testid={TestId.PRIMARY_NAV_LINK}
+  >
+    <Icon name={iconName} light />
+    <span className="hide-collapsed">{title}</span>
+    {children}
+  </NavLink>
+);
+
+export default PrimaryNavLink;

--- a/src/components/PrimaryNav/PrimaryNavLink/index.ts
+++ b/src/components/PrimaryNav/PrimaryNavLink/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./PrimaryNavLink";

--- a/src/store/general/selectors.test.ts
+++ b/src/store/general/selectors.test.ts
@@ -19,6 +19,7 @@ import {
   isLoggedIn,
   getActiveUserControllerAccess,
   getConnectionError,
+  getIsJuju,
 } from "./selectors";
 
 describe("selectors", () => {
@@ -33,6 +34,20 @@ describe("selectors", () => {
         })
       )
     ).toStrictEqual(config);
+  });
+
+  it("getIsJuju", () => {
+    expect(
+      getIsJuju(
+        rootStateFactory.build({
+          general: generalStateFactory.build({
+            config: configFactory.build({
+              isJuju: true,
+            }),
+          }),
+        })
+      )
+    ).toStrictEqual(true);
   });
 
   it("getUserPass", () => {

--- a/src/store/general/selectors.ts
+++ b/src/store/general/selectors.ts
@@ -15,6 +15,17 @@ export const getConfig = createSelector(
 );
 
 /**
+  Determines if Juju is used based on config value from state.
+  @param state The application state.
+  @returns true if Juju is used, false if Juju isn't used or
+    undefined if config is undefined.
+ */
+export const getIsJuju = createSelector(
+  [slice],
+  (sliceState) => sliceState?.config?.isJuju
+);
+
+/**
   Fetches the username and password from state.
   @param state The application state.
   @param wsControllerURL The fully qualified wsController URL to


### PR DESCRIPTION
## Done

- Refactored `PrimaryNav` component and added `getIsJuju` selector. This change will make it easier to merge `audit-logs` and `cross-model-queries` branches into `main`.