### PR TITLE
WD-6179 - Disable username/password instead of help text

### DIFF
--- a/src/panels/RegisterController/RegisterController.test.tsx
+++ b/src/panels/RegisterController/RegisterController.test.tsx
@@ -42,11 +42,6 @@ describe("RegisterController", () => {
     );
     await userEvent.click(
       screen.getByRole("checkbox", {
-        name: "An identity provider is available.",
-      })
-    );
-    await userEvent.click(
-      screen.getByRole("checkbox", {
         name: "The SSL certificate, if any, has been accepted. *",
       })
     );
@@ -58,7 +53,7 @@ describe("RegisterController", () => {
           password: "",
           user: "eggman@external",
         },
-        true,
+        null,
         true,
       ],
     ]);
@@ -67,6 +62,28 @@ describe("RegisterController", () => {
         .getActions()
         .find((action) => action.type === "connectAndStartPolling")
     ).toBeTruthy();
+  });
+
+  it("clears and disables the username and password if external auth is set", async () => {
+    renderComponent(<RegisterController />);
+    await userEvent.type(
+      screen.getByRole("textbox", {
+        name: "Username",
+      }),
+      "eggman@external"
+    );
+    await userEvent.type(screen.getByLabelText("Password"), "verysecure123");
+    expect(screen.getByRole("textbox", { name: "Username" })).toHaveValue(
+      "eggman@external"
+    );
+    expect(screen.getByLabelText("Password")).toHaveValue("verysecure123");
+    await userEvent.click(
+      screen.getByRole("checkbox", {
+        name: "This controller uses an external identity provider.",
+      })
+    );
+    expect(screen.getByRole("textbox", { name: "Username" })).toHaveValue("");
+    expect(screen.getByLabelText("Password")).toHaveValue("");
   });
 
   it("requires the certificate warning to be checked", async () => {

--- a/src/panels/RegisterController/RegisterController.test.tsx
+++ b/src/panels/RegisterController/RegisterController.test.tsx
@@ -83,7 +83,9 @@ describe("RegisterController", () => {
       })
     );
     expect(screen.getByRole("textbox", { name: "Username" })).toHaveValue("");
+    expect(screen.getByRole("textbox", { name: "Username" })).toBeDisabled();
     expect(screen.getByLabelText("Password")).toHaveValue("");
+    expect(screen.getByLabelText("Password")).toBeDisabled();
   });
 
   it("requires the certificate warning to be checked", async () => {

--- a/src/panels/RegisterController/RegisterController.tsx
+++ b/src/panels/RegisterController/RegisterController.tsx
@@ -23,8 +23,8 @@ export const STORAGE_KEY = "additionalControllers";
 type FormValues = {
   controllerName?: string;
   wsControllerHost?: string;
-  username?: string;
-  password?: string;
+  username: string;
+  password: string;
   identityProvider?: boolean;
   certificateAccepted?: boolean;
 };

--- a/src/panels/RegisterController/RegisterController.tsx
+++ b/src/panels/RegisterController/RegisterController.tsx
@@ -1,5 +1,4 @@
 import { Button, Col, Row } from "@canonical/react-components";
-import classNames from "classnames";
 import type { ChangeEvent } from "react";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
@@ -35,7 +34,10 @@ type RegisterControllerQueryParams = {
 };
 
 export default function RegisterController() {
-  const [formValues, setFormValues] = useState<FormValues>({});
+  const [formValues, setFormValues] = useState<FormValues>({
+    password: "",
+    username: "",
+  });
   const dispatch = useAppDispatch();
   const [additionalControllers, setAdditionalControllers] = useLocalStorage<
     ControllerArgs[]
@@ -170,7 +172,31 @@ export default function RegisterController() {
             </div>
           </div>
         </div>
-
+        <div className="p-form__group row">
+          <div className="col-10 col-start-large-3">
+            <input
+              type="checkbox"
+              id="identityProviderAvailable"
+              name="identityProvider"
+              defaultChecked={false}
+              onChange={(event) => {
+                setFormValues({
+                  ...formValues,
+                  identityProvider: event.target.checked,
+                  password: "",
+                  username: "",
+                });
+              }}
+            />{" "}
+            <label htmlFor="identityProviderAvailable">
+              This controller uses an external identity provider.
+            </label>
+            <p className="p-form-help-text identity-provider ">
+              This will be true for controllers with the `identity-url`
+              parameter set.
+            </p>
+          </div>
+        </div>
         <div className="p-form__group row">
           <div className="col-2">
             <label htmlFor="username" className="p-form__label">
@@ -181,10 +207,12 @@ export default function RegisterController() {
           <div className="col-10">
             <div className="p-form__control">
               <input
+                disabled={formValues.identityProvider}
                 type="text"
                 id="username"
                 name="username"
                 onChange={handleInputChange}
+                value={formValues.username}
               />
               <p className="p-form-help-text">
                 The username you use to access the controller.
@@ -203,39 +231,18 @@ export default function RegisterController() {
           <div className="col-10">
             <div className="p-form__control">
               <input
+                disabled={formValues.identityProvider}
                 type="password"
                 id="password"
                 name="password"
                 onChange={handleInputChange}
+                value={formValues.password}
               />
               <p className="p-form-help-text">
                 The password will be what you used when running{" "}
                 <code>juju register</code> or if unchanged from the default it
                 can be retrieved by running <code>juju dashboard</code>.
               </p>
-            </div>
-          </div>
-        </div>
-
-        <div
-          className={classNames("p-form__group row", {
-            "u-hide": formValues.username && formValues.password,
-          })}
-        >
-          <div className="col-10 col-start-large-3">
-            <input
-              type="checkbox"
-              id="identityProviderAvailable"
-              name="identityProvider"
-              defaultChecked={false}
-              onChange={handleInputChange}
-            />
-            <label htmlFor="identityProviderAvailable">
-              An identity provider is available.{" "}
-            </label>
-            <div className="p-form-help-text identity-provider">
-              If you provided a username and password this should be left
-              unchecked.
             </div>
           </div>
         </div>
@@ -258,7 +265,7 @@ export default function RegisterController() {
               defaultChecked={false}
               onChange={handleInputChange}
               required={true}
-            />
+            />{" "}
             <label htmlFor="certificateHasBeenAccepted">
               The SSL certificate, if any, has been accepted.{" "}
               <span className="required-star">*</span>


### PR DESCRIPTION


## Done

- Remove help text about not filling in username/password when using external auth and instead disable the fields.
- Change field order so that you make the decision about using external auth first.

## QA

- Go to the controllers page.
- Click "Register a controller".
- Fill in the username and password.
- Tick "This controller uses an external identity provider."
- The username and password fields should get disabled and cleared.

## Details

https://warthogs.atlassian.net/browse/WD-6179
Fixes: https://github.com/canonical/juju-dashboard/issues/1501.


## Screenshots

<img width="531" alt="Screenshot 2023-09-06 at 12 09 11 pm" src="https://github.com/canonical/juju-dashboard/assets/361637/d5142834-599d-4117-947d-1a8cdbaeea8c">

