### PR TITLE
WD-6052 - Link charms to Charmhub

### DIFF
--- a/src/pages/AdvancedSearch/CodeSnippetBlock/CodeSnippetBlock.tsx
+++ b/src/pages/AdvancedSearch/CodeSnippetBlock/CodeSnippetBlock.tsx
@@ -5,7 +5,8 @@ import {
 import { isValid, parseISO } from "date-fns";
 import { Highlight } from "prism-react-renderer";
 import Prism from "prismjs/components/prism-core";
-import { useState } from "react";
+import { useCallback, useState } from "react";
+import type { KeyPath } from "react-json-tree";
 import {
   JSONTree,
   type LabelRenderer,
@@ -16,6 +17,7 @@ import "prismjs/components/prism-json";
 import Status from "components/Status";
 import { formatFriendlyDateToNow } from "components/utils";
 import { type CrossModelQueryResponse } from "juju/jimm-facade";
+import type { CrossModelQueryState } from "store/juju/types";
 import { ModelTab } from "urls";
 
 import ResultsModelLink from "../ResultsModelLink";
@@ -63,6 +65,34 @@ const getTab = (key: string) => {
   }
 };
 
+// Use a key path to get the parent object that contains the current item from the results data.
+const getCurrentObject = (
+  keyPath: KeyPath,
+  results: CrossModelQueryState["results"]
+) =>
+  keyPath
+    // Ignore the first item, as we want to get the parent object.
+    .slice(1, keyPath.length)
+    // The first item in the key path is the current parameter and then has
+    // the parents in ascending order (e.g. [current, parent, grandparent]),
+    // but we need to follow the path from the outside in.
+    .reverse()
+    // This reduce follows the keypath by returning the next child until it
+    // finally reaches the end.
+    .reduce<object | null>((current, key) => {
+      // Check that the current item in the path is a valid object.
+      if (current && typeof current === "object" && key in current) {
+        const inner = current[key as keyof typeof current];
+        // Check that the next child is a valid object.
+        if (typeof inner === "object") {
+          // Store the next child.
+          return inner;
+        }
+      }
+      // Handle the case where the key path does not match the object that was provided.
+      return null;
+    }, results);
+
 const labelRenderer: LabelRenderer = (keyPath) => {
   const currentKey = keyPath[0];
   // The last item in keyPath should always be the model UUID.
@@ -100,40 +130,71 @@ const labelRenderer: LabelRenderer = (keyPath) => {
   }
 };
 
-const valueRenderer: ValueRenderer = (valueAsString, value, ...keyPath) => {
-  const currentKey = keyPath[0];
-  const parentKey = keyPath.length >= 2 ? keyPath[1] : null;
-  // Match a status of the following structure:
-  //   "application-status": {
-  //     "current": "unknown",
-  //     ...
-  //   }
-  if (
-    currentKey === "current" &&
-    typeof parentKey === "string" &&
-    parentKey.endsWith("-status") &&
-    typeof value === "string" &&
-    typeof valueAsString === "string"
-  ) {
-    return <Status status={value}>{valueAsString}</Status>;
-  }
-  // Display date values as tooltip with relative date.
-  if (typeof value === "string" && isValid(parseISO(value))) {
-    return (
-      <>
-        {value}{" "}
-        <span className="u-text--muted">
-          ({formatFriendlyDateToNow(value)})
-        </span>
-      </>
-    );
-  }
-  return <>{valueAsString}</>;
-};
-
 const CodeSnippetBlock = ({ className, title, code }: Props): JSX.Element => {
   const [codeSnippetView, setCodeSnippetView] = useState<CodeSnippetView>(
     CodeSnippetView.TREE
+  );
+
+  const valueRenderer = useCallback<ValueRenderer>(
+    (valueAsString, value, ...keyPath) => {
+      const currentKey = keyPath[0];
+      const parentKey = keyPath.length >= 2 ? keyPath[1] : null;
+      // Match a status of the following structure:
+      //   "application-status": {
+      //     "current": "unknown",
+      //     ...
+      //   }
+      if (
+        currentKey === "current" &&
+        typeof parentKey === "string" &&
+        parentKey.endsWith("-status") &&
+        typeof value === "string" &&
+        typeof valueAsString === "string"
+      ) {
+        return <Status status={value}>{valueAsString}</Status>;
+      }
+      // Display date values as tooltip with relative date.
+      if (typeof value === "string" && isValid(parseISO(value))) {
+        return (
+          <>
+            {value}{" "}
+            <span className="u-text--muted">
+              ({formatFriendlyDateToNow(value)})
+            </span>
+          </>
+        );
+      }
+      // Match charms with the following structure:
+      //   "charm": "mysql",
+      //   "charm-channel": "8.0/stable",
+      //   "charm-name": "mysql",
+      //   "charm-origin": "charmhub",
+      if (currentKey === "charm" && typeof valueAsString === "string") {
+        const currentObject = getCurrentObject(keyPath, code);
+        if (
+          currentObject &&
+          "charm-name" in currentObject &&
+          currentObject["charm-name"] &&
+          "charm-origin" in currentObject &&
+          currentObject["charm-origin"] === "charmhub"
+        ) {
+          let charmURL = `https://charmhub.io/${currentObject["charm-name"]}`;
+          if (
+            "charm-channel" in currentObject &&
+            currentObject["charm-channel"]
+          ) {
+            charmURL += `?channel=${currentObject["charm-channel"]}`;
+          }
+          return (
+            <a href={charmURL} target="_blank" rel="noopener noreferrer">
+              {valueAsString}
+            </a>
+          );
+        }
+      }
+      return <>{valueAsString}</>;
+    },
+    [code]
   );
 
   return (


### PR DESCRIPTION
## Done

- Link to Charmhub from charms.

## QA

- Go to the advanced search page and do a search.
- In the tree open an applications object and then open an app.
- The "charm" value should link to charmhub.io.

## Details

https://warthogs.atlassian.net/browse/WD-6052

## Screenshots

<img width="351" alt="Screenshot 2023-08-29 at 1 44 43 pm" src="https://github.com/canonical/juju-dashboard/assets/361637/d8dda9eb-e814-4564-8c75-d754adc461e5">

