### PR TITLE
WD-5815 - Add search history

### DIFF
--- a/docs/multipass-microk8s.md
+++ b/docs/multipass-microk8s.md
@@ -25,7 +25,7 @@ Now install MicroK8s. Newer versions of Juju require strict MicroK8s (you can ch
 channels using `snap info microk8s`).
 
 ```shell
-sudo snap install microk8s --channel=1.27-strict/stable
+sudo snap install microk8s --channel=1.28-strict/stable
 ```
 
 You will need to be in the microk8s group so run:

--- a/src/pages/AdvancedSearch/SearchForm/SearchForm.test.tsx
+++ b/src/pages/AdvancedSearch/SearchForm/SearchForm.test.tsx
@@ -62,4 +62,19 @@ describe("SearchForm", () => {
       JSON.stringify([".applications"])
     );
   });
+
+  it("should move duplicate queries to the top in local storage", async () => {
+    renderComponent(<SearchForm />, { state });
+    await userEvent.type(screen.getByRole("textbox"), ".applications{Enter}");
+    await userEvent.clear(screen.getByRole("textbox"));
+    await userEvent.type(screen.getByRole("textbox"), ".machines{Enter}");
+    expect(window.localStorage.getItem(QUERY_HISTORY_KEY)).toBe(
+      JSON.stringify([".machines", ".applications"])
+    );
+    await userEvent.clear(screen.getByRole("textbox"));
+    await userEvent.type(screen.getByRole("textbox"), ".applications{Enter}");
+    expect(window.localStorage.getItem(QUERY_HISTORY_KEY)).toBe(
+      JSON.stringify([".applications", ".machines"])
+    );
+  });
 });

--- a/src/pages/AdvancedSearch/SearchForm/SearchForm.test.tsx
+++ b/src/pages/AdvancedSearch/SearchForm/SearchForm.test.tsx
@@ -7,7 +7,7 @@ import { rootStateFactory } from "testing/factories";
 import { generalStateFactory, configFactory } from "testing/factories/general";
 import { renderComponent } from "testing/utils";
 
-import SearchForm from "./SearchForm";
+import SearchForm, { Label, QUERY_HISTORY_KEY } from "./SearchForm";
 
 describe("SearchForm", () => {
   let state: RootState;
@@ -23,6 +23,10 @@ describe("SearchForm", () => {
         }),
       }),
     });
+  });
+
+  afterEach(() => {
+    localStorage.clear();
   });
 
   it("should initialise the form with the query from the URL", async () => {
@@ -48,5 +52,14 @@ describe("SearchForm", () => {
     renderComponent(<SearchForm />, { state });
     await userEvent.type(screen.getByRole("textbox"), ".applications{Enter}");
     expect(window.location.search).toBe("?q=.applications");
+  });
+
+  it("should store the query in local storage when submitting the form", async () => {
+    renderComponent(<SearchForm />, { state });
+    await userEvent.type(screen.getByRole("textbox"), ".applications");
+    await userEvent.click(screen.getByRole("button", { name: Label.SEARCH }));
+    expect(window.localStorage.getItem(QUERY_HISTORY_KEY)).toBe(
+      JSON.stringify([".applications"])
+    );
   });
 });

--- a/src/pages/AdvancedSearch/SearchForm/SearchForm.tsx
+++ b/src/pages/AdvancedSearch/SearchForm/SearchForm.tsx
@@ -3,6 +3,7 @@ import type { FormikProps } from "formik";
 import { Field, Form, Formik } from "formik";
 import { useEffect, useRef } from "react";
 
