### PR TITLE
WD-6094 - Display JIMM errors

### DIFF
--- a/src/store/middleware/model-poller.ts
+++ b/src/store/middleware/model-poller.ts
@@ -10,6 +10,7 @@ import {
   loginWithBakery,
   setModelSharingPermissions,
 } from "juju/api";
+import type { CrossModelQueryFullResponse } from "juju/jimm-facade";
 import type { ConnectionWithFacades } from "juju/types";
 import { actions as appActions, thunks as appThunks } from "store/app";
 import { actions as generalActions } from "store/general";
@@ -189,7 +190,14 @@ export const modelPollerMiddleware: Middleware<
       if (!conn) {
         return;
       }
-      const crossModelQueryResponse = await crossModelQuery(conn, query);
+      let crossModelQueryResponse: CrossModelQueryFullResponse;
+      try {
+        crossModelQueryResponse = await crossModelQuery(conn, query);
+      } catch (error) {
+        console.error("Could not perform cross model query:", error);
+        crossModelQueryResponse =
+          "Unable to perform search. Please try again later.";
+      }
       reduxStore.dispatch(
         jujuActions.updateCrossModelQuery(crossModelQueryResponse)
       );


### PR DESCRIPTION
## Done

- Display errors from the API.

## QA

- Open `jimm-facade.ts` and at the bottom change the version to `JIMMV4.VERSION = 99;`.
- Load the dashboard
- Go to the advanced search page.
- Do a search.
- You should see an error.

## Details

https://warthogs.atlassian.net/browse/WD-6094

## Screenshots

<img width="438" alt="Screenshot 2023-09-01 at 12 45 02 pm" src="https://github.com/canonical/juju-dashboard/assets/361637/de965380-2969-4598-859e-0373347b43c1">

