### PR TITLE
WD-6258 - Hide controls on read only models

### DIFF
--- a/src/components/ModelTableList/CloudGroup.tsx
+++ b/src/components/ModelTableList/CloudGroup.tsx
@@ -12,7 +12,7 @@ import {
 } from "store/juju/selectors";
 import type { Filters } from "store/juju/utils/models";
 import {
-  canAdministerModelAccess,
+  canAdministerModel,
   extractOwnerName,
   getModelStatusGroupData,
 } from "store/juju/utils/models";
@@ -113,7 +113,7 @@ export default function CloudGroup({ filters }: Props) {
             content: (
               <>
                 {model?.info
-                  ? canAdministerModelAccess(activeUser, model.info.users) && (
+                  ? canAdministerModel(activeUser, model.info.users) && (
                       <AccessButton
                         setPanelQs={setPanelQs}
                         modelName={model.info.name}
@@ -124,7 +124,7 @@ export default function CloudGroup({ filters }: Props) {
               </>
             ),
             className: `u-align--right lrg-screen-access-cell ${
-              canAdministerModelAccess(activeUser, model?.info?.users)
+              canAdministerModel(activeUser, model?.info?.users)
                 ? "has-permission"
                 : ""
             }`,
@@ -133,7 +133,7 @@ export default function CloudGroup({ filters }: Props) {
             content: (
               <>
                 {model?.info
-                  ? canAdministerModelAccess(activeUser, model.info.users) && (
+                  ? canAdministerModel(activeUser, model.info.users) && (
                       <AccessButton
                         setPanelQs={setPanelQs}
                         modelName={model.info.name}

--- a/src/components/ModelTableList/OwnerGroup.tsx
+++ b/src/components/ModelTableList/OwnerGroup.tsx
@@ -13,7 +13,7 @@ import {
 } from "store/juju/selectors";
 import type { Filters } from "store/juju/utils/models";
 import {
-  canAdministerModelAccess,
+  canAdministerModel,
   getModelStatusGroupData,
 } from "store/juju/utils/models";
 
@@ -108,7 +108,7 @@ export default function OwnerGroup({ filters }: Props) {
             content: (
               <>
                 {model.info
-                  ? canAdministerModelAccess(activeUser, model.info.users) && (
+                  ? canAdministerModel(activeUser, model.info.users) && (
                       <AccessButton
                         setPanelQs={setPanelQs}
                         modelName={model.info.name}
@@ -119,7 +119,7 @@ export default function OwnerGroup({ filters }: Props) {
               </>
             ),
             className: `u-align--right lrg-screen-access-cell ${
-              canAdministerModelAccess(activeUser, model?.info?.users)
+              canAdministerModel(activeUser, model?.info?.users)
                 ? "has-permission"
                 : ""
             }`,
@@ -128,10 +128,7 @@ export default function OwnerGroup({ filters }: Props) {
             content: (
               <>
                 {model.info
-                  ? canAdministerModelAccess(
-                      activeUser,
-                      model?.info?.users
-                    ) && (
+                  ? canAdministerModel(activeUser, model?.info?.users) && (
                       <AccessButton
                         setPanelQs={setPanelQs}
                         modelName={model.info.name}

--- a/src/components/ModelTableList/StatusGroup.tsx
+++ b/src/components/ModelTableList/StatusGroup.tsx
@@ -15,7 +15,7 @@ import {
 import type { Controllers, ModelData } from "store/juju/types";
 import type { Filters, Status } from "store/juju/utils/models";
 import {
-  canAdministerModelAccess,
+  canAdministerModel,
   extractOwnerName,
   getModelStatusGroupData,
 } from "store/juju/utils/models";
@@ -187,7 +187,7 @@ function generateModelTableDataByStatus(
             "data-testid": "column-updated",
             content: (
               <>
-                {canAdministerModelAccess(activeUser, model?.info?.users) && (
+                {canAdministerModel(activeUser, model?.info?.users) && (
                   <AccessButton
                     setPanelQs={setPanelQs}
                     modelName={model.model.name}
@@ -197,7 +197,7 @@ function generateModelTableDataByStatus(
               </>
             ),
             className: `u-align--right lrg-screen-access-cell ${
-              canAdministerModelAccess(activeUser, model?.info?.users)
+              canAdministerModel(activeUser, model?.info?.users)
                 ? "has-permission"
                 : ""
             }`,
@@ -205,7 +205,7 @@ function generateModelTableDataByStatus(
           {
             content: (
               <>
-                {canAdministerModelAccess(activeUser, model?.info?.users) && (
+                {canAdministerModel(activeUser, model?.info?.users) && (
                   <AccessButton
                     setPanelQs={setPanelQs}
                     modelName={model.model.name}

--- a/src/hooks/useCanConfigureModel.test.tsx
+++ b/src/hooks/useCanConfigureModel.test.tsx
@@ -1,0 +1,139 @@
+import { renderHook } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+import { Provider } from "react-redux";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import type { RootState } from "store/store";
+import { rootStateFactory } from "testing/factories";
+import {
+  generalStateFactory,
+  configFactory,
+  credentialFactory,
+} from "testing/factories/general";
+import { modelUserInfoFactory } from "testing/factories/juju/ModelManagerV9";
+import {
+  jujuStateFactory,
+  modelDataFactory,
+  modelDataInfoFactory,
+  modelListInfoFactory,
+} from "testing/factories/juju/juju";
+import { modelWatcherModelDataFactory } from "testing/factories/juju/model-watcher";
+
+import useCanConfigureModel from "./useCanConfigureModel";
+
+const mockStore = configureStore();
+
+const generateContainer =
+  (state: RootState, path: string, url: string) =>
+  ({ children }: PropsWithChildren) => {
+    window.history.pushState({}, "", url);
+    const store = mockStore(state);
+    return (
+      <Provider store={store}>
+        <BrowserRouter>
+          <Routes>
+            <Route path={path} element={children} />
+          </Routes>
+        </BrowserRouter>
+      </Provider>
+    );
+  };
+
+describe("useModelStatus", () => {
+  let state: RootState;
+  const url = "/models/eggman@external/test1";
+  const path = "/models/:userName/:modelName";
+
+  beforeEach(() => {
+    state = rootStateFactory.build({
+      general: generalStateFactory.build({
+        config: configFactory.build({
+          controllerAPIEndpoint: "wss://jimm.jujucharms.com/api",
+        }),
+        controllerConnections: {
+          "wss://jimm.jujucharms.com/api": {
+            user: {
+              "display-name": "eggman",
+              identity: "user-eggman@external",
+              "controller-access": "",
+              "model-access": "",
+            },
+          },
+        },
+        credentials: {
+          "wss://jimm.jujucharms.com/api": credentialFactory.build(),
+        },
+      }),
+      juju: jujuStateFactory.build({
+        modelData: {
+          abc123: modelDataFactory.build(),
+        },
+        models: {
+          abc123: modelListInfoFactory.build({
+            uuid: "abc123",
+            name: "test1",
+            wsControllerURL: "wss://jimm.jujucharms.com/api",
+          }),
+        },
+        modelWatcherData: {
+          abc123: modelWatcherModelDataFactory.build(),
+        },
+      }),
+    });
+  });
+
+  it("should return true when user has admin access", () => {
+    state.juju.modelData.abc123.info = modelDataInfoFactory.build({
+      uuid: "abc123",
+      name: "test1",
+      "controller-uuid": "controller123",
+      users: [
+        modelUserInfoFactory.build({
+          user: "eggman@external",
+          access: "admin",
+        }),
+      ],
+    });
+    const { result } = renderHook(() => useCanConfigureModel(), {
+      wrapper: generateContainer(state, path, url),
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it("should return true when user has write access", () => {
+    state.juju.modelData.abc123.info = modelDataInfoFactory.build({
+      uuid: "abc123",
+      name: "test1",
+      "controller-uuid": "controller123",
+      users: [
+        modelUserInfoFactory.build({
+          user: "eggman@external",
+          access: "write",
+        }),
+      ],
+    });
+    const { result } = renderHook(() => useCanConfigureModel(), {
+      wrapper: generateContainer(state, path, url),
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it("should return false when user has read access", () => {
+    state.juju.modelData.abc123.info = modelDataInfoFactory.build({
+      uuid: "abc123",
+      name: "test1",
+      "controller-uuid": "controller123",
+      users: [
+        modelUserInfoFactory.build({
+          user: "eggman@external",
+          access: "read",
+        }),
+      ],
+    });
+    const { result } = renderHook(() => useCanConfigureModel(), {
+      wrapper: generateContainer(state, path, url),
+    });
+    expect(result.current).toBe(false);
+  });
+});

--- a/src/hooks/useCanConfigureModel.ts
+++ b/src/hooks/useCanConfigureModel.ts
@@ -1,0 +1,19 @@
+import { useParams } from "react-router-dom";
+
+import type { EntityDetailsRoute } from "components/Routes/Routes";
+import useModelStatus from "hooks/useModelStatus";
+import { getActiveUser, getModelUUIDFromList } from "store/juju/selectors";
+import { canAdministerModel } from "store/juju/utils/models";
+import { useAppSelector } from "store/store";
+
+const useCanConfigureModel = () => {
+  const { userName, modelName } = useParams<EntityDetailsRoute>();
+  const modelUUID = useAppSelector(getModelUUIDFromList(modelName, userName));
+  const activeUser = useAppSelector((state) => getActiveUser(state, modelUUID));
+  const modelStatusData = useModelStatus();
+  return (
+    !!activeUser && canAdministerModel(activeUser, modelStatusData?.info?.users)
+  );
+};
+
+export default useCanConfigureModel;

--- a/src/pages/EntityDetails/Model/Model.tsx
+++ b/src/pages/EntityDetails/Model/Model.tsx
@@ -1,4 +1,4 @@
-import { MainTable } from "@canonical/react-components";
+import { Button, Icon, MainTable } from "@canonical/react-components";
 import { useMemo } from "react";
 import { useSelector } from "react-redux";
 import { useParams } from "react-router-dom";
@@ -6,10 +6,10 @@ import { useParams } from "react-router-dom";
 import EntityInfo from "components/EntityInfo/EntityInfo";
 import InfoPanel from "components/InfoPanel/InfoPanel";
 import type { EntityDetailsRoute } from "components/Routes/Routes";
+import useCanConfigureModel from "hooks/useCanConfigureModel";
 import useModelStatus from "hooks/useModelStatus";
 import { useQueryParams } from "hooks/useQueryParams";
 import {
-  getActiveUser,
   getModelAccess,
   getModelApplications,
   getModelInfo,
@@ -18,10 +18,7 @@ import {
   getModelUnits,
   getModelUUIDFromList,
 } from "store/juju/selectors";
-import {
-  canAdministerModelAccess,
-  extractCloudName,
-} from "store/juju/utils/models";
+import { extractCloudName } from "store/juju/utils/models";
 import { useAppSelector } from "store/store";
 import {
   consumedTableHeaders,
@@ -92,7 +89,7 @@ const Model = () => {
   const relations = useSelector(getModelRelations(modelUUID));
   const machines = useSelector(getModelMachines(modelUUID));
   const units = useSelector(getModelUnits(modelUUID));
-  const activeUser = useAppSelector((state) => getActiveUser(state, modelUUID));
+  const canConfigureModel = useCanConfigureModel();
 
   const machinesTableRows = useMemo(() => {
     return modelName && userName
@@ -132,24 +129,20 @@ const Model = () => {
         */}
         <div className="entity-details__sidebar">
           <InfoPanel />
-          <div className="entity-details__actions">
-            {activeUser &&
-              canAdministerModelAccess(
-                activeUser,
-                modelStatusData?.info?.users
-              ) && (
-                <button
-                  className="entity-details__action-button"
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    setQuery({ panel: "share-model" }, { replace: true });
-                  }}
-                >
-                  <i className="p-icon--share"></i>
-                  {Label.ACCESS_BUTTON}
-                </button>
-              )}
-          </div>
+          {canConfigureModel && (
+            <div className="entity-details__actions">
+              <Button
+                className="entity-details__action-button"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  setQuery({ panel: "share-model" }, { replace: true });
+                }}
+              >
+                <Icon name="share" />
+                {Label.ACCESS_BUTTON}
+              </Button>
+            </div>
+          )}
           {modelInfoData && (
             <EntityInfo
               data={{

--- a/src/store/juju/utils/models.test.ts
+++ b/src/store/juju/utils/models.test.ts
@@ -9,7 +9,7 @@ import {
 } from "testing/factories/juju/juju";
 
 import {
-  canAdministerModelAccess,
+  canAdministerModel,
   generateIconPath,
   pluralize,
   getModelStatusGroupData,
@@ -33,7 +33,7 @@ describe("pluralize", () => {
   });
 });
 
-describe("canAdministerModelAccess", () => {
+describe("canAdministerModel", () => {
   it("should return true when user has admin access", () => {
     const userName = "john-smith@external";
     const modelData = {
@@ -49,7 +49,7 @@ describe("canAdministerModelAccess", () => {
         ],
       },
     };
-    expect(canAdministerModelAccess(userName, modelData.info.users)).toBe(true);
+    expect(canAdministerModel(userName, modelData.info.users)).toBe(true);
   });
 
   it("should return false when user has read access", () => {
@@ -67,9 +67,7 @@ describe("canAdministerModelAccess", () => {
         ],
       },
     };
-    expect(canAdministerModelAccess(userName, modelData.info.users)).toBe(
-      false
-    );
+    expect(canAdministerModel(userName, modelData.info.users)).toBe(false);
   });
 });
 

--- a/src/store/juju/utils/models.ts
+++ b/src/store/juju/utils/models.ts
@@ -301,7 +301,7 @@ export const extractRelationEndpoints = (relation: {
   return endpoints;
 };
 
-export const canAdministerModelAccess = (
+export const canAdministerModel = (
   userName: string,
   modelUsers?: ModelUserInfo[]
 ) => {

--- a/src/tables/tableHeaders.tsx
+++ b/src/tables/tableHeaders.tsx
@@ -40,14 +40,16 @@ export const unitTableHeaders: Header = [
 ];
 
 export const generateSelectableUnitTableHeaders = (
-  selectContent: HeaderRow,
+  selectContent: HeaderRow | null,
   removeMachines: boolean
 ): Header => {
   let headers = cloneDeep(unitTableHeaders);
   if (removeMachines) {
     headers = headers.filter((header) => !(header.sortKey === "machine"));
   }
-  headers.splice(0, 0, selectContent);
+  if (selectContent) {
+    headers.splice(0, 0, selectContent);
+  }
   return headers;
 };
 


### PR DESCRIPTION
## Done

- Don't display configure and action controls if the user has read only permissions.

## QA

- Using a local controller add a new user with `juju add-user [username]`.
- Grant them read only permissions for a model with at least one app: `juju grant [username] read [model-name]`.
- In the dashboard log in as the new user.
- Go to the model with read-only permissions.
- Search for an app. There shouldn't be any checkboxes or a "Run action" button.
- Click on an app. There shouldn't be a "Configure" button on the left or a "Run action" button and there should be no checkboxes.

## Details

https://warthogs.atlassian.net/browse/WD-6258
Fixes: https://github.com/canonical/juju-dashboard/issues/1620
