### PR TITLE
WD-6200 - reduce full status calls for Juju 3.2

### DIFF
--- a/src/juju/types.ts
+++ b/src/juju/types.ts
@@ -106,7 +106,7 @@ export interface WatcherModelData {
 // This type is used for Juju versions before 3.2.
 export interface Pre32AnnotatedWatcherModelInfo extends Pre32ModelChangeDelta {
   cloud: string;
-  region?: string;
+  "cloud-region"?: string;
   type: string;
   version: string;
 }
@@ -259,7 +259,7 @@ type Pre32ModelChangeDelta = {
 
 type Post32ModelChangeDelta = Pre32ModelChangeDelta & {
   cloud: string;
-  region: string;
+  "cloud-region": string;
   type: string;
   version: string;
 };

--- a/src/juju/types.ts
+++ b/src/juju/types.ts
@@ -103,12 +103,17 @@ export interface WatcherModelData {
   units: UnitData;
 }
 
-export interface WatcherModelInfo extends ModelChangeDelta {
-  "cloud-tag": string;
+// This type is used for Juju versions before 3.2.
+export interface Pre32AnnotatedWatcherModelInfo extends Pre32ModelChangeDelta {
+  cloud: string;
   region?: string;
   type: string;
   version: string;
 }
+
+export type WatcherModelInfo =
+  | Post32ModelChangeDelta
+  | Pre32AnnotatedWatcherModelInfo;
 
 export interface AnnotationInfo {
   [annotationName: string]: string;
@@ -239,7 +244,7 @@ export interface HardwareCharacteristics {
   "availability-zone": string;
 }
 
-export interface ModelChangeDelta {
+type Pre32ModelChangeDelta = {
   "model-uuid": string;
   name: string;
   life: Life;
@@ -250,7 +255,16 @@ export interface ModelChangeDelta {
   status: ModelAgentStatus;
   constraints: { [key: string]: unknown };
   sla: ModelSLAInfo;
-}
+};
+
+type Post32ModelChangeDelta = Pre32ModelChangeDelta & {
+  cloud: string;
+  region: string;
+  type: string;
+  version: string;
+};
+
+export type ModelChangeDelta = Pre32ModelChangeDelta | Post32ModelChangeDelta;
 
 export interface ModelAgentStatus extends Status {
   current: "available" | "busy" | "";

--- a/src/juju/watchers.ts
+++ b/src/juju/watchers.ts
@@ -21,7 +21,7 @@ export function generateModelWatcherBase(): WatcherModelData {
     charms: {},
     machines: {},
     model: {
-      "cloud-tag": "",
+      cloud: "",
       "controller-uuid": "",
       "is-controller": false,
       "model-uuid": "",

--- a/src/juju/watchers.ts
+++ b/src/juju/watchers.ts
@@ -30,7 +30,7 @@ export function generateModelWatcherBase(): WatcherModelData {
       life: "",
       name: "",
       owner: "",
-      region: "",
+      "cloud-region": "",
       sla: {
         level: "",
         owner: "",

--- a/src/pages/EntityDetails/EntityDetails.tsx
+++ b/src/pages/EntityDetails/EntityDetails.tsx
@@ -25,6 +25,7 @@ import {
 import { useAppSelector } from "store/store";
 import urls from "urls";
 import { ModelTab } from "urls";
+import { getMajorMinorVersion } from "utils";
 
 import "./_entity-details.scss";
 
@@ -93,10 +94,7 @@ const EntityDetails = () => {
   };
 
   useEffect(() => {
-    // Regex to extract the first two numbers:
-    const versionRegex = /^\d+\.\d+/g;
-    const version = Number(versionRegex.exec(modelInfo?.version ?? "")?.[0]);
-    if (version >= 2.9) {
+    if (getMajorMinorVersion(modelInfo?.version) >= 2.9) {
       // The Web CLI is only available in Juju controller versions 2.9 and
       // above. This will allow us to only show the shell on multi-controller
       // setups with different versions where the correct controller version

--- a/src/pages/EntityDetails/Model/Model.tsx
+++ b/src/pages/EntityDetails/Model/Model.tsx
@@ -150,7 +150,7 @@ const Model = () => {
                 controller: modelInfoData.type,
                 "Cloud/Region": generateCloudAndRegion(
                   modelInfoData["cloud"],
-                  modelInfoData.region
+                  modelInfoData["cloud-region"]
                 ),
                 version: modelInfoData.version,
                 sla: modelInfoData.sla?.level,

--- a/src/pages/EntityDetails/Model/Model.tsx
+++ b/src/pages/EntityDetails/Model/Model.tsx
@@ -149,7 +149,7 @@ const Model = () => {
                 access: modelAccess ?? "Unknown",
                 controller: modelInfoData.type,
                 "Cloud/Region": generateCloudAndRegion(
-                  modelInfoData["cloud-tag"],
+                  modelInfoData["cloud"],
                   modelInfoData.region
                 ),
                 version: modelInfoData.version,

--- a/src/pages/ModelDetails/ModelDetails.tsx
+++ b/src/pages/ModelDetails/ModelDetails.tsx
@@ -15,6 +15,7 @@ import { actions as jujuActions } from "store/juju";
 import { getModelUUIDFromList } from "store/juju/selectors";
 import { useAppStore } from "store/store";
 import urls from "urls";
+import { getMajorMinorVersion } from "utils";
 
 export default function ModelDetails() {
   const appState = useAppStore().getState();
@@ -32,15 +33,17 @@ export default function ModelDetails() {
       conn = response?.conn ?? null;
       watcherHandle = response?.watcherHandle ?? null;
       pingerIntervalId = response?.pingerIntervalId ?? null;
-      // Fetch the missing model status data. This data should eventually make
-      // its way into the all watcher at which point we can drop this additional
-      // request for data.
-      // https://bugs.launchpad.net/juju/+bug/1939341
-      const status = await conn?.facades.client?.fullStatus({ patterns: [] });
-      if (status) {
-        dispatch(
-          jujuActions.populateMissingAllWatcherData({ uuid: modelUUID, status })
-        );
+      // Fetch additional model data for pre Juju 3.2.
+      if (getMajorMinorVersion(conn?.info.serverVersion) < 3.2) {
+        const status = await conn?.facades.client?.fullStatus({ patterns: [] });
+        if (status) {
+          dispatch(
+            jujuActions.populateMissingAllWatcherData({
+              uuid: modelUUID,
+              status,
+            })
+          );
+        }
       }
     }
     if (modelUUID) {

--- a/src/store/juju/reducers.test.ts
+++ b/src/store/juju/reducers.test.ts
@@ -287,7 +287,7 @@ describe("reducers", () => {
           ...state.modelWatcherData?.abc123,
           model: modelWatcherModelInfoFactory.build({
             ...state.modelWatcherData?.abc123.model,
-            "cloud-tag": status.model["cloud-tag"],
+            cloud: status.model["cloud-tag"],
             type: status.model.type,
             region: status.model.region,
             version: status.model.version,

--- a/src/store/juju/reducers.test.ts
+++ b/src/store/juju/reducers.test.ts
@@ -289,7 +289,7 @@ describe("reducers", () => {
             ...state.modelWatcherData?.abc123.model,
             cloud: status.model["cloud-tag"],
             type: status.model.type,
-            region: status.model.region,
+            "cloud-region": status.model.region,
             version: status.model.version,
           }),
         }),

--- a/src/store/juju/slice.ts
+++ b/src/store/juju/slice.ts
@@ -183,7 +183,7 @@ const slice = createSlice({
         // Match the data returned by the Juju 3.2 watcher:
         cloud: extractCloudName(action.payload.status.model["cloud-tag"]),
         type: action.payload.status.model.type,
-        region: action.payload.status.model.region,
+        "cloud-region": action.payload.status.model.region,
         version: action.payload.status.model.version,
       };
     },

--- a/src/store/juju/slice.ts
+++ b/src/store/juju/slice.ts
@@ -18,6 +18,7 @@ import type {
   FullStatusWithAnnotations,
 } from "juju/types";
 import { processDeltas } from "juju/watchers";
+import { extractCloudName } from "store/juju/utils/models";
 
 import type { Controllers, JujuState } from "./types";
 
@@ -166,6 +167,7 @@ const slice = createSlice({
       controllers[action.payload.wsControllerURL] = action.payload.controllers;
       state.controllers = controllers;
     },
+    // This is required for Juju versions before 3.2.
     populateMissingAllWatcherData: (
       state,
       action: PayloadAction<{ uuid: string; status: FullStatus }>
@@ -178,7 +180,8 @@ const slice = createSlice({
       }
       state.modelWatcherData[action.payload.uuid].model = {
         ...(state.modelWatcherData[action.payload.uuid]?.model ?? {}),
-        "cloud-tag": action.payload.status.model["cloud-tag"],
+        // Match the data returned by the Juju 3.2 watcher:
+        cloud: extractCloudName(action.payload.status.model["cloud-tag"]),
         type: action.payload.status.model.type,
         region: action.payload.status.model.region,
         version: action.payload.status.model.version,

--- a/src/testing/factories/juju/model-watcher.ts
+++ b/src/testing/factories/juju/model-watcher.ts
@@ -41,7 +41,7 @@ export const modelSLAFactory = Factory.define<ModelSLAInfo>(() => ({
 
 export const modelWatcherModelInfoFactory = Factory.define<WatcherModelInfo>(
   () => ({
-    "cloud-tag": "cloud-aws",
+    cloud: "aws",
     region: "us-east-1",
     type: "iaas",
     version: "2.9.12",

--- a/src/utils/getMajorMinorVersion.test.ts
+++ b/src/utils/getMajorMinorVersion.test.ts
@@ -1,0 +1,11 @@
+import getMajorMinorVersion from "./getMajorMinorVersion";
+
+describe("getMajorMinorVersion", () => {
+  it("should handle semver", () => {
+    expect(getMajorMinorVersion("1.2.3")).toBe(1.2);
+  });
+
+  it("should handle pre-release labels", () => {
+    expect(getMajorMinorVersion("1.2.3-alpha")).toBe(1.2);
+  });
+});

--- a/src/utils/getMajorMinorVersion.ts
+++ b/src/utils/getMajorMinorVersion.ts
@@ -1,0 +1,7 @@
+const getMajorMinorVersion = (version?: string): number => {
+  // Regex to extract the first two numbers:
+  const versionRegex = /^\d+\.\d+/g;
+  return Number(versionRegex.exec(version ?? "")?.[0]);
+};
+
+export default getMajorMinorVersion;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,3 @@
 export { argPath } from "./argPath";
+export { default as getMajorMinorVersion } from "./getMajorMinorVersion";
+export { default as getUserName } from "./getUserName";


### PR DESCRIPTION
## Done

 - Use data from the watcher instead of getting the full status when using Juju 3.2 and later. This reduces the number of full status calls we need to make, which is expensive for the server.

## QA

- Connect to a local Juju 3.2 controller.
- Go to the model list and click on a model.
- On the left side there should be data for controller, cloud/region and version.
- Open the redux dev tools and filter the dispatched actions by `populateMissingAllWatcherData`. There should be no entries.
- Connect to a pre Juju 3.2 controller (e.g. JAAS which is 2.9).
- Go to the model list and click on a model.
- On the left side there should be data for controller, cloud/region and version.
- Open the redux dev tools and filter the dispatched actions by `populateMissingAllWatcherData`. There should be at least one entry.

## Details

https://warthogs.atlassian.net/browse/WD-6200
Fixes: https://github.com/canonical/juju-dashboard/issues/1529.
