### PR TITLE
WD-5821 - JSON tree theme

### DIFF
--- a/src/pages/AdvancedSearch/ResultsBlock/ResultsBlock.tsx
+++ b/src/pages/AdvancedSearch/ResultsBlock/ResultsBlock.tsx
@@ -27,26 +27,26 @@ enum CodeSnippetView {
   JSON = "json",
 }
 
-const DEFAULT = "#00000099";
+const DEFAULT_THEME_COLOUR = "#00000099";
 
 const THEME = {
   scheme: "Vanilla",
   base00: "#00000000",
-  base01: DEFAULT,
-  base02: DEFAULT,
-  base03: DEFAULT,
-  base04: DEFAULT,
-  base05: DEFAULT,
-  base06: DEFAULT,
+  base01: DEFAULT_THEME_COLOUR,
+  base02: DEFAULT_THEME_COLOUR,
+  base03: DEFAULT_THEME_COLOUR,
+  base04: DEFAULT_THEME_COLOUR,
+  base05: DEFAULT_THEME_COLOUR,
+  base06: DEFAULT_THEME_COLOUR,
   base07: "#000000",
   base08: "#a86500",
   base09: "#c7162b",
-  base0A: DEFAULT,
+  base0A: DEFAULT_THEME_COLOUR,
   base0B: "#0e811f",
-  base0C: DEFAULT,
+  base0C: DEFAULT_THEME_COLOUR,
   base0D: "#000000",
-  base0E: DEFAULT,
-  base0F: DEFAULT,
+  base0E: DEFAULT_THEME_COLOUR,
+  base0F: DEFAULT_THEME_COLOUR,
 };
 
 const valueRenderer: ValueRenderer = (valueAsString, value, ...keyPath) => {

--- a/src/pages/AdvancedSearch/ResultsBlock/ResultsBlock.tsx
+++ b/src/pages/AdvancedSearch/ResultsBlock/ResultsBlock.tsx
@@ -27,6 +27,28 @@ enum CodeSnippetView {
   JSON = "json",
 }
 
+const DEFAULT = "#00000099";
+
+const THEME = {
+  scheme: "Vanilla",
+  base00: "#00000000",
+  base01: DEFAULT,
+  base02: DEFAULT,
+  base03: DEFAULT,
+  base04: DEFAULT,
+  base05: DEFAULT,
+  base06: DEFAULT,
+  base07: "#000000",
+  base08: "#a86500",
+  base09: "#c7162b",
+  base0A: DEFAULT,
+  base0B: "#0e811f",
+  base0C: DEFAULT,
+  base0D: "#000000",
+  base0E: DEFAULT,
+  base0F: DEFAULT,
+};
+
 const valueRenderer: ValueRenderer = (valueAsString, value, ...keyPath) => {
   const currentKey = keyPath[0];
   const parentKey = keyPath.length >= 2 ? keyPath[1] : null;
@@ -102,6 +124,7 @@ const ResultsBlock = (): JSX.Element | null => {
                   shouldExpandNodeInitially={(_keyPath, _data, level) =>
                     level <= 2
                   }
+                  theme={THEME}
                   valueRenderer={valueRenderer}
                 />
               ),


### PR DESCRIPTION
## Done

- Theme the JSON tree to use Vanilla colours.

## QA

- Go to the advanced search page.
- Search for something.
- The tree should use Vanilla colours based on the [syntax highlighting colours](https://vanillaframework.io/docs/base/code#syntax-highlighting).

## Details

https://warthogs.atlassian.net/browse/WD-5821

## Screenshots

<img width="982" alt="Screenshot 2023-08-24 at 10 28 28 am" src="https://github.com/canonical/juju-dashboard/assets/361637/a887aecc-46b7-4a30-939e-02c209df7971">

