### PR TITLE
fix: Fix sidebar scroll when BaseLayout height exceeds viewport height

### DIFF
--- a/src/layout/BaseLayout/_base-layout.scss
+++ b/src/layout/BaseLayout/_base-layout.scss
@@ -142,7 +142,13 @@
   // sticky from being used by the the entity details sidebar.
   overflow-y: visible !important;
 
-  .l-navigation.is-pinned + .l-main {
-    padding-left: 0;
+  .l-navigation.is-pinned {
+    + .l-main {
+      padding-left: 0;
+    }
+
+    @include desktop {
+      position: sticky;
+    }
   }
 }


### PR DESCRIPTION
## Done

- Fixed sidebar scroll when BaseLayout height exceeds viewport height.

## Details

- Fix was previously implemented in a7f42ab for Audit Logs feature.
- Fixes: #1616 

## Screenshots

Without fix:
![Screenshot from 2023-09-11 00-23-27](https://github.com/canonical/juju-dashboard/assets/108150922/ac5d109e-afb1-4dc4-b1e3-012e8442b761)

With fix:
![Screenshot from 2023-09-11 00-23-17](https://github.com/canonical/juju-dashboard/assets/108150922/5597bc10-d06c-4efd-81f3-125a616ec09b)


