### PR TITLE
WD-6180 - Fix topology position

### DIFF
--- a/src/components/Topology/Topology.test.tsx
+++ b/src/components/Topology/Topology.test.tsx
@@ -80,7 +80,7 @@ describe("Topology", () => {
     );
     const apps = document.querySelectorAll(".application");
     expect(apps[0]).toHaveAttribute("data-name", "landscape");
-    expect(apps[0]).toHaveAttribute("transform", "translate(100, 150)");
+    expect(apps[0]).toHaveAttribute("transform", "translate(0, 0)");
     expect(apps[0].querySelector("circle")).toBeInTheDocument();
     expect(apps[0].querySelector("image")).toBeInTheDocument();
     expect(apps[0].querySelector("image")).toHaveAttribute(
@@ -88,7 +88,7 @@ describe("Topology", () => {
       "https://charmhub.io/landscape/icon"
     );
     expect(apps[1]).toHaveAttribute("data-name", "postgresql");
-    expect(apps[1]).toHaveAttribute("transform", "translate(250, 300)");
+    expect(apps[1]).toHaveAttribute("transform", "translate(150, 150)");
     expect(apps[1].querySelector("circle")).toBeInTheDocument();
     expect(apps[1].querySelector("image")).toBeInTheDocument();
     expect(apps[1].querySelector("image")).toHaveAttribute(
@@ -191,9 +191,9 @@ describe("Topology", () => {
     const relationLine = document
       .querySelector(".relation")
       ?.querySelector("line");
-    expect(relationLine).toHaveAttribute("x1", "190");
-    expect(relationLine).toHaveAttribute("x2", "340");
-    expect(relationLine).toHaveAttribute("y1", "240");
-    expect(relationLine).toHaveAttribute("y2", "390");
+    expect(relationLine).toHaveAttribute("x1", "90");
+    expect(relationLine).toHaveAttribute("x2", "240");
+    expect(relationLine).toHaveAttribute("y1", "90");
+    expect(relationLine).toHaveAttribute("y2", "240");
   });
 });

--- a/src/components/Topology/Topology.tsx
+++ b/src/components/Topology/Topology.tsx
@@ -1,3 +1,4 @@
+import cloneDeep from "clone-deep";
 import * as d3 from "d3";
 import { useRef, useEffect, memo } from "react";
 
@@ -144,13 +145,15 @@ const getRelationPosition = (data: string[]) => {
 // glitches.
 const Topology = memo(
   ({
-    annotations: annotationData,
+    annotations,
     applications: applicationData,
     relations: relationData,
     width,
     height,
   }: Props) => {
     const ref = useRef<SVGSVGElement>(null);
+    // Clone the data so that it can be manipulated before rendering.
+    const annotationData = cloneDeep(annotations);
 
     const { deltaX, deltaY } = computePositionDelta(annotationData);
 
@@ -166,7 +169,7 @@ const Topology = memo(
 
     // Apply deltas to the annotations.
     for (const appName in annotationData) {
-      const annotation = { ...annotationData[appName] };
+      const annotation = annotationData[appName];
       if (annotation["gui-x"]) {
         annotation["gui-x"] = applyDelta(
           annotation["gui-x"],


### PR DESCRIPTION
## Done

- Fix annotation mutations so that the topology gets centred.

## QA

- Using a local controller add a model.
- Deploy a bundle that has annotations information e.g. `juju deploy charmed-kubernetes`.
- Load the dashboard.
- Go to the model list and click on the model you added.
- In the little bundle visualisation check that the contents are nicely centred, with even space around the edges.

## Details

https://warthogs.atlassian.net/browse/WD-6180
Fixes: https://github.com/canonical/juju-dashboard/issues/1507

## Screenshots

<img width="249" alt="Screenshot 2023-09-06 at 2 26 28 pm" src="https://github.com/canonical/juju-dashboard/assets/361637/b714d699-1a91-4cca-a937-fda5d9ef9f02">

