### PR TITLE
WD-5959 - Link keys to the model tabs

### DIFF
--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 
 import { useEntityDetailsParams } from "components/hooks";
 import urls from "urls";
+import { ModelTab } from "urls";
 
 import "./_breadcrumbs.scss";
 
@@ -17,7 +18,7 @@ export default function Breadcrumb(): JSX.Element {
   } = useEntityDetailsParams();
 
   const generateBreadcrumbs = function (): ReactNode {
-    const view = machineId ? "machines" : "apps";
+    const view = machineId ? ModelTab.MACHINES : ModelTab.APPS;
     if (!userName || !modelName) {
       return null;
     }
@@ -49,7 +50,13 @@ export default function Breadcrumb(): JSX.Element {
                 className="p-breadcrumbs__item u-no-padding--top"
                 data-testid="breadcrumb-section"
               >
-                <Link to={urls.model.tab({ userName, modelName, tab: "apps" })}>
+                <Link
+                  to={urls.model.tab({
+                    userName,
+                    modelName,
+                    tab: ModelTab.APPS,
+                  })}
+                >
                   Applications
                 </Link>
               </li>

--- a/src/components/ModelDetailsLink/ModelDetailsLink.test.tsx
+++ b/src/components/ModelDetailsLink/ModelDetailsLink.test.tsx
@@ -5,6 +5,7 @@ import { rootStateFactory } from "testing/factories";
 import { modelListInfoFactory } from "testing/factories/juju/juju";
 import { renderComponent } from "testing/utils";
 import urls from "urls";
+import { ModelTab } from "urls";
 
 import ModelDetailsLink from "./ModelDetailsLink";
 
@@ -32,7 +33,9 @@ describe("ModelDetailsLink", () => {
       }),
     };
     renderComponent(
-      <ModelDetailsLink uuid="abc123">Test Model</ModelDetailsLink>,
+      <ModelDetailsLink replaceLabel uuid="abc123">
+        Test Model
+      </ModelDetailsLink>,
       { state }
     );
     expect(
@@ -61,7 +64,7 @@ describe("ModelDetailsLink", () => {
       <ModelDetailsLink
         modelName="test-model"
         ownerTag="user-eggman"
-        view="apps"
+        view={ModelTab.APPS}
       >
         Test Model
       </ModelDetailsLink>,
@@ -72,7 +75,7 @@ describe("ModelDetailsLink", () => {
       urls.model.tab({
         userName: "eggman",
         modelName: "test-model",
-        tab: "apps",
+        tab: ModelTab.APPS,
       })
     );
   });

--- a/src/components/ModelDetailsLink/ModelDetailsLink.tsx
+++ b/src/components/ModelDetailsLink/ModelDetailsLink.tsx
@@ -15,16 +15,18 @@ type BaseProps = {
 type NameProps = BaseProps & {
   modelName: string;
   ownerTag?: string | null;
+  replaceLabel?: never;
   uuid?: never;
 };
 
-type UUIDProps = BaseProps & {
+export type UUIDProps = BaseProps & {
   modelName?: never;
   ownerTag?: never;
+  replaceLabel?: boolean;
   uuid: string;
 };
 
-type Props = PropsWithSpread<
+export type Props = PropsWithSpread<
   NameProps | UUIDProps,
   Partial<LinkProps & React.RefAttributes<HTMLAnchorElement>>
 >;
@@ -33,6 +35,7 @@ const ModelDetailsLink = ({
   modelName,
   ownerTag,
   children,
+  replaceLabel,
   uuid,
   view,
   ...props
@@ -52,7 +55,8 @@ const ModelDetailsLink = ({
   // If the owner isn't the logged in user then we need to use the
   // fully qualified path name.
   const userName = owner.replace("user-", "");
-  const label = uuid && userName && model ? `${userName}/${model}` : children;
+  const label =
+    replaceLabel && userName && model ? `${userName}/${model}` : children;
   return (
     <Link
       to={

--- a/src/components/ModelTableList/ModelSummary/ModelSummary.tsx
+++ b/src/components/ModelTableList/ModelSummary/ModelSummary.tsx
@@ -2,6 +2,7 @@ import { Icon, Tooltip } from "@canonical/react-components";
 
 import ModelDetailsLink from "components/ModelDetailsLink";
 import type { ModelData } from "store/juju/types";
+import { ModelTab } from "urls";
 
 export enum Label {
   APPS = "Number of applications",
@@ -32,7 +33,7 @@ const ModelSummary = ({ modelData, ownerTag }: Props) => {
         <ModelDetailsLink
           modelName={modelData.model.name}
           ownerTag={ownerTag}
-          view="apps"
+          view={ModelTab.APPS}
           className="p-link--soft"
           aria-label={Label.APPS}
         >
@@ -56,7 +57,7 @@ const ModelSummary = ({ modelData, ownerTag }: Props) => {
         <ModelDetailsLink
           modelName={modelData.model.name}
           ownerTag={ownerTag}
-          view="machines"
+          view={ModelTab.MACHINES}
           className="p-link--soft"
           aria-label={Label.MACHINES}
         >

--- a/src/pages/AdvancedSearch/ResultsBlock/ResultsBlock.test.tsx
+++ b/src/pages/AdvancedSearch/ResultsBlock/ResultsBlock.test.tsx
@@ -5,10 +5,28 @@ import type { RootState } from "store/store";
 import { rootStateFactory } from "testing/factories";
 import { generalStateFactory, configFactory } from "testing/factories/general";
 import { crossModelQueryFactory } from "testing/factories/juju/jimm";
-import { modelListInfoFactory } from "testing/factories/juju/juju";
+import { crossModelQueryModelFactory } from "testing/factories/juju/jimm";
+import {
+  jujuStateFactory,
+  modelListInfoFactory,
+} from "testing/factories/juju/juju";
 import { renderComponent } from "testing/utils";
+import urls from "urls";
+import { ModelTab } from "urls";
 
 import ResultsBlock, { TestId } from "./ResultsBlock";
+
+// Handle clicking the toggle for a key that has an anchor wrapping the label.
+const clickToggleForLink = async (name: string) => {
+  // Get the parent element to click on instead of the anchor.
+  const toggle = screen.getByRole("link", {
+    name,
+  }).parentElement;
+  expect(toggle).toBeInTheDocument();
+  if (toggle) {
+    await userEvent.click(toggle);
+  }
+};
 
 describe("ResultsBlock", () => {
   let state: RootState;
@@ -22,6 +40,15 @@ describe("ResultsBlock", () => {
         config: configFactory.build({
           controllerAPIEndpoint: "wss://controller.example.com",
         }),
+      }),
+      juju: jujuStateFactory.build({
+        models: {
+          abc123: modelListInfoFactory.build({
+            uuid: "abc123",
+            name: "test-model",
+            ownerTag: "user-eggman@external",
+          }),
+        },
       }),
     });
   });
@@ -37,7 +64,7 @@ describe("ResultsBlock", () => {
     state.juju.crossModelQuery.loaded = true;
     state.juju.crossModelQuery.loading = false;
     state.juju.crossModelQuery.results = {
-      mockModelUUID: [crossModelQueryFactory.withModel().build()],
+      abc123: [crossModelQueryFactory.withModel().build()],
     };
     renderComponent(<ResultsBlock />, { state });
     const codeSnippetDropdownButton = screen.getByRole("combobox");
@@ -56,13 +83,13 @@ describe("ResultsBlock", () => {
     state.juju.crossModelQuery.loaded = true;
     state.juju.crossModelQuery.loading = false;
     state.juju.crossModelQuery.results = {
-      mockModelUUID: [crossModelQueryFactory.withModel().build()],
+      abc123: [crossModelQueryFactory.withModel().build()],
     };
     renderComponent(<ResultsBlock />, { state });
     const codeSnippetDropdownButton = screen.getByRole("combobox");
     await userEvent.selectOptions(codeSnippetDropdownButton, "Tree");
     expect(document.querySelector(".p-code-snippet__block")).toHaveTextContent(
-      "▶mockModelUUID:[] 1 item▶0:{} 1 key▶model:{} 8 keys"
+      "▶eggman@external/test-model[] 1 item▶0:{} 1 key▶model:{} 8 keys"
     );
   });
 
@@ -70,13 +97,6 @@ describe("ResultsBlock", () => {
     state.juju.crossModelQuery.loaded = true;
     state.juju.crossModelQuery.results = {
       abc123: [crossModelQueryFactory.withModel().build()],
-    };
-    state.juju.models = {
-      abc123: modelListInfoFactory.build({
-        uuid: "abc123",
-        name: "test-model",
-        ownerTag: "user-eggman@external",
-      }),
     };
     renderComponent(<ResultsBlock />, { state });
     expect(screen.queryByText("abc123")).not.toBeInTheDocument();
@@ -88,10 +108,10 @@ describe("ResultsBlock", () => {
   it("should show status icons in the tree", async () => {
     state.juju.crossModelQuery.loaded = true;
     state.juju.crossModelQuery.results = {
-      mockModelUUID: [crossModelQueryFactory.withModel().build()],
+      abc123: [crossModelQueryFactory.withModel().build()],
     };
     renderComponent(<ResultsBlock />, { state });
-    await userEvent.click(screen.getByText("model:"));
+    await clickToggleForLink("model:");
     await userEvent.click(screen.getByText("model-status:"));
     const status = screen.getByText('"pending"');
     expect(status).toBeInTheDocument();
@@ -101,10 +121,107 @@ describe("ResultsBlock", () => {
   it("displays values in the tree", async () => {
     state.juju.crossModelQuery.loaded = true;
     state.juju.crossModelQuery.results = {
-      mockModelUUID: [crossModelQueryFactory.withModel().build()],
+      abc123: [crossModelQueryFactory.withModel().build()],
     };
     renderComponent(<ResultsBlock />, { state });
-    await userEvent.click(screen.getByText("model:"));
+    await clickToggleForLink("model:");
     expect(screen.getByText('"jaas-staging"')).toBeInTheDocument();
+  });
+
+  it("should handle blank keys in the tree view", async () => {
+    state.juju.crossModelQuery.loaded = true;
+    state.juju.crossModelQuery.results = {
+      abc123: [
+        crossModelQueryFactory.build({
+          model: crossModelQueryModelFactory.build({
+            "": "test",
+          }),
+        }),
+      ],
+    };
+    renderComponent(<ResultsBlock />, { state });
+    await clickToggleForLink("model:");
+    expect(screen.getByText("[none]:")).toBeInTheDocument();
+  });
+
+  it("should link to applications in the tree view", async () => {
+    state.juju.crossModelQuery.loaded = true;
+    state.juju.crossModelQuery.results = {
+      abc123: [crossModelQueryFactory.withApplications().build()],
+    };
+    renderComponent(<ResultsBlock />, { state });
+    expect(screen.getByRole("link", { name: "applications:" })).toHaveAttribute(
+      "href",
+      urls.model.tab({
+        userName: "eggman@external",
+        modelName: "test-model",
+        tab: ModelTab.APPS,
+      })
+    );
+  });
+
+  it("should link to offers in the tree view", async () => {
+    state.juju.crossModelQuery.loaded = true;
+    state.juju.crossModelQuery.results = {
+      abc123: [crossModelQueryFactory.withOffers().build()],
+    };
+    renderComponent(<ResultsBlock />, { state });
+    expect(screen.getByRole("link", { name: "offers:" })).toHaveAttribute(
+      "href",
+      urls.model.tab({
+        userName: "eggman@external",
+        modelName: "test-model",
+        tab: ModelTab.APPS,
+      })
+    );
+  });
+
+  it("should link to machines in the tree view", async () => {
+    state.juju.crossModelQuery.loaded = true;
+    state.juju.crossModelQuery.results = {
+      abc123: [crossModelQueryFactory.withMachines().build()],
+    };
+    renderComponent(<ResultsBlock />, { state });
+    expect(screen.getByRole("link", { name: "machines:" })).toHaveAttribute(
+      "href",
+      urls.model.tab({
+        userName: "eggman@external",
+        modelName: "test-model",
+        tab: ModelTab.MACHINES,
+      })
+    );
+  });
+
+  it("should link to relations in the tree view", async () => {
+    state.juju.crossModelQuery.loaded = true;
+    state.juju.crossModelQuery.results = {
+      abc123: [crossModelQueryFactory.withApplications().build()],
+    };
+    renderComponent(<ResultsBlock />, { state });
+    await clickToggleForLink("applications:");
+    await userEvent.click(screen.getByText("application_0:"));
+    expect(screen.getByRole("link", { name: "relations:" })).toHaveAttribute(
+      "href",
+      urls.model.tab({
+        userName: "eggman@external",
+        modelName: "test-model",
+        tab: ModelTab.INTEGRATIONS,
+      })
+    );
+  });
+
+  it("should link to the model in the tree view", async () => {
+    state.juju.crossModelQuery.loaded = true;
+    state.juju.crossModelQuery.results = {
+      abc123: [crossModelQueryFactory.withModel().build()],
+    };
+    renderComponent(<ResultsBlock />, { state });
+    expect(screen.getByRole("link", { name: "model:" })).toHaveAttribute(
+      "href",
+      urls.model.index({
+        userName: "eggman@external",
+        modelName: "test-model",
+      })
+    );
   });
 });

--- a/src/pages/AdvancedSearch/ResultsBlock/ResultsBlock.test.tsx
+++ b/src/pages/AdvancedSearch/ResultsBlock/ResultsBlock.test.tsx
@@ -105,6 +105,15 @@ describe("ResultsBlock", () => {
     ).toBeInTheDocument();
   });
 
+  it("should not replace top key if it is not a model UUID", async () => {
+    state.juju.crossModelQuery.loaded = true;
+    state.juju.crossModelQuery.results = {
+      "": [],
+    };
+    renderComponent(<ResultsBlock />, { state });
+    expect(screen.queryByText("[none]:")).toBeInTheDocument();
+  });
+
   it("should show status icons in the tree", async () => {
     state.juju.crossModelQuery.loaded = true;
     state.juju.crossModelQuery.results = {

--- a/src/pages/AdvancedSearch/ResultsBlock/ResultsBlock.tsx
+++ b/src/pages/AdvancedSearch/ResultsBlock/ResultsBlock.tsx
@@ -53,8 +53,6 @@ const THEME = {
 
 const getTab = (key: string) => {
   switch (key) {
-    case "action-logs":
-      return ModelTab.ACTION_LOGS;
     case "applications":
     case "offers":
       return ModelTab.APPS;

--- a/src/pages/AdvancedSearch/ResultsBlock/ResultsBlock.tsx
+++ b/src/pages/AdvancedSearch/ResultsBlock/ResultsBlock.tsx
@@ -68,11 +68,10 @@ const getTab = (key: string) => {
 const labelRenderer: LabelRenderer = (keyPath) => {
   const currentKey = keyPath[0];
   // The last item in keyPath should always be the model UUID.
-  const lastItem = keyPath[keyPath.length - 1];
-  const modelUUID = typeof lastItem === "string" ? lastItem : null;
-  if (!modelUUID) {
-    // If this is somehow not a string then just display it.
-    return <>{currentKey}</>;
+  const modelUUID = keyPath[keyPath.length - 1];
+  if (!modelUUID || typeof modelUUID !== "string") {
+    // If this is not a value that can be displayed then display "[none]" instead.
+    return <span className="u-text--muted">[none]:</span>;
   }
   // If this is a top level key then it is a model UUID.
   if (keyPath.length === 1) {

--- a/src/pages/AdvancedSearch/ResultsBlock/ResultsBlock.tsx
+++ b/src/pages/AdvancedSearch/ResultsBlock/ResultsBlock.tsx
@@ -7,7 +7,6 @@ import { useEffect, useState } from "react";
 import type { LabelRenderer, ValueRenderer } from "react-json-tree";
 import { JSONTree } from "react-json-tree";
 
-import ModelDetailsLink from "components/ModelDetailsLink";
 import Status from "components/Status";
 import { actions as jujuActions } from "store/juju";
 import {
@@ -16,8 +15,10 @@ import {
   getCrossModelQueryResults,
 } from "store/juju/selectors";
 import { useAppDispatch, useAppSelector } from "store/store";
+import { ModelTab } from "urls";
 
 import "./_results-block.scss";
+import ResultsModelLink from "../ResultsModelLink";
 
 export enum TestId {
   LOADING = "loading",
@@ -50,22 +51,58 @@ const THEME = {
   base0F: DEFAULT_THEME_COLOUR,
 };
 
+const getTab = (key: string) => {
+  switch (key) {
+    case "action-logs":
+      return ModelTab.ACTION_LOGS;
+    case "applications":
+    case "offers":
+      return ModelTab.APPS;
+    case "machines":
+      return ModelTab.MACHINES;
+    case "relations":
+      return ModelTab.INTEGRATIONS;
+    default:
+      return;
+  }
+};
+
 const labelRenderer: LabelRenderer = (keyPath) => {
   const currentKey = keyPath[0];
+  // The last item in keyPath should always be the model UUID.
+  const lastItem = keyPath[keyPath.length - 1];
+  const modelUUID = typeof lastItem === "string" ? lastItem : null;
+  if (!modelUUID) {
+    // If this is somehow not a string then just display it.
+    return <>{currentKey}</>;
+  }
   // If this is a top level key then it is a model UUID.
   if (keyPath.length === 1) {
     return (
-      <ModelDetailsLink
-        // Prevent toggling the object when the link is clicked.
-        onClick={(event) => event.stopPropagation()}
-        title={`UUID: ${currentKey}`}
-        uuid={currentKey.toString()}
-      >
-        {currentKey}:
-      </ModelDetailsLink>
+      <ResultsModelLink
+        replaceLabel
+        title={`UUID: ${modelUUID}`}
+        uuid={modelUUID}
+      />
     );
   }
-  return <>{currentKey}:</>;
+  switch (currentKey) {
+    case "applications":
+    case "machines":
+    case "offers":
+    case "relations":
+    case "model":
+      return (
+        <ResultsModelLink uuid={modelUUID} view={getTab(currentKey)}>
+          {currentKey}
+        </ResultsModelLink>
+      );
+    // Display something when the key is a blank string.
+    case "":
+      return <span className="u-text--muted">[none]:</span>;
+    default:
+      return <>{currentKey}:</>;
+  }
 };
 
 const valueRenderer: ValueRenderer = (valueAsString, value, ...keyPath) => {

--- a/src/pages/AdvancedSearch/ResultsModelLink/ResultsModelLink.test.tsx
+++ b/src/pages/AdvancedSearch/ResultsModelLink/ResultsModelLink.test.tsx
@@ -1,0 +1,39 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import type { RootState } from "store/store";
+import { rootStateFactory, jujuStateFactory } from "testing/factories";
+import { modelListInfoFactory } from "testing/factories/juju/juju";
+import { renderComponent } from "testing/utils";
+
+import ResultsModelLink from "./ResultsModelLink";
+
+describe("ResultsModelLink", () => {
+  let state: RootState;
+
+  beforeEach(() => {
+    state = rootStateFactory.withGeneralConfig().build({
+      juju: jujuStateFactory.build({
+        models: {
+          abc123: modelListInfoFactory.build({
+            uuid: "abc123",
+            name: "test-model",
+            ownerTag: "user-eggman@external",
+          }),
+        },
+      }),
+    });
+  });
+
+  it("should not propagate clicks", async () => {
+    const onClick = jest.fn();
+    renderComponent(
+      <button onClick={onClick}>
+        <ResultsModelLink uuid="abc123">abc123</ResultsModelLink>
+      </button>,
+      { state }
+    );
+    await userEvent.click(screen.getByRole("link", { name: "abc123:" }));
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/AdvancedSearch/ResultsModelLink/ResultsModelLink.tsx
+++ b/src/pages/AdvancedSearch/ResultsModelLink/ResultsModelLink.tsx
@@ -1,0 +1,32 @@
+import type { PropsWithSpread } from "@canonical/react-components";
+import type { PropsWithChildren } from "react";
+
+import ModelDetailsLink from "components/ModelDetailsLink";
+import type {
+  Props as ModelDetailsLinkProps,
+  UUIDProps,
+} from "components/ModelDetailsLink/ModelDetailsLink";
+
+type Props = PropsWithSpread<
+  UUIDProps & PropsWithChildren,
+  ModelDetailsLinkProps
+>;
+
+const ResultsModelLink = ({
+  children,
+  uuid,
+  ...props
+}: Props): JSX.Element | null => {
+  return (
+    <ModelDetailsLink
+      // Prevent toggling the object when the link is clicked.
+      onClick={(event) => event.stopPropagation()}
+      uuid={uuid}
+      {...props}
+    >
+      {children}:
+    </ModelDetailsLink>
+  );
+};
+
+export default ResultsModelLink;

--- a/src/pages/AdvancedSearch/ResultsModelLink/index.ts
+++ b/src/pages/AdvancedSearch/ResultsModelLink/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ResultsModelLink";

--- a/src/pages/EntityDetails/App/App.tsx
+++ b/src/pages/EntityDetails/App/App.tsx
@@ -29,6 +29,7 @@ import {
 } from "tables/tableHeaders";
 import { generateMachineRows, generateUnitRows } from "tables/tableRows";
 import type { AppTab } from "urls";
+import { ModelTab } from "urls";
 import urls from "urls";
 
 import { generateMachineCounts, generateUnitCounts } from "../counts";
@@ -343,7 +344,7 @@ export default function App(): JSX.Element {
                       ? urls.model.tab({
                           userName,
                           modelName,
-                          tab: "action-logs",
+                          tab: ModelTab.ACTION_LOGS,
                         })
                       : ""
                   }

--- a/src/pages/EntityDetails/EntityDetails.tsx
+++ b/src/pages/EntityDetails/EntityDetails.tsx
@@ -24,6 +24,7 @@ import {
 } from "store/juju/selectors";
 import { useAppSelector } from "store/store";
 import urls from "urls";
+import { ModelTab } from "urls";
 
 import "./_entity-details.scss";
 
@@ -115,21 +116,21 @@ const EntityDetails = () => {
         active: activeView === "apps",
         label: "Applications",
         onClick: (e: MouseEvent) => handleNavClick(e),
-        to: urls.model.tab({ userName, modelName, tab: "apps" }),
+        to: urls.model.tab({ userName, modelName, tab: ModelTab.APPS }),
         component: Link,
       },
       {
         active: activeView === "integrations",
         label: "Integrations",
         onClick: (e: MouseEvent) => handleNavClick(e),
-        to: urls.model.tab({ userName, modelName, tab: "integrations" }),
+        to: urls.model.tab({ userName, modelName, tab: ModelTab.INTEGRATIONS }),
         component: Link,
       },
       {
         active: activeView === "action-logs",
         label: "Logs",
         onClick: (e: MouseEvent) => handleNavClick(e),
-        to: urls.model.tab({ userName, modelName, tab: "action-logs" }),
+        to: urls.model.tab({ userName, modelName, tab: ModelTab.ACTION_LOGS }),
         component: Link,
       },
     ];
@@ -139,7 +140,7 @@ const EntityDetails = () => {
         active: activeView === "machines",
         label: "Machines",
         onClick: (e: MouseEvent) => handleNavClick(e),
-        to: urls.model.tab({ userName, modelName, tab: "machines" }),
+        to: urls.model.tab({ userName, modelName, tab: ModelTab.MACHINES }),
         component: Link,
       });
     }

--- a/src/pages/EntityDetails/EntityDetails.tsx
+++ b/src/pages/EntityDetails/EntityDetails.tsx
@@ -113,21 +113,21 @@ const EntityDetails = () => {
     }
     const items = [
       {
-        active: activeView === "apps",
+        active: activeView === ModelTab.APPS,
         label: "Applications",
         onClick: (e: MouseEvent) => handleNavClick(e),
         to: urls.model.tab({ userName, modelName, tab: ModelTab.APPS }),
         component: Link,
       },
       {
-        active: activeView === "integrations",
+        active: activeView === ModelTab.INTEGRATIONS,
         label: "Integrations",
         onClick: (e: MouseEvent) => handleNavClick(e),
         to: urls.model.tab({ userName, modelName, tab: ModelTab.INTEGRATIONS }),
         component: Link,
       },
       {
-        active: activeView === "action-logs",
+        active: activeView === ModelTab.ACTION_LOGS,
         label: "Logs",
         onClick: (e: MouseEvent) => handleNavClick(e),
         to: urls.model.tab({ userName, modelName, tab: ModelTab.ACTION_LOGS }),
@@ -137,7 +137,7 @@ const EntityDetails = () => {
 
     if (modelInfo?.type !== "kubernetes") {
       items.push({
-        active: activeView === "machines",
+        active: activeView === ModelTab.MACHINES,
         label: "Machines",
         onClick: (e: MouseEvent) => handleNavClick(e),
         to: urls.model.tab({ userName, modelName, tab: ModelTab.MACHINES }),

--- a/src/urls.ts
+++ b/src/urls.ts
@@ -1,6 +1,12 @@
 import { argPath } from "utils";
 
-export type ModelTab = "apps" | "machines" | "integrations" | "action-logs";
+export enum ModelTab {
+  APPS = "apps",
+  MACHINES = "machines",
+  INTEGRATIONS = "integrations",
+  ACTION_LOGS = "action-logs",
+}
+
 export type AppTab = "machines" | "units";
 export type ModelsGroupedBy = "status" | "cloud" | "owner";
 


### PR DESCRIPTION
## Done

- Link keys to the model tabs in the tree view.
- Display `[none]` for empty string keys.

## QA

- Go to the advanced search page and do a search.
- Check that various keys such as applications and machines link to the model details tabs (but won't currently load due to the API issues).

## Details

- https://warthogs.atlassian.net/browse/WD-5959

## Screenshots

<img width="522" alt="Screenshot 2023-08-25 at 3 23 28 pm" src="https://github.com/canonical/juju-dashboard/assets/361637/1f7c2b41-3474-4615-8a88-1c0d6dd80e82">

