### PR TITLE
WD-5814 - Add help

### DIFF
--- a/src/pages/AdvancedSearch/SearchForm/QueryLink/QueryLink.test.tsx
+++ b/src/pages/AdvancedSearch/SearchForm/QueryLink/QueryLink.test.tsx
@@ -1,0 +1,18 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { renderComponent } from "testing/utils";
+
+import QueryLink from "./QueryLink";
+
+describe("QueryLink", () => {
+  it("should call the query handler when clicking the button", async () => {
+    const search = jest.fn();
+    renderComponent(<QueryLink query=".applications" handleQuery={search} />);
+    // Open the menu so that the portal gets rendered.
+    await userEvent.click(
+      screen.getByRole("button", { name: ".applications" })
+    );
+    expect(search).toHaveBeenCalledWith(".applications");
+  });
+});

--- a/src/pages/AdvancedSearch/SearchForm/QueryLink/QueryLink.tsx
+++ b/src/pages/AdvancedSearch/SearchForm/QueryLink/QueryLink.tsx
@@ -1,0 +1,21 @@
+import { Button } from "@canonical/react-components";
+
+type Props = {
+  handleQuery: (query: string) => void;
+  query: string;
+};
+
+const QueryLink = ({ handleQuery, query }: Props): JSX.Element => {
+  return (
+    <Button
+      appearance="link"
+      className="u-no-margin u-no-padding u-align--left p-text--small"
+      onClick={() => handleQuery(query)}
+      type="button"
+    >
+      <code>{query}</code>
+    </Button>
+  );
+};
+
+export default QueryLink;

--- a/src/pages/AdvancedSearch/SearchForm/QueryLink/index.ts
+++ b/src/pages/AdvancedSearch/SearchForm/QueryLink/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./QueryLink";

--- a/src/pages/AdvancedSearch/SearchForm/SearchHelp/SearchHelp.test.tsx
+++ b/src/pages/AdvancedSearch/SearchForm/SearchHelp/SearchHelp.test.tsx
@@ -1,0 +1,25 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Field, Form, Formik } from "formik";
+
+import { renderComponent } from "testing/utils";
+
+import SearchHelp from "./SearchHelp";
+
+describe("SearchHelp", () => {
+  it("should update the field and perform a search when clicking a link", async () => {
+    const search = jest.fn();
+    renderComponent(
+      <Formik initialValues={{ query: "" }} onSubmit={jest.fn()}>
+        <Form>
+          <Field name="query" />
+          <SearchHelp search={search} />
+        </Form>
+      </Formik>,
+      { url: "/?q=.applications" }
+    );
+    // Open the menu so that the portal gets rendered.
+    await userEvent.click(screen.getByRole("button", { name: "." }));
+    expect(search).toHaveBeenCalledWith(".");
+  });
+});

--- a/src/pages/AdvancedSearch/SearchForm/SearchHelp/SearchHelp.tsx
+++ b/src/pages/AdvancedSearch/SearchForm/SearchHelp/SearchHelp.tsx
@@ -1,0 +1,61 @@
+import { useFormikContext } from "formik";
+
+import QueryLink from "../QueryLink";
+import type { FormFields } from "../types";
+
+type Props = {
+  search: (query: string) => void;
+};
+
+const SearchHelp = ({ search }: Props): JSX.Element => {
+  const { setFieldValue } = useFormikContext<FormFields>();
+
+  const handleQuery = (query: string) => {
+    setFieldValue("query", query);
+    search(query);
+  };
+
+  return (
+    <>
+      <p className="p-form-help-text u-no-margin--top">
+        Search all models using the{" "}
+        <a
+          href="https://jqlang.github.io/jq/"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          JQ
+        </a>{" "}
+        syntax. To see the JSON that is queried you can use the CLI to run{" "}
+        <code>juju status --format json</code> or search for{" "}
+        <QueryLink query="." handleQuery={handleQuery} /> to return the
+        unmodified output for all models.
+      </p>
+      <div className="u-hide u-show--large">
+        <p className="p-form-help-text">Examples:</p>
+        <ul className="p-form-help-text">
+          <li>
+            Get all applications:{" "}
+            <QueryLink query=".applications" handleQuery={handleQuery} />
+          </li>
+          <li>
+            Get all available models:{" "}
+            <QueryLink
+              query={`. | select(."model-status".current=="available")`}
+              handleQuery={handleQuery}
+            />
+          </li>
+          <li>
+            Get all models that contain an application named postgresql:{" "}
+            <QueryLink
+              query={`select(.applications | to_entries[] | select(.key=="postgresql")) | .`}
+              handleQuery={handleQuery}
+            />
+          </li>
+        </ul>
+      </div>
+    </>
+  );
+};
+
+export default SearchHelp;

