### PR TITLE
WD-5786 - Sort by most recent first

### DIFF
--- a/src/components/AuditLogsTable/hooks.ts
+++ b/src/components/AuditLogsTable/hooks.ts
@@ -62,6 +62,8 @@ export const useFetchAuditEvents = () => {
         "user-tag": queryParams.user ? `user-${queryParams.user}` : undefined,
         model: model ?? undefined,
         method: queryParams.method ?? undefined,
+        // Sort by most recent first.
+        sortTime: true,
       })
     );
   }, [

--- a/src/juju/jimm/JIMMV3.ts
+++ b/src/juju/jimm/JIMMV3.ts
@@ -35,6 +35,7 @@ export type FindAuditEventsRequest = {
   method?: string;
   model?: string;
   offset?: number;
+  sortTime?: boolean;
   "user-tag"?: string;
 };
 


### PR DESCRIPTION
## Done

- Sort audit logs by most recent first.

## QA

- Go to the logs page.
- Check that the audit logs appear with most recent first.

## Details

https://warthogs.atlassian.net/browse/WD-5786
