### PR TITLE
WD-6249 - feat: Disable charm radio input when no action is available

### DIFF
--- a/src/panels/CharmsAndActionsPanel/CharmsAndActionsPanel.test.tsx
+++ b/src/panels/CharmsAndActionsPanel/CharmsAndActionsPanel.test.tsx
@@ -120,6 +120,9 @@ describe("CharmsAndActionsPanel", () => {
       ...state.juju.charms,
       charmInfoFactory.build({
         url: "ch:ceph2",
+        actions: charmActionsFactory.build({
+          specs: { "apt-update": charmActionSpecFactory.build() },
+        }),
       }),
     ];
     const {
@@ -133,7 +136,7 @@ describe("CharmsAndActionsPanel", () => {
     );
     const charmOptions = screen.getAllByRole("radio");
     expect(charmOptions).toHaveLength(2);
-    act(() => charmOptions[0].click());
+    act(() => charmOptions[1].click());
     expect(screen.getByRole("button", { name: "Next" })).toBeEnabled();
   });
 });

--- a/src/panels/CharmsPanel/CharmsPanel.tsx
+++ b/src/panels/CharmsPanel/CharmsPanel.tsx
@@ -51,23 +51,24 @@ export default function CharmsPanel({
           const hasActionData =
             !!charm?.actions?.specs &&
             !!Object.keys(charm.actions.specs).length;
+          const charmRadioInput = (
+            <RadioInput
+              id={charm.url}
+              label={`${charm.meta?.name} (rev: ${charm.revision})`}
+              checked={selectedCharm === charm.url}
+              onChange={
+                hasActionData ? () => setSelectedCharm(charm.url) : undefined
+              }
+              disabled={!hasActionData}
+            />
+          );
           return (
             <div key={charm.url} className="p-form__group">
               {hasActionData ? (
-                <RadioInput
-                  id={charm.url}
-                  label={`${charm.meta?.name} (rev: ${charm.revision})`}
-                  checked={selectedCharm === charm.url}
-                  onChange={() => setSelectedCharm(charm.url)}
-                />
+                charmRadioInput
               ) : (
                 <Tooltip message={Label.NO_ACTIONS} position="left">
-                  <RadioInput
-                    id={charm.url}
-                    label={`${charm.meta?.name} (rev: ${charm.revision})`}
-                    checked={selectedCharm === charm.url}
-                    disabled={true}
-                  />
+                  {charmRadioInput}
                 </Tooltip>
               )}
             </div>

--- a/src/panels/CharmsPanel/CharmsPanel.tsx
+++ b/src/panels/CharmsPanel/CharmsPanel.tsx
@@ -66,7 +66,6 @@ export default function CharmsPanel({
                     id={charm.url}
                     label={`${charm.meta?.name} (rev: ${charm.revision})`}
                     checked={selectedCharm === charm.url}
-                    onChange={() => setSelectedCharm(charm.url)}
                     disabled={true}
                   />
                 </Tooltip>

--- a/src/panels/CharmsPanel/CharmsPanel.tsx
+++ b/src/panels/CharmsPanel/CharmsPanel.tsx
@@ -1,6 +1,5 @@
-import { Button, RadioInput } from "@canonical/react-components";
-import type { FormEventHandler } from "react";
-import { useState } from "react";
+import { Button, RadioInput, Tooltip } from "@canonical/react-components";
+import { useState, type FormEventHandler } from "react";
 import { useSelector } from "react-redux";
 
 import Panel from "components/Panel";
@@ -9,6 +8,7 @@ import { getCharms } from "store/juju/selectors";
 
 export enum Label {
   PANEL_TITLE = "Choose applications of charm:",
+  NO_ACTIONS = "No actions available for this charm!",
 }
 
 type Props = {
@@ -47,16 +47,33 @@ export default function CharmsPanel({
       loading={isLoading}
     >
       <form onSubmit={handleSubmit}>
-        {charms.map((charm) => (
-          <div key={charm.url} className="p-form__group">
-            <RadioInput
-              id={charm.url}
-              label={`${charm.meta?.name} (rev: ${charm.revision})`}
-              checked={selectedCharm === charm.url}
-              onChange={() => setSelectedCharm(charm.url)}
-            />
-          </div>
-        ))}
+        {charms.map((charm) => {
+          const hasActionData =
+            !!charm?.actions?.specs &&
+            !!Object.keys(charm.actions.specs).length;
+          return (
+            <div key={charm.url} className="p-form__group">
+              {hasActionData ? (
+                <RadioInput
+                  id={charm.url}
+                  label={`${charm.meta?.name} (rev: ${charm.revision})`}
+                  checked={selectedCharm === charm.url}
+                  onChange={() => setSelectedCharm(charm.url)}
+                />
+              ) : (
+                <Tooltip message={Label.NO_ACTIONS} position="left">
+                  <RadioInput
+                    id={charm.url}
+                    label={`${charm.meta?.name} (rev: ${charm.revision})`}
+                    checked={selectedCharm === charm.url}
+                    onChange={() => setSelectedCharm(charm.url)}
+                    disabled={true}
+                  />
+                </Tooltip>
+              )}
+            </div>
+          );
+        })}
       </form>
     </Panel>
   );


### PR DESCRIPTION
## Done

- Disable charm radio input in `CharmsPanel` when no action is available.

## Details

- Jira: https://warthogs.atlassian.net/browse/WD-6249
- Fixes: #1533 

## Screenshots

![Screenshot from 2023-09-11 23-19-56](https://github.com/canonical/juju-dashboard/assets/108150922/e41093d0-2b34-48ca-8e20-82a9db07a68e)

