### PR TITLE
Tag to username util

### DIFF
--- a/src/components/ModelTableList/ModelDetailsLink/ModelDetailsLink.tsx
+++ b/src/components/ModelTableList/ModelDetailsLink/ModelDetailsLink.tsx
@@ -5,6 +5,7 @@ import type { LinkProps } from "react-router-dom";
 
 import type { ModelTab } from "urls";
 import urls from "urls";
+import getUserName from "utils/getUserName";
 
 type Props = PropsWithSpread<
   {
@@ -34,7 +35,7 @@ const ModelDetailsLink = ({
   }
   // If the owner isn't the logged in user then we need to use the
   // fully qualified path name.
-  const userName = ownerTag.replace("user-", "");
+  const userName = getUserName(ownerTag);
   return (
     <Link
       to={

--- a/src/components/ModelTableList/StatusGroup.tsx
+++ b/src/components/ModelTableList/StatusGroup.tsx
@@ -20,6 +20,7 @@ import {
   getModelStatusGroupData,
 } from "store/juju/utils/models";
 import urls from "urls";
+import getUserName from "utils/getUserName";
 
 import AccessButton from "./AccessButton/AccessButton";
 import CloudCell from "./CloudCell/CloudCell";
@@ -48,7 +49,7 @@ const generateWarningMessage = (model: ModelData) => {
     return null;
   }
   const ownerTag = model?.info?.["owner-tag"] ?? "";
-  const userName = ownerTag.replace("user-", "");
+  const userName = getUserName(ownerTag);
   const modelName = model.model.name;
   const link = (
     <ModelDetailsLink modelName={modelName} ownerTag={ownerTag}>

--- a/src/components/WebCLI/WebCLI.tsx
+++ b/src/components/WebCLI/WebCLI.tsx
@@ -8,6 +8,7 @@ import bakery from "juju/bakery";
 import { getActiveUserTag } from "store/general/selectors";
 import type { Credential } from "store/general/types";
 import { externalURLs } from "urls";
+import getUserName from "utils/getUserName";
 
 import useAnalytics from "../../hooks/useAnalytics";
 
@@ -156,7 +157,7 @@ const WebCLI = ({
           storeState,
           `${originalWSOrigin}/api`
         );
-        authentication.user = activeUser?.replace("user-", "");
+        authentication.user = activeUser ? getUserName(activeUser) : undefined;
         authentication.macaroons = [deserialized];
       } else {
         // XXX Surface error to the user.

--- a/src/panels/ShareModelPanel/ShareModel.tsx
+++ b/src/panels/ShareModelPanel/ShareModel.tsx
@@ -18,6 +18,7 @@ import {
   getUserDomainsInModel,
 } from "store/juju/selectors";
 import { useAppSelector, usePromiseDispatch } from "store/store";
+import getUserName from "utils/getUserName";
 
 import "./share-model.scss";
 
@@ -111,7 +112,8 @@ export default function ShareModel() {
   }, [users]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const isOwner = (user: string) => {
-    return user === modelStatusData?.info?.["owner-tag"].replace("user-", "");
+    const ownerTag = modelStatusData?.info?.["owner-tag"];
+    return !!ownerTag && user === getUserName(ownerTag);
   };
 
   const userAlreadyHasAccess = (username: string, users?: User[]) => {

--- a/src/store/juju/selectors.ts
+++ b/src/store/juju/selectors.ts
@@ -19,6 +19,7 @@ import {
   getActiveUserControllerAccess,
 } from "store/general/selectors";
 import type { RootState } from "store/store";
+import getUserName from "utils/getUserName";
 
 import type {
   Controllers,
@@ -163,8 +164,10 @@ export const getUserDomainsInModel = createSelector(
 */
 export const getActiveUser = createSelector(
   [getModelByUUID, (state: RootState) => state],
-  (model, state) =>
-    getActiveUserTag(state, model?.wsControllerURL)?.replace("user-", "")
+  (model, state) => {
+    const activeUserTag = getActiveUserTag(state, model?.wsControllerURL);
+    return activeUserTag ? getUserName(activeUserTag) : undefined;
+  }
 );
 
 export const getModelAccess = createSelector(
@@ -235,7 +238,7 @@ export function getModelUUIDFromList(
       return modelUUID;
     }
     Object.entries(modelList).some(([_key, { name, ownerTag, uuid }]) => {
-      if (name === modelName && ownerTag.replace("user-", "") === ownerName) {
+      if (name === modelName && getUserName(ownerTag) === ownerName) {
         modelUUID = uuid;
         return true;
       }

--- a/src/store/juju/utils/models.ts
+++ b/src/store/juju/utils/models.ts
@@ -2,6 +2,7 @@ import type { ModelUserInfo } from "@canonical/jujulib/dist/api/facades/model-ma
 import type { Endpoint } from "@canonical/jujulib/dist/api/facades/uniter/UniterV18";
 
 import defaultCharmIcon from "static/images/icons/default-charm-icon.svg";
+import getUserName from "utils/getUserName";
 
 import type { ModelData, ModelDataList } from "../types";
 
@@ -179,7 +180,7 @@ export const getUnitStatusGroup = (
   @returns The simplified owner string
 */
 export const extractOwnerName = (tag: string) => {
-  return tag.split("@")[0].replace("user-", "");
+  return getUserName(tag.split("@")[0]);
 };
 
 /**

--- a/src/utils/getUserName.test.ts
+++ b/src/utils/getUserName.test.ts
@@ -1,0 +1,18 @@
+import getUserName from "./getUserName";
+
+describe("getUser", () => {
+  it("should return user name if no prefix is present", () => {
+    const userName = getUserName("eggman");
+    expect(userName).toBe("eggman");
+  });
+
+  it("should return same user name if other prefix is present", () => {
+    const userName = getUserName("otherPrefix-eggman");
+    expect(userName).toBe("otherPrefix-eggman");
+  });
+
+  it("should remove the prefix when present", () => {
+    const userName = getUserName("user-eggman");
+    expect(userName).toBe("eggman");
+  });
+});

--- a/src/utils/getUserName.ts
+++ b/src/utils/getUserName.ts
@@ -1,0 +1,4 @@
+const getUserName = (userNameWithPrefix: string): string =>
+  userNameWithPrefix.replace("user-", "");
+
+export default getUserName;


### PR DESCRIPTION
## Done

- Add util for getting the username from a tag (originally added in the audit-logs branch: https://github.com/canonical/juju-dashboard/pull/1541).