--- a/src/pages/AdvancedSearch/SearchForm/SearchHelp/index.ts
+++ b/src/pages/AdvancedSearch/SearchForm/SearchHelp/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SearchHelp";

--- a/src/pages/AdvancedSearch/SearchForm/SearchHistoryMenu/SearchHistoryMenu.test.tsx
+++ b/src/pages/AdvancedSearch/SearchForm/SearchHistoryMenu/SearchHistoryMenu.test.tsx
@@ -13,14 +13,18 @@ describe("SearchHistoryMenu", () => {
   it("should be disabled when there is no history", async () => {
     renderComponent(
       <Formik initialValues={{ query: "" }} onSubmit={jest.fn()}>
-        <SearchHistoryMenu queryHistory={[]} setQueryHistory={jest.fn()} />
+        <SearchHistoryMenu
+          queryHistory={[]}
+          search={jest.fn()}
+          setQueryHistory={jest.fn()}
+        />
       </Formik>,
       { url: "/?q=.applications" }
     );
     expect(screen.getByRole("button", { name: Label.HISTORY })).toBeDisabled();
   });
 
-  it("should be disabled while loading", async () => {
+  it("should disable the items while loading", async () => {
     const state = rootStateFactory.build({
       juju: jujuStateFactory.build({
         crossModelQuery: crossModelQueryStateFactory.build({
@@ -30,11 +34,19 @@ describe("SearchHistoryMenu", () => {
     });
     renderComponent(
       <Formik initialValues={{ query: "" }} onSubmit={jest.fn()}>
-        <SearchHistoryMenu queryHistory={[]} setQueryHistory={jest.fn()} />
+        <SearchHistoryMenu
+          queryHistory={[".applications"]}
+          search={jest.fn()}
+          setQueryHistory={jest.fn()}
+        />
       </Formik>,
       { state, url: "/?q=.applications" }
     );
-    expect(screen.getByRole("button", { name: Label.HISTORY })).toBeDisabled();
+    // Open the menu so that the portal gets rendered.
+    await userEvent.click(screen.getByRole("button", { name: Label.HISTORY }));
+    expect(
+      screen.getByRole("button", { name: ".applications" })
+    ).toBeDisabled();
   });
 
   it("should display the history in the menu", async () => {
@@ -42,6 +54,7 @@ describe("SearchHistoryMenu", () => {
       <Formik initialValues={{ query: "" }} onSubmit={jest.fn()}>
         <SearchHistoryMenu
           queryHistory={[".applications", ".machines"]}
+          search={jest.fn()}
           setQueryHistory={jest.fn()}
         />
       </Formik>,
@@ -57,13 +70,15 @@ describe("SearchHistoryMenu", () => {
     ).toBeInTheDocument();
   });
 
-  it("should update the field and query param when clicking an item", async () => {
+  it("should update the field and perform a search when clicking an item", async () => {
+    const search = jest.fn();
     renderComponent(
       <Formik initialValues={{ query: "" }} onSubmit={jest.fn()}>
         <Form>
           <Field name="query" />
           <SearchHistoryMenu
             queryHistory={[".applications", ".machines"]}
+            search={search}
             setQueryHistory={jest.fn()}
           />
         </Form>
@@ -73,7 +88,7 @@ describe("SearchHistoryMenu", () => {
     // Open the menu so that the portal gets rendered.
     await userEvent.click(screen.getByRole("button", { name: Label.HISTORY }));
     await userEvent.click(screen.getByRole("button", { name: ".machines" }));
-    expect(window.location.search).toBe("?q=.machines");
+    expect(search).toHaveBeenCalledWith(".machines");
     expect(screen.getByRole("textbox")).toHaveValue(".machines");
   });
 
@@ -83,6 +98,7 @@ describe("SearchHistoryMenu", () => {
       <Formik initialValues={{ query: "" }} onSubmit={jest.fn()}>
         <SearchHistoryMenu
           queryHistory={[".applications", ".machines"]}
+          search={jest.fn()}
           setQueryHistory={setQueryHistory}
         />
       </Formik>,

--- a/src/pages/AdvancedSearch/SearchForm/SearchHistoryMenu/SearchHistoryMenu.tsx
+++ b/src/pages/AdvancedSearch/SearchForm/SearchHistoryMenu/SearchHistoryMenu.tsx
@@ -1,7 +1,6 @@
 import { ContextualMenu, Icon } from "@canonical/react-components";
 import { useFormikContext } from "formik";
 
-import { useQueryParams } from "hooks/useQueryParams";
 import { getCrossModelQueryLoading } from "store/juju/selectors";
 import { useAppSelector } from "store/store";
 
@@ -14,26 +13,26 @@ export enum Label {
 
 type Props = {
   queryHistory: string[];
+  search: (query: string) => void;
   setQueryHistory: (queryHistory: string[]) => void;
 };
 
 const SearchHistoryMenu = ({
   queryHistory,
+  search,
   setQueryHistory,
 }: Props): JSX.Element => {
   const loading = useAppSelector(getCrossModelQueryLoading);
   const { setFieldValue } = useFormikContext<FormFields>();
-  const [, setQueryParams] = useQueryParams<{ q: string }>({
-    q: "",
-  });
 
   return (
     <ContextualMenu
       links={[
         ...queryHistory.map((query) => ({
           children: query,
+          disabled: loading,
           onClick: () => {
-            setQueryParams({ q: encodeURIComponent(query) });
+            search(query);
             setFieldValue("query", query);
           },
         })),
@@ -48,7 +47,7 @@ const SearchHistoryMenu = ({
       ]}
       position="left"
       toggleClassName="has-icon"
-      toggleDisabled={queryHistory.length === 0 || loading}
+      toggleDisabled={queryHistory.length === 0}
       toggleLabel={<Icon name="revisions">{Label.HISTORY}</Icon>}
     />
   );

--- a/src/pages/AdvancedSearch/SearchForm/_search-form.scss
+++ b/src/pages/AdvancedSearch/SearchForm/_search-form.scss
@@ -1,5 +1,42 @@
 @import "vanilla-framework/scss/vanilla";
 
-.p-button.copy-json {
-  margin-left: $sph--large;
+@import "../../../scss/breakpoints";
+
+.search-form {
+  &__fields {
+    display: grid;
+    gap: 0 $sph--x-large;
+    grid-template:
+      "field help"
+      "controls help"
+      / 1fr 1fr;
+
+    @media screen and (max-width: $breakpoint-large - 1px) {
+      gap: 0;
+      grid-template:
+        "field"
+        "help"
+        "controls";
+
+      textarea {
+        margin-bottom: $spv--small;
+      }
+    }
+  }
+
+  &__controls {
+    grid-area: controls;
+  }
+
+  &__field {
+    grid-area: field;
+  }
+
+  &__help {
+    grid-area: help;
+  }
+
+  .p-button.copy-json {
+    margin-left: $sph--large;
+  }
 }

--- a/src/pages/AdvancedSearch/SearchForm/_search-form.scss
+++ b/src/pages/AdvancedSearch/SearchForm/_search-form.scss
@@ -1,5 +1,4 @@
 @import "vanilla-framework/scss/vanilla";
-
 @import "../../../scss/breakpoints";
 
 .search-form {


### PR DESCRIPTION
## Done

- Add cross model queries help.

## QA

- Go to the advanced search page.
- Check that the help appears next to the form on desktop.
- Resize to mobile and the help should move below the input and the examples should disappear.

## Details

https://warthogs.atlassian.net/browse/WD-5814

## Screenshots

<img width="726" alt="Screenshot 2023-08-23 at 2 53 45 pm" src="https://github.com/canonical/juju-dashboard/assets/361637/0dee671f-ac85-428e-aaea-9fd329a821f1">
<img width="1257" alt="Screenshot 2023-08-23 at 2 53 58 pm" src="https://github.com/canonical/juju-dashboard/assets/361637/1581d76e-217c-4b9e-95f0-eff0fdc0518b">