+import useLocalStorage from "hooks/useLocalStorage";
 import { useQueryParams } from "hooks/useQueryParams";
 import {
   getControllerConnection,
@@ -11,12 +12,17 @@ import {
 import { actions as jujuActions } from "store/juju";
 import { useAppDispatch, useAppSelector } from "store/store";
 
-type Fields = {
-  query: string;
-};
+import SearchHistoryMenu from "./SearchHistoryMenu/SearchHistoryMenu";
+import type { FormFields } from "./types";
+
+export enum Label {
+  SEARCH = "Search",
+}
+
+export const QUERY_HISTORY_KEY = "queryHistory";
 
 const SearchForm = (): JSX.Element => {
-  const formikRef = useRef<FormikProps<Fields>>(null);
+  const formikRef = useRef<FormikProps<FormFields>>(null);
   const dispatch = useAppDispatch();
   const wsControllerURL = useAppSelector(getWSControllerURL);
   const hasControllerConnection = useAppSelector((state) =>
@@ -26,6 +32,10 @@ const SearchForm = (): JSX.Element => {
     q: "",
   });
   const jqParam = decodeURIComponent(queryParams.q);
+  const [queryHistory, setQueryHistory] = useLocalStorage<string[]>(
+    QUERY_HISTORY_KEY,
+    []
+  );
 
   useEffect(() => {
     if (jqParam && hasControllerConnection && wsControllerURL) {
@@ -39,7 +49,7 @@ const SearchForm = (): JSX.Element => {
   }, [dispatch, hasControllerConnection, jqParam, wsControllerURL]);
 
   return (
-    <Formik<Fields>
+    <Formik<FormFields>
       initialValues={{
         query: jqParam,
       }}
@@ -48,6 +58,10 @@ const SearchForm = (): JSX.Element => {
         const { query } = values;
         if (query) {
           setQueryParams({ q: encodeURIComponent(query) });
+          setQueryHistory([
+            query,
+            ...queryHistory.filter((previous) => previous !== query),
+          ]);
         }
       }}
     >
@@ -67,7 +81,11 @@ const SearchForm = (): JSX.Element => {
               name="query"
               rows={8}
             />
-            <Button type="submit">Search</Button>
+            <Button type="submit">{Label.SEARCH}</Button>
+            <SearchHistoryMenu
+              queryHistory={queryHistory}
+              setQueryHistory={setQueryHistory}
+            />
           </Col>
         </Row>
       </Form>

--- a/src/pages/AdvancedSearch/SearchForm/SearchForm.tsx
+++ b/src/pages/AdvancedSearch/SearchForm/SearchForm.tsx
@@ -60,6 +60,7 @@ const SearchForm = (): JSX.Element => {
           setQueryParams({ q: encodeURIComponent(query) });
           setQueryHistory([
             query,
+            // Remove old queries that match the new one.
             ...queryHistory.filter((previous) => previous !== query),
           ]);
         }

--- a/src/pages/AdvancedSearch/SearchForm/SearchHistoryMenu/SearchHistoryMenu.test.tsx
+++ b/src/pages/AdvancedSearch/SearchForm/SearchHistoryMenu/SearchHistoryMenu.test.tsx
@@ -1,0 +1,77 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Field, Form, Formik } from "formik";
+
+import { renderComponent } from "testing/utils";
+
+import SearchHistoryMenu from "./SearchHistoryMenu";
+import { Label } from "./SearchHistoryMenu";
+
+describe("SearchHistoryMenu", () => {
+  it("should be disabled when there is no history", async () => {
+    renderComponent(
+      <Formik initialValues={{ query: "" }} onSubmit={jest.fn()}>
+        <SearchHistoryMenu queryHistory={[]} setQueryHistory={jest.fn()} />
+      </Formik>,
+      { url: "/?q=.applications" }
+    );
+    expect(screen.getByRole("button", { name: Label.HISTORY })).toBeDisabled();
+  });
+
+  it("should display the history in the menu", async () => {
+    renderComponent(
+      <Formik initialValues={{ query: "" }} onSubmit={jest.fn()}>
+        <SearchHistoryMenu
+          queryHistory={[".applications", ".machines"]}
+          setQueryHistory={jest.fn()}
+        />
+      </Formik>,
+      { url: "/?q=.applications" }
+    );
+    // Open the menu so that the portal gets rendered.
+    await userEvent.click(screen.getByRole("button", { name: Label.HISTORY }));
+    expect(
+      screen.getByRole("button", { name: ".applications" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: ".machines" })
+    ).toBeInTheDocument();
+  });
+
+  it("should update the field and query param when clicking an item", async () => {
+    renderComponent(
+      <Formik initialValues={{ query: "" }} onSubmit={jest.fn()}>
+        <Form>
+          <Field name="query" />
+          <SearchHistoryMenu
+            queryHistory={[".applications", ".machines"]}
+            setQueryHistory={jest.fn()}
+          />
+        </Form>
+      </Formik>,
+      { url: "/?q=.applications" }
+    );
+    // Open the menu so that the portal gets rendered.
+    await userEvent.click(screen.getByRole("button", { name: Label.HISTORY }));
+    await userEvent.click(screen.getByRole("button", { name: ".machines" }));
+    expect(window.location.search).toBe("?q=.machines");
+    expect(screen.getByRole("textbox")).toHaveValue(".machines");
+  });
+
+  it("should be able to clear the history", async () => {
+    const setQueryHistory = jest.fn();
+    renderComponent(
+      <Formik initialValues={{ query: "" }} onSubmit={jest.fn()}>
+        <SearchHistoryMenu
+          queryHistory={[".applications", ".machines"]}
+          setQueryHistory={setQueryHistory}
+        />
+      </Formik>,
+      { url: "/?q=.applications" }
+    );
+    // Open the menu so that the portal gets rendered.
+    await userEvent.click(screen.getByRole("button", { name: Label.HISTORY }));
+    await userEvent.click(screen.getByRole("button", { name: Label.CLEAR }));
+    expect(setQueryHistory).toHaveBeenCalledWith([]);
+  });
+});

--- a/src/pages/AdvancedSearch/SearchForm/SearchHistoryMenu/SearchHistoryMenu.test.tsx
+++ b/src/pages/AdvancedSearch/SearchForm/SearchHistoryMenu/SearchHistoryMenu.test.tsx
@@ -2,6 +2,8 @@ import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Field, Form, Formik } from "formik";
 
+import { jujuStateFactory, rootStateFactory } from "testing/factories";
+import { crossModelQueryStateFactory } from "testing/factories/juju/juju";
 import { renderComponent } from "testing/utils";
 
 import SearchHistoryMenu from "./SearchHistoryMenu";
@@ -14,6 +16,23 @@ describe("SearchHistoryMenu", () => {
         <SearchHistoryMenu queryHistory={[]} setQueryHistory={jest.fn()} />
       </Formik>,
       { url: "/?q=.applications" }
+    );
+    expect(screen.getByRole("button", { name: Label.HISTORY })).toBeDisabled();
+  });
+
+  it("should be disabled while loading", async () => {
+    const state = rootStateFactory.build({
+      juju: jujuStateFactory.build({
+        crossModelQuery: crossModelQueryStateFactory.build({
+          loading: true,
+        }),
+      }),
+    });
+    renderComponent(
+      <Formik initialValues={{ query: "" }} onSubmit={jest.fn()}>
+        <SearchHistoryMenu queryHistory={[]} setQueryHistory={jest.fn()} />
+      </Formik>,
+      { state, url: "/?q=.applications" }
     );
     expect(screen.getByRole("button", { name: Label.HISTORY })).toBeDisabled();
   });

--- a/src/pages/AdvancedSearch/SearchForm/SearchHistoryMenu/SearchHistoryMenu.tsx
+++ b/src/pages/AdvancedSearch/SearchForm/SearchHistoryMenu/SearchHistoryMenu.tsx
@@ -2,6 +2,8 @@ import { ContextualMenu, Icon } from "@canonical/react-components";
 import { useFormikContext } from "formik";
 
 import { useQueryParams } from "hooks/useQueryParams";
+import { getCrossModelQueryLoading } from "store/juju/selectors";
+import { useAppSelector } from "store/store";
 
 import type { FormFields } from "../types";
 
@@ -19,6 +21,7 @@ const SearchHistoryMenu = ({
   queryHistory,
   setQueryHistory,
 }: Props): JSX.Element => {
+  const loading = useAppSelector(getCrossModelQueryLoading);
   const { setFieldValue } = useFormikContext<FormFields>();
   const [, setQueryParams] = useQueryParams<{ q: string }>({
     q: "",
@@ -45,7 +48,7 @@ const SearchHistoryMenu = ({
       ]}
       position="left"
       toggleClassName="has-icon"
-      toggleDisabled={queryHistory.length === 0}
+      toggleDisabled={queryHistory.length === 0 || loading}
       toggleLabel={<Icon name="revisions">{Label.HISTORY}</Icon>}
     />
   );

--- a/src/pages/AdvancedSearch/SearchForm/SearchHistoryMenu/SearchHistoryMenu.tsx
+++ b/src/pages/AdvancedSearch/SearchForm/SearchHistoryMenu/SearchHistoryMenu.tsx
@@ -1,0 +1,54 @@
+import { ContextualMenu, Icon } from "@canonical/react-components";
+import { useFormikContext } from "formik";
+
+import { useQueryParams } from "hooks/useQueryParams";
+
+import type { FormFields } from "../types";
+
+export enum Label {
+  CLEAR = "Clear history",
+  HISTORY = "History",
+}
+
+type Props = {
+  queryHistory: string[];
+  setQueryHistory: (queryHistory: string[]) => void;
+};
+
+const SearchHistoryMenu = ({
+  queryHistory,
+  setQueryHistory,
+}: Props): JSX.Element => {
+  const { setFieldValue } = useFormikContext<FormFields>();
+  const [, setQueryParams] = useQueryParams<{ q: string }>({
+    q: "",
+  });
+
+  return (
+    <ContextualMenu
+      links={[
+        ...queryHistory.map((query) => ({
+          children: query,
+          onClick: () => {
+            setQueryParams({ q: encodeURIComponent(query) });
+            setFieldValue("query", query);
+          },
+        })),
+        {
+          children: (
+            <>
+              <Icon name="delete" /> {Label.CLEAR}
+            </>
+          ),
+          onClick: () => setQueryHistory([]),
+        },
+      ]}
+      position="left"
+      toggleClassName="has-icon"
+      toggleDisabled={queryHistory.length === 0}
+      toggleLabel={<Icon name="revisions">{Label.HISTORY}</Icon>}
+    />
+  );
+};
+
+export default SearchHistoryMenu;

--- a/src/pages/AdvancedSearch/SearchForm/SearchHistoryMenu/index.ts
+++ b/src/pages/AdvancedSearch/SearchForm/SearchHistoryMenu/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SearchHistoryMenu";

--- a/src/pages/AdvancedSearch/SearchForm/types.ts
+++ b/src/pages/AdvancedSearch/SearchForm/types.ts
@@ -1,0 +1,3 @@
+export type FormFields = {
+  query: string;
+};

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -39,6 +39,7 @@ $color-navigation-background: $color-brand;
 @include vf-p-icon-models;
 @include vf-p-icon-machines;
 @include vf-p-icon-pin;
+@include vf-p-icon-revisions;
 @include vf-p-icon-units;
 @include vf-p-icon-user;
 @include vf-p-icon-video-play;


### PR DESCRIPTION
## Done

- Add a history of queries to the cross model search form.

## QA

- Connect to staging.
- Go to the advanced search page.
- See that there is a button to open the search history.
- Perform a search.
- Open the menu and you should see the search item.
- Do a second search and open the menu again and click on the first search you did. The URL and input should update.
- Refresh the page and open the menu again and your items should be there again.
- Click the clear button and they should get removed.

## Details

https://warthogs.atlassian.net/browse/WD-5815

## Screenshots

<img width="906" alt="Screenshot 2023-08-22 at 2 59 52 pm" src="https://github.com/canonical/juju-dashboard/assets/361637/73420967-5f3b-4ee9-9aeb-72b591236527">

