### PR TITLE
WD-5823 - Display status icons

### DIFF
--- a/src/components/Status/Status.test.tsx
+++ b/src/components/Status/Status.test.tsx
@@ -11,6 +11,13 @@ describe("Status", () => {
     expect(status).not.toHaveClass("is-middle");
   });
 
+  it("can display a provided content", () => {
+    render(<Status status="middle">Upper middle</Status>);
+    const status = screen.getByText("Upper middle");
+    expect(status).toBeInTheDocument();
+    expect(status).toHaveClass("is-middle");
+  });
+
   it("can display an icon", () => {
     render(<Status status="middle" useIcon />);
     const status = screen.getByText("middle");

--- a/src/components/Status/Status.tsx
+++ b/src/components/Status/Status.tsx
@@ -1,5 +1,6 @@
 import { Spinner } from "@canonical/react-components";
 import classNames from "classnames";
+import type { PropsWithChildren } from "react";
 
 type Props = {
   status?: string;
@@ -7,10 +8,11 @@ type Props = {
   useIcon?: boolean;
   actionsLogs?: boolean;
   className?: string | null;
-};
+} & PropsWithChildren;
 
 const Status = ({
   status = "unknown",
+  children,
   count,
   useIcon = true,
   actionsLogs = false,
@@ -28,7 +30,7 @@ const Status = ({
         [`is-${status.toLowerCase()}`]: useIcon && status,
       })}
     >
-      {status}
+      {children ?? status}
       {count || count === 0 ? ` (${count})` : null}
     </span>
   );

--- a/src/pages/AdvancedSearch/ResultsBlock/ResultsBlock.test.tsx
+++ b/src/pages/AdvancedSearch/ResultsBlock/ResultsBlock.test.tsx
@@ -78,7 +78,7 @@ describe("ResultsBlock", () => {
     expect(status).toHaveClass("is-pending");
   });
 
-  it("should put quotes around strings in the tree", async () => {
+  it("displays values in the tree", async () => {
     state.juju.crossModelQuery.loaded = true;
     state.juju.crossModelQuery.results = {
       mockModelUUID: [crossModelQueryFactory.withModel().build()],

--- a/src/pages/AdvancedSearch/ResultsBlock/ResultsBlock.test.tsx
+++ b/src/pages/AdvancedSearch/ResultsBlock/ResultsBlock.test.tsx
@@ -64,4 +64,27 @@ describe("ResultsBlock", () => {
       "▶mockModelUUID:[] 1 item▶0:{} 1 key▶model:{} 8 keys"
     );
   });
+
+  it("should show status icons in the tree", async () => {
+    state.juju.crossModelQuery.loaded = true;
+    state.juju.crossModelQuery.results = {
+      mockModelUUID: [crossModelQueryFactory.withModel().build()],
+    };
+    renderComponent(<ResultsBlock />, { state });
+    await userEvent.click(screen.getByText("model:"));
+    await userEvent.click(screen.getByText("model-status:"));
+    const status = screen.getByText('"pending"');
+    expect(status).toBeInTheDocument();
+    expect(status).toHaveClass("is-pending");
+  });
+
+  it("should put quotes around strings in the tree", async () => {
+    state.juju.crossModelQuery.loaded = true;
+    state.juju.crossModelQuery.results = {
+      mockModelUUID: [crossModelQueryFactory.withModel().build()],
+    };
+    renderComponent(<ResultsBlock />, { state });
+    await userEvent.click(screen.getByText("model:"));
+    expect(screen.getByText('"jaas-staging"')).toBeInTheDocument();
+  });
 });

--- a/src/pages/AdvancedSearch/ResultsBlock/ResultsBlock.tsx
+++ b/src/pages/AdvancedSearch/ResultsBlock/ResultsBlock.tsx
@@ -27,7 +27,7 @@ enum CodeSnippetView {
   JSON = "json",
 }
 
-const valueRenderer: ValueRenderer = (_valueAsString, value, ...keyPath) => {
+const valueRenderer: ValueRenderer = (valueAsString, value, ...keyPath) => {
   const currentKey = keyPath[0];
   const parentKey = keyPath.length >= 2 ? keyPath[1] : null;
   // Match a status of the following structure:
@@ -39,14 +39,12 @@ const valueRenderer: ValueRenderer = (_valueAsString, value, ...keyPath) => {
     currentKey === "current" &&
     typeof parentKey === "string" &&
     parentKey.endsWith("-status") &&
-    typeof value === "string"
+    typeof value === "string" &&
+    typeof valueAsString === "string"
   ) {
-    return <Status status={value}>"{value}"</Status>;
+    return <Status status={value}>{valueAsString}</Status>;
   }
-  if (typeof value === "string") {
-    return <>"{value}"</>;
-  }
-  return <>{value}</>;
+  return <>{valueAsString}</>;
 };
 
 const ResultsBlock = (): JSX.Element | null => {

--- a/src/pages/AdvancedSearch/ResultsBlock/_results-block.scss
+++ b/src/pages/AdvancedSearch/ResultsBlock/_results-block.scss
@@ -1,0 +1,7 @@
+@import "vanilla-framework/scss/vanilla";
+
+.results-block {
+  .status-icon::before {
+    left: -$sph--small;
+  }
+}

--- a/src/scss/custom/_status_icons.scss
+++ b/src/scss/custom/_status_icons.scss
@@ -33,6 +33,7 @@
     }
   }
 
+  &.is-busy,
   &.is-maintenance,
   &.is-attention,
   &.is-stopped,
@@ -50,6 +51,7 @@
     }
   }
 
+  &.is-available,
   &.is-completed,
   &.is-running,
   &.is-joined,


### PR DESCRIPTION
## Done

- Insert status icons into the JSON tree output.

## QA

- Go to the advanced search page.
- Do a search.
- Look through the tree and you should see status icons next to the status values.

## Details

https://warthogs.atlassian.net/browse/WD-5823

## Screenshots

<img width="531" alt="Screenshot 2023-08-24 at 1 23 52 pm" src="https://github.com/canonical/juju-dashboard/assets/361637/a26d09c0-b71d-4121-811b-64d9813bdaee">
<img width="416" alt="Screenshot 2023-08-24 at 1 23 59 pm" src="https://github.com/canonical/juju-dashboard/assets/361637/1f24fbda-e2f2-42b9-bbb8-9e9718f572b0">
<img width="411" alt="Screenshot 2023-08-24 at 1 24 07 pm" src="https://github.com/canonical/juju-dashboard/assets/361637/9cd1884b-1adc-499a-ab25-ea3a96b0a702">

