### PR TITLE
WD-6051 - Scroll the history menu

### DIFF
--- a/src/pages/AdvancedSearch/CodeSnippetBlock/CodeSnippetBlock.tsx
+++ b/src/pages/AdvancedSearch/CodeSnippetBlock/CodeSnippetBlock.tsx
@@ -46,7 +46,7 @@ const THEME = {
   base0A: DEFAULT_THEME_COLOUR,
   base0B: "#0e811f",
   base0C: DEFAULT_THEME_COLOUR,
-  base0D: "#000000",
+  base0D: "#77216f",
   base0E: DEFAULT_THEME_COLOUR,
   base0F: DEFAULT_THEME_COLOUR,
 };

--- a/src/pages/AdvancedSearch/SearchForm/SearchHistoryMenu/SearchHistoryMenu.tsx
+++ b/src/pages/AdvancedSearch/SearchForm/SearchHistoryMenu/SearchHistoryMenu.tsx
@@ -46,6 +46,7 @@ const SearchHistoryMenu = ({
         },
       ]}
       position="left"
+      scrollOverflow
       toggleClassName="has-icon"
       toggleDisabled={queryHistory.length === 0}
       toggleLabel={<Icon name="revisions">{Label.HISTORY}</Icon>}


### PR DESCRIPTION
## Done

- Scroll the history menu if it has too many items to fit on the screen.

## QA

- Go to the advanced search page.
- Perform a number of searches so that your history menu is long.
- Resize your screen so that the history menu doesn't fit on the screen.
- The history dropdown should scroll instead of causing the entire app to scroll.

## Details

https://warthogs.atlassian.net/browse/WD-6051

## Screenshots

<img width="838" alt="Screenshot 2023-08-31 at 4 04 26 pm" src="https://github.com/canonical/juju-dashboard/assets/361637/8be9c6b8-eb01-40fb-a591-9f8f35b1e453">

