### PR TITLE
WD-6278 - Fix additional JIMM controllers

### DIFF
--- a/src/components/AuthenticationButton/AuthenticationButton.test.tsx
+++ b/src/components/AuthenticationButton/AuthenticationButton.test.tsx
@@ -1,0 +1,36 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { actions as generalActions } from "store/general";
+import { renderComponent } from "testing/utils";
+
+import AuthenticationButton from "./AuthenticationButton";
+
+describe("AuthenticationButton", () => {
+  it("displays a link to open an auth URL", () => {
+    renderComponent(
+      <AuthenticationButton visitURL="http://example.com">
+        Log in
+      </AuthenticationButton>
+    );
+    expect(screen.getByRole("link", { name: "Log in" })).toHaveAttribute(
+      "href",
+      "http://example.com"
+    );
+  });
+
+  it("should remove the URL when clicked", async () => {
+    const onClick = jest.fn();
+    const { store } = renderComponent(
+      <AuthenticationButton onClick={onClick} visitURL="http://example.com">
+        Log in
+      </AuthenticationButton>
+    );
+    await userEvent.click(screen.getByRole("link", { name: "Log in" }));
+    expect(onClick).toHaveBeenCalled();
+    const action = generalActions.removeVisitURL("http://example.com");
+    expect(
+      store.getActions().find((dispatch) => dispatch.type === action.type)
+    ).toMatchObject(action);
+  });
+});

--- a/src/components/AuthenticationButton/AuthenticationButton.tsx
+++ b/src/components/AuthenticationButton/AuthenticationButton.tsx
@@ -1,0 +1,36 @@
+import type { ButtonProps, PropsWithSpread } from "@canonical/react-components";
+import { Button } from "@canonical/react-components";
+import type { HTMLProps } from "react";
+
+import { actions as generalActions } from "store/general";
+import { useAppDispatch } from "store/store";
+
+type Props = PropsWithSpread<
+  {
+    visitURL: string;
+    onClick?: () => void;
+  },
+  ButtonProps
+>;
+
+const AuthenticationButton = ({ onClick, visitURL, ...props }: Props) => {
+  const dispatch = useAppDispatch();
+  return (
+    <Button<HTMLProps<HTMLAnchorElement>>
+      element="a"
+      href={visitURL}
+      rel="noopener noreferrer"
+      target="_blank"
+      onClick={() => {
+        // Remove the stored URL once the authentication page has been opened.
+        // This is required as we don't have a way to match the visit URL with
+        // the authentication request, so can't remove it on the login response.
+        dispatch(generalActions.removeVisitURL(visitURL));
+        onClick?.();
+      }}
+      {...props}
+    />
+  );
+};
+
+export default AuthenticationButton;

--- a/src/components/AuthenticationButton/index.ts
+++ b/src/components/AuthenticationButton/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AuthenticationButton";

--- a/src/components/LogIn/LogIn.test.tsx
+++ b/src/components/LogIn/LogIn.test.tsx
@@ -53,7 +53,7 @@ describe("LogIn", () => {
   it("renders an IdentityProvider login UI if the user is not logged in", () => {
     const state = rootStateFactory.build({
       general: generalStateFactory.withConfig().build({
-        visitURL: "I am a url",
+        visitURLs: ["I am a url"],
         config: configFactory.build({
           identityProviderAvailable: true,
         }),
@@ -177,7 +177,7 @@ describe("LogIn", () => {
   it("displays the JAAS logo under JAAS", () => {
     const state = rootStateFactory.build({
       general: generalStateFactory.withConfig().build({
-        visitURL: "I am a url",
+        visitURLs: ["I am a url"],
         config: configFactory.build({
           isJuju: false,
         }),

--- a/src/components/LogIn/LogIn.tsx
+++ b/src/components/LogIn/LogIn.tsx
@@ -49,6 +49,8 @@ export default function LogIn({ children }: PropsWithChildren) {
   );
   const visitURLs = useAppSelector(getVisitURLs);
 
+  // This login component wraps all other views, so this useEffect will run each
+  // time we get an authentication request.
   useEffect(() => {
     visitURLs?.forEach((visitURL) => {
       if (!viewedAuthRequests.current.includes(visitURL)) {
@@ -67,12 +69,14 @@ export default function LogIn({ children }: PropsWithChildren) {
                 reactHotToast.remove(t.id);
               }}
             >
-              Log in
+              Authenticate
             </AuthenticationButton>
           </ToastCard>
         ));
         // Append this to the list of auth requests that have been displayed, so
-        // that we don't display the same notifications again if visitURLs is mutated.
+        // that we don't display the same notifications again if visitURLs is
+        // mutated (e.g. if we remove a URL from the array we don't want this
+        // useEffect to run again and display all the notifications again).
         viewedAuthRequests.current = [...viewedAuthRequests.current, visitURL];
       }
     });
@@ -135,6 +139,9 @@ function generateErrorMessage(loginError?: string | null) {
 function IdentityProviderForm({ userIsLoggedIn }: { userIsLoggedIn: boolean }) {
   const visitURL = useSelector((state: RootState) => {
     if (!userIsLoggedIn) {
+      // This form only gets displayed on the main login page, at which point
+      // there can only be one authentication request, so just return the
+      // first one.
       return state?.general?.visitURLs?.[0];
     }
   });

--- a/src/components/ModelTableList/ModelTableList.test.tsx
+++ b/src/components/ModelTableList/ModelTableList.test.tsx
@@ -2,6 +2,7 @@ import type { RenderResult } from "@testing-library/react";
 import { screen, within } from "@testing-library/react";
 
 import * as appSelectors from "store/juju/selectors";
+import { JAAS_CONTROLLER_UUID } from "store/juju/utils/controllers";
 import type { RootState } from "store/store";
 import {
   controllerFactory,
@@ -15,7 +16,6 @@ import { TestId as CloudTestId } from "./CloudGroup";
 import ModelTableList from "./ModelTableList";
 import { TestId as OwnerTestId } from "./OwnerGroup";
 import { TestId as StatusTestId } from "./StatusGroup";
-import { JAAS_CONTROLLER_UUID } from "./shared";
 
 describe("ModelTableList", () => {
   let state: RootState;

--- a/src/components/ModelTableList/shared.test.tsx
+++ b/src/components/ModelTableList/shared.test.tsx
@@ -1,3 +1,4 @@
+import { JAAS_CONTROLLER_UUID } from "store/juju/utils/controllers";
 import {
   detailedStatusFactory,
   modelStatusInfoFactory,
@@ -9,7 +10,6 @@ import {
 } from "testing/factories/juju/juju";
 
 import {
-  JAAS_CONTROLLER_UUID,
   generateCloudAndRegion,
   getCloudName,
   getControllerName,
@@ -73,6 +73,25 @@ describe("shared", () => {
     });
     expect(getControllerName(modelData, controllers)).toStrictEqual(
       "default-controller"
+    );
+  });
+
+  it("can get a controller name from a controller", () => {
+    const controllers = {
+      "wss://test.com/api": [
+        controllerFactory.build({
+          name: "a controller",
+          uuid: "controller123",
+        }),
+      ],
+    };
+    const modelData = modelDataFactory.build({
+      info: modelDataInfoFactory.build({
+        "controller-uuid": "controller123",
+      }),
+    });
+    expect(getControllerName(modelData, controllers)).toStrictEqual(
+      "a controller"
     );
   });
 

--- a/src/components/ModelTableList/shared.tsx
+++ b/src/components/ModelTableList/shared.tsx
@@ -2,12 +2,11 @@ import type { MainTableHeader } from "@canonical/react-components/dist/component
 
 import Status from "components/Status";
 import type { Controllers, ModelData } from "store/juju/types";
+import { JAAS_CONTROLLER_UUID } from "store/juju/utils/controllers";
 import {
   extractCloudName,
   extractCredentialName,
 } from "store/juju/utils/models";
-
-export const JAAS_CONTROLLER_UUID = "a030379a-940f-4760-8fcf-3062b41a04e7";
 
 export const getCloudName = (model: ModelData) =>
   extractCloudName(model.model["cloud-tag"]);
@@ -33,7 +32,8 @@ export const getControllerName = (
     (controller) =>
       !!controller[1].some((controller) => {
         if ("uuid" in controller && controllerUUID === controller.uuid) {
-          controllerName = controller.path;
+          controllerName =
+            "name" in controller ? controller.name : controller.path;
         }
         return !!controllerName;
       })

--- a/src/components/PrimaryNav/PrimaryNav.test.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.test.tsx
@@ -1,5 +1,5 @@
 import * as versionsAPI from "@canonical/jujulib/dist/api/versions";
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 
 import { configFactory, generalStateFactory } from "testing/factories/general";
 import {
@@ -97,6 +97,20 @@ describe("Primary Nav", () => {
     });
     renderComponent(<PrimaryNav />, { state });
     expect(screen.getByText("Version 0.4.0")).toHaveClass("version");
+  });
+
+  it("displays an icon if controllers require authentication", () => {
+    const state = rootStateFactory.build({
+      general: generalStateFactory.build({
+        visitURLs: ["/login"],
+      }),
+    });
+    renderComponent(<PrimaryNav />, { state });
+    expect(
+      within(screen.getByRole("link", { name: "Controllers" })).getByTitle(
+        "Authentication required"
+      )
+    ).toBeInTheDocument();
   });
 
   it("displays the count of the controllers with old versions", () => {

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -8,6 +8,7 @@ import UserMenu from "components/UserMenu/UserMenu";
 import {
   getAppVersion,
   isCrossModelQueriesEnabled,
+  getVisitURLs,
 } from "store/general/selectors";
 import {
   getControllerData,
@@ -38,6 +39,8 @@ const ModelsLink = () => {
 
 const ControllersLink = () => {
   const controllers: Controllers | null = useSelector(getControllerData);
+  const authenticationRequired =
+    (useAppSelector(getVisitURLs)?.length ?? 0) > 0;
 
   const controllersUpdateCount = useMemo(() => {
     if (!controllers) {
@@ -63,6 +66,11 @@ const ControllersLink = () => {
       iconName="controllers"
       title="Controllers"
     >
+      {authenticationRequired && (
+        <span className="entity-count">
+          <Icon name="lock-locked" light title="Authentication required" />
+        </span>
+      )}
       {controllersUpdateCount > 0 && (
         <span className="entity-count is-caution">
           {controllersUpdateCount}

--- a/src/components/ToastCard/ToastCard.test.tsx
+++ b/src/components/ToastCard/ToastCard.test.tsx
@@ -21,11 +21,9 @@ describe("Toast Card", () => {
   it("should display message", () => {
     const t = cloneDeep(toastInstanceExample);
     render(
-      <ToastCard
-        type="positive"
-        text="I am a toast message"
-        toastInstance={t}
-      />
+      <ToastCard type="positive" toastInstance={t}>
+        I am a toast message
+      </ToastCard>
     );
     expect(screen.getByText("I am a toast message")).toHaveClass(
       "toast-card__message"
@@ -35,11 +33,9 @@ describe("Toast Card", () => {
   it("should display as correct type", () => {
     const t = cloneDeep(toastInstanceExample);
     const { container } = render(
-      <ToastCard
-        type="positive"
-        text="I am a toast message"
-        toastInstance={t}
-      />
+      <ToastCard type="positive" toastInstance={t}>
+        I am a toast message
+      </ToastCard>
     );
     expect(container.firstChild).toHaveAttribute("data-type", "positive");
   });
@@ -47,11 +43,9 @@ describe("Toast Card", () => {
   it("should display correct success icon", () => {
     const t = cloneDeep(toastInstanceExample);
     render(
-      <ToastCard
-        type="positive"
-        text="I am a toast message"
-        toastInstance={t}
-      />
+      <ToastCard type="positive" toastInstance={t}>
+        I am a toast message
+      </ToastCard>
     );
     expect(document.querySelector(".p-icon--success")).toBeInTheDocument();
   });
@@ -59,11 +53,9 @@ describe("Toast Card", () => {
   it("should display correct error icon", () => {
     const t = cloneDeep(toastInstanceExample);
     render(
-      <ToastCard
-        type="negative"
-        text="I am a toast message"
-        toastInstance={t}
-      />
+      <ToastCard type="negative" toastInstance={t}>
+        I am a toast message
+      </ToastCard>
     );
     expect(document.querySelector(".p-icon--error")).toBeInTheDocument();
   });
@@ -71,7 +63,9 @@ describe("Toast Card", () => {
   it("should display correct warning icon", () => {
     const t = cloneDeep(toastInstanceExample);
     render(
-      <ToastCard type="caution" text="I am a toast message" toastInstance={t} />
+      <ToastCard type="caution" toastInstance={t}>
+        I am a toast message
+      </ToastCard>
     );
     expect(document.querySelector(".p-icon--warning")).toBeInTheDocument();
   });
@@ -79,11 +73,9 @@ describe("Toast Card", () => {
   it("should display close icon", () => {
     const t = cloneDeep(toastInstanceExample);
     render(
-      <ToastCard
-        type="negative"
-        text="I am a toast message"
-        toastInstance={t}
-      />
+      <ToastCard type="negative" toastInstance={t}>
+        I am a toast message
+      </ToastCard>
     );
     expect(screen.getByRole("button", { name: "Close" })).toHaveClass(
       "p-icon--close"
@@ -93,11 +85,9 @@ describe("Toast Card", () => {
   it("should not display an undo button if an undo function is not passed", () => {
     const t = cloneDeep(toastInstanceExample);
     render(
-      <ToastCard
-        type="negative"
-        text="I am a toast message"
-        toastInstance={t}
-      />
+      <ToastCard type="negative" toastInstance={t}>
+        I am a toast message
+      </ToastCard>
     );
     expect(
       screen.queryByRole("button", { name: "Undo" })
@@ -108,12 +98,9 @@ describe("Toast Card", () => {
     const undoFn = jest.fn();
     const t = cloneDeep(toastInstanceExample);
     render(
-      <ToastCard
-        type="negative"
-        text="I am a toast message"
-        toastInstance={t}
-        undo={undoFn}
-      />
+      <ToastCard type="negative" toastInstance={t} undo={undoFn}>
+        I am a toast message
+      </ToastCard>
     );
     const undoButton = screen.getByRole("button", { name: "Undo" });
     expect(undoButton).toBeInTheDocument();
@@ -125,11 +112,9 @@ describe("Toast Card", () => {
     render(<Toaster />);
     await act(async () => {
       reactHotToast.custom((t) => (
-        <ToastCard
-          type="negative"
-          text="I am a toast message"
-          toastInstance={t}
-        />
+        <ToastCard type="negative" toastInstance={t}>
+          I am a toast message
+        </ToastCard>
       ));
     });
     expect(screen.getByRole("status")).toBeInTheDocument();
@@ -141,11 +126,9 @@ describe("Toast Card", () => {
     render(<Toaster />);
     await act(async () => {
       reactHotToast.custom((t) => (
-        <ToastCard
-          type="negative"
-          text="I am a toast message"
-          toastInstance={t}
-        />
+        <ToastCard type="negative" toastInstance={t}>
+          I am a toast message
+        </ToastCard>
       ));
     });
     expect(screen.getByRole("status")).toBeInTheDocument();

--- a/src/components/ToastCard/ToastCard.tsx
+++ b/src/components/ToastCard/ToastCard.tsx
@@ -1,3 +1,4 @@
+import type { PropsWithChildren } from "react";
 import type { Renderable, Toast, ValueOrFunction } from "react-hot-toast";
 import reactHotToast from "react-hot-toast";
 
@@ -16,11 +17,15 @@ type ToastInstance = {
 type Props = {
   toastInstance: ToastInstance;
   type: "positive" | "caution" | "negative";
-  text: string;
   undo?: () => void;
-};
+} & PropsWithChildren;
 
-export default function ToastCard({ toastInstance, type, text, undo }: Props) {
+export default function ToastCard({
+  children,
+  toastInstance,
+  type,
+  undo,
+}: Props) {
   let iconName;
   switch (type) {
     case "positive":
@@ -49,10 +54,7 @@ export default function ToastCard({ toastInstance, type, text, undo }: Props) {
     >
       <div className="toast-card__body">
         {iconName && <i className={`p-icon--${iconName}`}>Success</i>}
-        <div
-          className="toast-card__message"
-          dangerouslySetInnerHTML={{ __html: text }}
-        ></div>
+        <div className="toast-card__message">{children}</div>
         <i
           className="p-icon--close"
           onClick={() => handleClose(toastInstance.id)}

--- a/src/components/ToastCard/ToastCard.tsx
+++ b/src/components/ToastCard/ToastCard.tsx
@@ -51,6 +51,7 @@ export default function ToastCard({
       data-type={type}
       role="status"
       aria-live="polite"
+      data-testid="toast-card"
     >
       <div className="toast-card__body">
         {iconName && <i className={`p-icon--${iconName}`}>Success</i>}

--- a/src/components/ToastCard/_toast-card.scss
+++ b/src/components/ToastCard/_toast-card.scss
@@ -1,4 +1,10 @@
 @import "vanilla-framework/scss/vanilla";
+@import "../../scss/functions/z-index";
+
+.toast-container {
+  // These cards need to appear above modals and panels.
+  z-index: z("zelda") + 3 !important;
+}
 
 .toast-card {
   background-color: $color-x-light;
@@ -17,7 +23,6 @@
   }
 
   &__message {
-    margin-bottom: 2rem;
     word-break: break-word;
   }
 

--- a/src/juju/api.test.ts
+++ b/src/juju/api.test.ts
@@ -646,7 +646,11 @@ describe("Juju API", () => {
           jimM: {
             listControllers: jest.fn().mockResolvedValueOnce({
               controllers: [
-                { path: "admin/jaas1", uuid: "abc123" },
+                {
+                  "agent-version": "1.2.3",
+                  name: "jaas1",
+                  uuid: "abc123",
+                },
                 { path: "admin/jaas2", uuid: "def456" },
               ],
             }),
@@ -669,7 +673,8 @@ describe("Juju API", () => {
           wsControllerURL: "wss://example.com/api",
           controllers: [
             {
-              path: "admin/jaas1",
+              "agent-version": "1.2.3",
+              name: "jaas1",
               uuid: "abc123",
               additionalController: true,
               updateAvailable: true,
@@ -728,6 +733,49 @@ describe("Juju API", () => {
               additionalController: true,
               updateAvailable: true,
               version: "1.2.3",
+            },
+          ],
+        })
+      );
+    });
+
+    it("can handle null responses when checking for updates", async () => {
+      const dispatch = jest.fn();
+      const conn = {
+        facades: {
+          jimM: {
+            listControllers: jest.fn().mockResolvedValueOnce({
+              controllers: [
+                {
+                  "agent-version": "1.2.3",
+                  name: "jaas1",
+                  uuid: "abc123",
+                },
+              ],
+            }),
+          },
+        },
+      } as unknown as Connection;
+      jest
+        .spyOn(jujuLibVersions, "jujuUpdateAvailable")
+        .mockImplementationOnce(async () => null);
+      await fetchControllerList(
+        "wss://example.com/api",
+        conn,
+        true,
+        dispatch,
+        () => rootStateFactory.build()
+      );
+      expect(dispatch).toHaveBeenCalledWith(
+        jujuActions.updateControllerList({
+          wsControllerURL: "wss://example.com/api",
+          controllers: [
+            {
+              "agent-version": "1.2.3",
+              name: "jaas1",
+              uuid: "abc123",
+              additionalController: true,
+              updateAvailable: false,
             },
           ],
         })

--- a/src/juju/api.ts
+++ b/src/juju/api.ts
@@ -362,7 +362,7 @@ export async function fetchAllModelStatuses(
             })
           );
         }
-        if (modelInfo?.results[0].result["is-controller"]) {
+        if (modelInfo?.results[0].result?.["is-controller"]) {
           // If this is a controller model then update the
           // controller data with this model data.
           dispatch(addControllerCloudRegion({ wsControllerURL, modelInfo }));
@@ -397,10 +397,10 @@ export async function fetchControllerList(
   if (conn.facades.jimM) {
     try {
       const response = await conn.facades.jimM?.listControllers();
-      controllers = response.controllers;
-      controllers?.forEach(
-        (c) => (c.additionalController = additionalController)
-      );
+      controllers = response.controllers.map((controller) => ({
+        ...controller,
+        additionalController,
+      }));
     } catch (error) {
       dispatch(
         generalActions.storeConnectionError(
@@ -434,7 +434,11 @@ export async function fetchControllerList(
         let updateAvailable = false;
         try {
           updateAvailable =
-            (await jujuUpdateAvailable(controller.version || "")) ?? false;
+            (await jujuUpdateAvailable(
+              "agent-version" in controller
+                ? controller["agent-version"]
+                : controller.version || ""
+            )) ?? false;
         } catch (error) {
           updateAvailable = false;
         }

--- a/src/juju/jimm/JIMMV3.ts
+++ b/src/juju/jimm/JIMMV3.ts
@@ -1,7 +1,19 @@
 import type { ConnectionInfo, Transport } from "@canonical/jujulib";
+import type { EntityStatus } from "@canonical/jujulib/dist/api/facades/model-manager/ModelManagerV9";
 import { autoBind } from "@canonical/jujulib/dist/api/utils";
 
-import type { Controller } from "store/juju/types";
+export type ControllerInfo = {
+  "agent-version": string;
+  "api-addresses"?: [];
+  "ca-certificate"?: string;
+  "cloud-region"?: string;
+  "cloud-tag"?: string;
+  name: string;
+  "public-address"?: string;
+  status: EntityStatus;
+  username: string;
+  uuid: string;
+};
 
 class JIMMV3 {
   static NAME: string;
@@ -31,7 +43,7 @@ class JIMMV3 {
     });
   }
 
-  listControllers(): Promise<{ controllers: Controller[] }> {
+  listControllers(): Promise<{ controllers: ControllerInfo[] }> {
     return new Promise((resolve, reject) => {
       const params = {};
       const req = {

--- a/src/juju/jimm/JIMMV3.ts
+++ b/src/juju/jimm/JIMMV3.ts
@@ -2,6 +2,8 @@ import type { ConnectionInfo, Transport } from "@canonical/jujulib";
 import type { EntityStatus } from "@canonical/jujulib/dist/api/facades/model-manager/ModelManagerV9";
 import { autoBind } from "@canonical/jujulib/dist/api/utils";
 
+// As typed in JIMM:
+// https://github.com/canonical/jimm/blob/30c6c9daa3af57014d0fb93abab9c6941942beaa/api/params/params.go#L120
 export type ControllerInfo = {
   "agent-version": string;
   "api-addresses"?: [];

--- a/src/pages/ControllersIndex/ControllersIndex.tsx
+++ b/src/pages/ControllersIndex/ControllersIndex.tsx
@@ -30,6 +30,7 @@ import type { AdditionalController, Controller } from "store/juju/types";
 import { isJAASFromUUID } from "store/juju/utils/controllers";
 import { useAppSelector } from "store/store";
 import urls from "urls";
+import { breakLines } from "utils";
 
 import ControllersOverview from "./ControllerOverview/ControllerOverview";
 import "./_controllers.scss";
@@ -189,8 +190,9 @@ function Details() {
       {
         content: (
           <Tooltip
-            message={loginError}
+            message={breakLines(loginError)}
             positionElementClassName="controllers__status"
+            tooltipClassName="p-tooltip--fixed-width"
           >
             <Status className="u-truncate controllers__status" status={status}>
               {label}

--- a/src/pages/ControllersIndex/ControllersIndex.tsx
+++ b/src/pages/ControllersIndex/ControllersIndex.tsx
@@ -53,7 +53,6 @@ function Details() {
   const modelData = useSelector(getModelData);
   const loginErrors = useAppSelector(getLoginErrors);
   const visitURLs = useAppSelector(getVisitURLs);
-  // TODO HOW TO SHOW CONNECTING INSTEAD OF AUTH NEEDED?
 
   const controllerMap: Record<string, AnnotatedController> = {};
   const additionalControllers: string[] = [];

--- a/src/pages/ControllersIndex/ControllersIndex.tsx
+++ b/src/pages/ControllersIndex/ControllersIndex.tsx
@@ -1,4 +1,9 @@
-import { Icon, MainTable, Tooltip } from "@canonical/react-components";
+import {
+  Icon,
+  MainTable,
+  Notification,
+  Tooltip,
+} from "@canonical/react-components";
 import type {
   MainTableCell,
   MainTableHeader,
@@ -8,16 +13,21 @@ import { useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 
 import FadeIn from "animations/FadeIn";
+import AuthenticationButton from "components/AuthenticationButton";
 import Header from "components/Header/Header";
 import Status from "components/Status";
 import TruncatedTooltip from "components/TruncatedTooltip";
 import { useQueryParams } from "hooks/useQueryParams";
 import useWindowTitle from "hooks/useWindowTitle";
 import BaseLayout from "layout/BaseLayout/BaseLayout";
-import { getLoginErrors } from "store/general/selectors";
+import {
+  getControllerConnections,
+  getLoginErrors,
+  getVisitURLs,
+} from "store/general/selectors";
 import { getControllerData, getModelData } from "store/juju/selectors";
 import type { AdditionalController, Controller } from "store/juju/types";
-import { isJAASFromPath } from "store/juju/utils/controllers";
+import { isJAASFromUUID } from "store/juju/utils/controllers";
 import { useAppSelector } from "store/store";
 import urls from "urls";
 
@@ -38,9 +48,12 @@ type AnnotatedController = (Controller | AdditionalController) & {
 
 function Details() {
   useWindowTitle("Controllers");
+  const controllerConnections = useAppSelector(getControllerConnections);
   const controllerData = useSelector(getControllerData);
   const modelData = useSelector(getModelData);
   const loginErrors = useAppSelector(getLoginErrors);
+  const visitURLs = useAppSelector(getVisitURLs);
+  // TODO HOW TO SHOW CONNECTING INSTEAD OF AUTH NEEDED?
 
   const controllerMap: Record<string, AnnotatedController> = {};
   const additionalControllers: string[] = [];
@@ -48,8 +61,7 @@ function Details() {
     Object.entries(controllerData).forEach(
       ([wsControllerURL, controllers], i) => {
         controllers.forEach((controller) => {
-          const id =
-            "uuid" in controller ? controller.uuid : `${wsControllerURL}-${i}`;
+          const id = "uuid" in controller ? controller.uuid : wsControllerURL;
           if (controller.additionalController) {
             additionalControllers.push(id);
           }
@@ -120,18 +132,34 @@ function Details() {
 
   function generatePathValue(controllerData: AnnotatedController) {
     const column: MainTableCell = { content: "" };
-    if (isJAASFromPath(controllerData)) {
+    // Remove protocol and trailing /api from websocket addresses.
+    const controllerAddress = controllerData.wsControllerURL
+      .replace(/^wss?:\/\//i, "")
+      .replace(/\/api$/i, "");
+    if (isJAASFromUUID(controllerData)) {
       column.content = "JAAS";
+    } else if ("name" in controllerData && controllerData.name) {
+      column.content = (
+        <Tooltip
+          message={controllerAddress}
+          positionElementClassName="truncated-tooltip__position-element"
+        >
+          {controllerData.name}
+        </Tooltip>
+      );
     } else if ("path" in controllerData && controllerData.path) {
       column.content = (
-        <Tooltip message={controllerData.wsControllerURL}>
+        <Tooltip
+          message={controllerAddress}
+          positionElementClassName="truncated-tooltip__position-element"
+        >
           {controllerData.path}
         </Tooltip>
       );
     } else {
       column.content = (
-        <TruncatedTooltip message={controllerData?.wsControllerURL}>
-          {controllerData?.wsControllerURL}
+        <TruncatedTooltip message={controllerAddress}>
+          {controllerAddress}
         </TruncatedTooltip>
       );
       column.className = "u-text--muted";
@@ -139,14 +167,24 @@ function Details() {
     return column;
   }
 
-  function generateRow(c: AnnotatedController) {
+  function generateRow(c: AnnotatedController, authenticated: boolean) {
+    const isJAAS = isJAASFromUUID(c);
     const cloud =
       "location" in c && c?.location?.cloud ? c.location.cloud : "unknown";
     const region =
       "location" in c && c?.location?.region ? c.location.region : "unknown";
     const cloudRegion = `${cloud}/${region}`;
-    const access = "Public" in c && c.Public ? "Public" : "Private";
+    const access = ("Public" in c && c.Public) || isJAAS ? "Public" : "Private";
     const loginError = loginErrors?.[c.wsControllerURL];
+    let status = "Connected";
+    let label = null;
+    if (loginError) {
+      status = "Error";
+      label = "Failed to connect";
+    } else if (!authenticated) {
+      status = "caution";
+      label = "Authentication required";
+    }
     const columns = [
       generatePathValue(c),
       {
@@ -155,14 +193,13 @@ function Details() {
             message={loginError}
             positionElementClassName="controllers__status"
           >
-            <Status
-              className="u-truncate controllers__status"
-              status={loginError ? "Disconnected" : "Connected"}
-            />
+            <Status className="u-truncate controllers__status" status={status}>
+              {label}
+            </Status>
           </Tooltip>
         ),
       },
-      { content: isJAASFromPath(c) ? "Multiple" : cloudRegion },
+      { content: isJAAS ? "Multiple" : cloudRegion },
       { content: c.models },
       { content: c.machines },
       { content: c.applications },
@@ -170,11 +207,14 @@ function Details() {
       { content: "" },
       { content: access, className: "u-capitalise" },
     ];
-    if ("version" in c && c.version) {
+    const version =
+      ("agent-version" in c && c["agent-version"]) ||
+      ("version" in c && c.version);
+    if (version) {
       columns[columns.length - 2] = {
         content: (
           <>
-            {c.version}{" "}
+            {version}{" "}
             {c.updateAvailable ? (
               <Tooltip
                 message={
@@ -205,12 +245,24 @@ function Details() {
   }
   // XXX this isn't a great way of doing this.
   const additionalRows = additionalControllers.map((uuid) => {
-    const row = generateRow(controllerMap[uuid]);
+    const row = generateRow(
+      controllerMap[uuid],
+      !!controllerConnections &&
+        controllerMap[uuid].wsControllerURL in controllerConnections
+    );
     delete controllerMap[uuid];
     return row;
   });
 
-  const rows = controllerMap && Object.values(controllerMap).map(generateRow);
+  const rows =
+    controllerMap &&
+    Object.values(controllerMap).map((controller) =>
+      generateRow(
+        controller,
+        !!controllerConnections &&
+          controller.wsControllerURL in controllerConnections
+      )
+    );
 
   const [, setPanelQs] = useQueryParams<{ panel: string | null }>({
     panel: null,
@@ -218,6 +270,15 @@ function Details() {
 
   return (
     <>
+      {visitURLs?.map((visitURL) => (
+        <Notification severity="caution" key={visitURL}>
+          Controller authentication required.{" "}
+          <AuthenticationButton appearance="link" visitURL={visitURL}>
+            Authenticate
+          </AuthenticationButton>
+          .
+        </Notification>
+      ))}
       <div className="controllers--header">
         <div className="controllers__heading">
           Model status across controllers

--- a/src/panels/ActionsPanel/CharmActionsPanel.tsx
+++ b/src/panels/ActionsPanel/CharmActionsPanel.tsx
@@ -96,20 +96,16 @@ export default function CharmActionsPanel({
         const error = payload?.actions?.find((e) => e.error);
         if (error) throw error;
         reactHotToast.custom((t) => (
-          <ToastCard
-            toastInstance={t}
-            type="positive"
-            text={Label.ACTION_SUCCESS}
-          />
+          <ToastCard toastInstance={t} type="positive">
+            {Label.ACTION_SUCCESS}
+          </ToastCard>
         ));
       })
       .catch(() => {
         reactHotToast.custom((t) => (
-          <ToastCard
-            toastInstance={t}
-            type="negative"
-            text={Label.ACTION_ERROR}
-          />
+          <ToastCard toastInstance={t} type="negative">
+            {Label.ACTION_ERROR}
+          </ToastCard>
         ));
       });
   };

--- a/src/panels/ShareModelPanel/ShareModel.test.tsx
+++ b/src/panels/ShareModelPanel/ShareModel.test.tsx
@@ -161,6 +161,29 @@ describe("Share Model Panel", () => {
     ).toBeInTheDocument();
   });
 
+  it("catches errors when adding a user", async () => {
+    jest
+      .spyOn(storeModule, "usePromiseDispatch")
+      .mockReturnValue(
+        jest.fn().mockImplementation(() => Promise.reject("Uh oh!"))
+      );
+    renderComponent(
+      <>
+        <ShareModel />
+        <Toaster />
+      </>,
+      { state, url, path }
+    );
+    await userEvent.type(
+      screen.getByRole("textbox", { name: "Username" }),
+      "another@external"
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: Label.ADD_BUTTON })
+    );
+    expect(await screen.findByText(/Uh oh!/)).toBeInTheDocument();
+  });
+
   it("handles error responses when adding a user", async () => {
     jest.spyOn(storeModule, "usePromiseDispatch").mockReturnValue(
       jest.fn().mockImplementation(() =>

--- a/src/panels/ShareModelPanel/ShareModel.tsx
+++ b/src/panels/ShareModelPanel/ShareModel.tsx
@@ -149,15 +149,11 @@ export default function ShareModel() {
       );
     } catch (error) {
       reactHotToast.custom((t) => (
-        <ToastCard
-          toastInstance={t}
-          type="negative"
-          text={
-            typeof error === "string"
-              ? error
-              : "Unable to update model permissions"
-          }
-        />
+        <ToastCard toastInstance={t} type="negative">
+          {typeof error === "string"
+            ? error
+            : "Unable to update model permissions"}
+        </ToastCard>
       ));
       response = null;
     }
@@ -189,14 +185,14 @@ export default function ShareModel() {
     }
 
     reactHotToast.custom((t) => (
-      <ToastCard
-        toastInstance={t}
-        type={error ? "negative" : "positive"}
-        text={
-          error ??
-          `Permissions for <strong>${username}</strong> have been changed to <em>${permissionTo}.</em>`
-        }
-      />
+      <ToastCard toastInstance={t} type={error ? "negative" : "positive"}>
+        {error ?? (
+          <>
+            Permissions for <strong>{username}</strong> have been changed to{" "}
+            <em>{permissionTo}.</em>
+          </>
+        )}
+      </ToastCard>
     ));
     return response ?? null;
   };
@@ -217,7 +213,6 @@ export default function ShareModel() {
       <ToastCard
         toastInstance={t}
         type="positive"
-        text={`<strong>${username}</strong> has been successfully removed.`}
         undo={async () => {
           const permissionTo = usersAccess?.[username];
           const permissionFrom = undefined;
@@ -228,7 +223,9 @@ export default function ShareModel() {
             permissionFrom
           );
         }}
-      />
+      >
+        <strong>{username}</strong> has been successfully removed.
+      </ToastCard>
     ));
   };
 
@@ -238,11 +235,9 @@ export default function ShareModel() {
   ) => {
     if (userAlreadyHasAccess(values.username, users)) {
       reactHotToast.custom((t) => (
-        <ToastCard
-          toastInstance={t}
-          type="negative"
-          text={`<strong>${values.username}</strong> already has access to this model.`}
-        />
+        <ToastCard toastInstance={t} type="negative">
+          <strong>{values.username}</strong> already has access to this model.
+        </ToastCard>
       ));
     } else {
       const newUserName = values.username;
@@ -260,16 +255,16 @@ export default function ShareModel() {
       const error = response?.results?.[0]?.error?.message;
       if (error) {
         reactHotToast.custom((t) => (
-          <ToastCard toastInstance={t} type="negative" text={error} />
+          <ToastCard toastInstance={t} type="negative">
+            {error}
+          </ToastCard>
         ));
       } else if (response) {
         resetForm();
         reactHotToast.custom((t) => (
-          <ToastCard
-            toastInstance={t}
-            type="positive"
-            text={`<strong>${values.username}</strong> now has access to this model.`}
-          />
+          <ToastCard toastInstance={t} type="positive">
+            <strong>{values.username}</strong> now has access to this model.
+          </ToastCard>
         ));
       }
     }

--- a/src/scss/custom/_status_icons.scss
+++ b/src/scss/custom/_status_icons.scss
@@ -35,6 +35,7 @@
   }
 
   &.is-busy,
+  &.is-caution,
   &.is-maintenance,
   &.is-attention,
   &.is-stopped,

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -43,6 +43,7 @@ $color-navigation-background: $color-brand;
 @include vf-p-icon-units;
 @include vf-p-icon-user;
 @include vf-p-icon-video-play;
+@include vf-p-icon-lock-locked;
 
 // Overrides for Vanilla. This needs to be after the Vanilla includes.
 @import "vanilla-overrides";

--- a/src/store/general/reducers.test.ts
+++ b/src/store/general/reducers.test.ts
@@ -151,11 +151,31 @@ describe("reducers", () => {
 
   it("storeVisitURL", () => {
     const state = generalStateFactory.build({
-      visitURL: "/visit",
+      visitURLs: ["/visit"],
     });
     expect(reducer(state, actions.storeVisitURL("/welcome"))).toStrictEqual({
       ...state,
-      visitURL: "/welcome",
+      visitURLs: ["/visit", "/welcome"],
+    });
+  });
+
+  it("removeVisitURL", () => {
+    const state = generalStateFactory.build({
+      visitURLs: ["/visit", "/welcome"],
+    });
+    expect(reducer(state, actions.removeVisitURL("/welcome"))).toStrictEqual({
+      ...state,
+      visitURLs: ["/visit"],
+    });
+  });
+
+  it("clearVisitURLs", () => {
+    const state = generalStateFactory.build({
+      visitURLs: ["/visit", "/welcome"],
+    });
+    expect(reducer(state, actions.clearVisitURLs())).toStrictEqual({
+      ...state,
+      visitURLs: null,
     });
   });
 
@@ -164,12 +184,12 @@ describe("reducers", () => {
       controllerConnections: {
         "wss://example.com": { controllerTag: "default-info" },
       },
-      visitURL: "/visit",
+      visitURLs: ["/visit"],
     });
     expect(reducer(state, actions.logOut())).toStrictEqual({
       ...state,
       controllerConnections: null,
-      visitURL: null,
+      visitURLs: null,
     });
   });
 

--- a/src/store/general/reducers.test.ts
+++ b/src/store/general/reducers.test.ts
@@ -159,6 +159,16 @@ describe("reducers", () => {
     });
   });
 
+  it("storeVisitURL creates array if it is null", () => {
+    const state = generalStateFactory.build({
+      visitURLs: null,
+    });
+    expect(reducer(state, actions.storeVisitURL("/welcome"))).toStrictEqual({
+      ...state,
+      visitURLs: ["/welcome"],
+    });
+  });
+
   it("removeVisitURL", () => {
     const state = generalStateFactory.build({
       visitURLs: ["/visit", "/welcome"],

--- a/src/store/general/selectors.test.ts
+++ b/src/store/general/selectors.test.ts
@@ -17,7 +17,6 @@ import {
   getPingerIntervalIds,
   getUserPass,
   getWSControllerURL,
-  isConnecting,
   isLoggedIn,
   getActiveUserControllerAccess,
   getConnectionError,
@@ -26,6 +25,7 @@ import {
   getControllerFeatureEnabled,
   getLoginErrors,
   isCrossModelQueriesEnabled,
+  getVisitURLs,
 } from "./selectors";
 
 describe("selectors", () => {
@@ -54,6 +54,18 @@ describe("selectors", () => {
         })
       )
     ).toStrictEqual(true);
+  });
+
+  it("getVisitURLs", () => {
+    expect(
+      getVisitURLs(
+        rootStateFactory.build({
+          general: generalStateFactory.build({
+            visitURLs: ["/login", "/auth"],
+          }),
+        })
+      )
+    ).toStrictEqual(["/login", "/auth"]);
   });
 
   it("getUserPass", () => {
@@ -240,18 +252,6 @@ describe("selectors", () => {
         })
       )
     ).toStrictEqual(false);
-  });
-
-  it("isConnecting", () => {
-    expect(
-      isConnecting(
-        rootStateFactory.build({
-          general: generalStateFactory.build({
-            visitURL: "/visit",
-          }),
-        })
-      )
-    ).toBe(true);
   });
 
   it("getActiveUserTag", () => {

--- a/src/store/general/selectors.ts
+++ b/src/store/general/selectors.ts
@@ -27,6 +27,11 @@ export const getIsJuju = createSelector(
   (sliceState) => sliceState?.config?.isJuju
 );
 
+export const getVisitURLs = createSelector(
+  [slice],
+  (sliceState) => sliceState?.visitURLs
+);
+
 /**
   Fetches the username and password from state.
   @param state The application state.
@@ -111,11 +116,6 @@ export const getControllerFeatureEnabled = createSelector(
   ],
   (controllerFeatures, { wsControllerURL, feature }) =>
     controllerFeatures?.[wsControllerURL]?.[feature]
-);
-
-export const isConnecting = createSelector(
-  [slice],
-  (sliceState) => !!sliceState?.visitURL
 );
 
 /**

--- a/src/store/general/slice.ts
+++ b/src/store/general/slice.ts
@@ -14,7 +14,7 @@ const slice = createSlice({
     credentials: null,
     loginErrors: null,
     pingerIntervalIds: null,
-    visitURL: null,
+    visitURLs: null,
   } as GeneralState,
   reducers: {
     cleanupLoginErrors: (state) => {
@@ -59,14 +59,27 @@ const slice = createSlice({
     storeVersion: (state, action) => {
       state.appVersion = action.payload;
     },
-    storeVisitURL: (state, action) => {
-      state.visitURL = action.payload;
+    storeVisitURL: (state, action: PayloadAction<string>) => {
+      if (!state.visitURLs) {
+        state.visitURLs = [];
+      }
+      state.visitURLs.push(action.payload);
+    },
+    removeVisitURL: (state, action: PayloadAction<string>) => {
+      if (state.visitURLs) {
+        state.visitURLs = state.visitURLs?.filter(
+          (url) => url !== action.payload
+        );
+      }
+    },
+    clearVisitURLs: (state) => {
+      state.visitURLs = null;
     },
     logOut: (state) => {
       state.controllerConnections = null;
       state.credentials = null;
       state.pingerIntervalIds = null;
-      state.visitURL = null;
+      state.visitURLs = null;
     },
     updatePingerIntervalId: (state, action) => {
       const intervals = state.pingerIntervalIds ?? {};

--- a/src/store/general/types.ts
+++ b/src/store/general/types.ts
@@ -40,5 +40,5 @@ export type GeneralState = {
   credentials: Credentials | null;
   loginErrors: LoginErrors | null;
   pingerIntervalIds: PingerIntervalIds | null;
-  visitURL: string | null;
+  visitURLs: string[] | null;
 };

--- a/src/store/juju/selectors.test.ts
+++ b/src/store/juju/selectors.test.ts
@@ -171,11 +171,11 @@ describe("selectors", () => {
   it("getControllerData", () => {
     const controllers = {
       "wss://example.com": [
-        {
+        controllerFactory.build({
           path: "/",
           uuid: "abc123",
           version: "1",
-        },
+        }),
       ],
     };
     expect(

--- a/src/store/juju/types.ts
+++ b/src/store/juju/types.ts
@@ -1,6 +1,7 @@
 import type { Charm } from "@canonical/jujulib/dist/api/facades/charms/CharmsV6";
 import type { ModelInfo } from "@canonical/jujulib/dist/api/facades/model-manager/ModelManagerV9";
 
+import type { ControllerInfo } from "juju/jimm/JIMMV3";
 import type { CrossModelQueryResponse } from "juju/jimm/JIMMV4";
 import type {
   ApplicationInfo,
@@ -13,15 +14,20 @@ export type ControllerLocation = {
   region: string;
 };
 
-export type Controller = {
-  additionalController?: boolean;
+export type ControllerAnnotations = {
+  additionalController: boolean;
   location?: ControllerLocation;
+  updateAvailable?: boolean;
+};
+
+export type LocalController = {
   path: string;
-  Public?: boolean;
   uuid: string;
   version?: string;
-  updateAvailable?: boolean | null;
 };
+
+export type Controller = (ControllerInfo | LocalController) &
+  ControllerAnnotations;
 
 export type AdditionalController = {
   additionalController: true;

--- a/src/store/juju/utils/controllers.test.ts
+++ b/src/store/juju/utils/controllers.test.ts
@@ -3,14 +3,16 @@ import {
   controllerFactory,
 } from "testing/factories/juju/juju";
 
-import { isJAASFromPath } from "./controllers";
+import { JAAS_CONTROLLER_UUID, isJAASFromUUID } from "./controllers";
 
-describe("isJAASFromPath", () => {
-  it("identifies a JAAS controller from the path", () => {
-    expect(isJAASFromPath(controllerFactory.build())).toBe(true);
+describe("isJAASFromUUID", () => {
+  it("identifies a JAAS controller from the UUID", () => {
+    expect(
+      isJAASFromUUID(controllerFactory.build({ uuid: JAAS_CONTROLLER_UUID }))
+    ).toBe(true);
   });
 
-  it("identifies a non-JAAS controller from the path", () => {
-    expect(isJAASFromPath(additionalControllerFactory.build())).toBe(false);
+  it("identifies a non-JAAS controller from the UUID", () => {
+    expect(isJAASFromUUID(additionalControllerFactory.build())).toBe(false);
   });
 });

--- a/src/store/juju/utils/controllers.ts
+++ b/src/store/juju/utils/controllers.ts
@@ -1,5 +1,7 @@
 import type { AdditionalController, Controller } from "store/juju/types";
 
-export const isJAASFromPath = (
+export const JAAS_CONTROLLER_UUID = "a030379a-940f-4760-8fcf-3062b41a04e7";
+
+export const isJAASFromUUID = (
   controllerData: Controller | AdditionalController
-) => "path" in controllerData && controllerData?.path === "admin/jaas";
+) => "uuid" in controllerData && controllerData.uuid === JAAS_CONTROLLER_UUID;

--- a/src/store/middleware/check-auth.ts
+++ b/src/store/middleware/check-auth.ts
@@ -51,7 +51,9 @@ export const checkAuthMiddleware: Middleware<
     const actionAllowlist = [
       appActions.connectAndPollControllers.type,
       generalActions.cleanupLoginErrors.type,
+      generalActions.clearVisitURLs.type,
       generalActions.logOut.type,
+      generalActions.removeVisitURL.type,
       generalActions.storeConfig.type,
       generalActions.storeLoginError.type,
       generalActions.storeConnectionError.type,

--- a/src/store/middleware/model-poller.test.ts
+++ b/src/store/middleware/model-poller.test.ts
@@ -178,6 +178,9 @@ describe("model poller", () => {
     await runMiddleware();
     expect(next).not.toHaveBeenCalled();
     expect(fakeStore.dispatch).toHaveBeenCalledWith(
+      generalActions.clearVisitURLs()
+    );
+    expect(fakeStore.dispatch).toHaveBeenCalledWith(
       generalActions.updateControllerConnection({
         wsControllerURL,
         info: conn.info,
@@ -254,6 +257,9 @@ describe("model poller", () => {
   });
 
   it("disables masking when using JIMM", async () => {
+    const controllers = [
+      [wsControllerURL, { user: "eggman@external", password: "test" }, true],
+    ];
     const disableControllerUUIDMasking = jest.spyOn(
       jujuModule,
       "disableControllerUUIDMasking"

--- a/src/store/middleware/model-poller.ts
+++ b/src/store/middleware/model-poller.ts
@@ -35,6 +35,9 @@ export const modelPollerMiddleware: Middleware<
   const jujus = new Map<string, Client>();
   return (next) => async (action: AnyAction) => {
     if (action.type === appActions.connectAndPollControllers.type) {
+      // Each time we try to log in to a controller we get new macaroons, so
+      // first clean up any old auth requests:
+      reduxStore.dispatch(generalActions.clearVisitURLs());
       action.payload.controllers.forEach(
         async (controllerData: ControllerOptions) => {
           const [
@@ -127,8 +130,7 @@ export const modelPollerMiddleware: Middleware<
             reduxStore.dispatch,
             reduxStore.getState
           );
-          // XXX the isJuju Check needs to be done on a per-controller basis
-          if (!action.payload.isJuju) {
+          if (identityProviderAvailable) {
             // This call will be a noop if the user isn't an administrator
             // on the JIMM controller we're connected to.
             try {

--- a/src/testing/factories/general.ts
+++ b/src/testing/factories/general.ts
@@ -47,5 +47,5 @@ export const generalStateFactory = GeneralStateFactory.define(() => ({
   credentials: null,
   loginErrors: null,
   pingerIntervalIds: null,
-  visitURL: null,
+  visitURLs: null,
 }));

--- a/src/testing/factories/juju/juju.ts
+++ b/src/testing/factories/juju/juju.ts
@@ -48,6 +48,19 @@ export const controllerFactory = Factory.define<Controller>(() => ({
   version: "1.2.3",
 }));
 
+export const controllerInfoFactory = Factory.define<Controller>(() => ({
+  additionalController: false,
+  "agent-version": "1.2.3",
+  name: "controller1",
+  status: {
+    status: "available",
+    info: "",
+    since: "2021-07-28T22:05:36.877177235Z",
+  },
+  username: "eggman@external",
+  uuid: "def456",
+}));
+
 export const modelListInfoFactory = Factory.define<ModelListInfo>(() => ({
   name: "test-model",
   ownerTag: "user-eggman@external",

--- a/src/testing/factories/juju/juju.ts
+++ b/src/testing/factories/juju/juju.ts
@@ -44,6 +44,8 @@ export const controllerLocationFactory = Factory.define<ControllerLocation>(
 export const controllerFactory = Factory.define<Controller>(() => ({
   path: "admin/jaas",
   uuid: "a030379a-940f-4760-8fcf-3062bfake4e7",
+  additionalController: false,
+  version: "1.2.3",
 }));
 
 export const modelListInfoFactory = Factory.define<ModelListInfo>(() => ({


### PR DESCRIPTION
## Done

- Add an authentication flow for additional controllers that use JIMM.

## QA

- Connect your dashboard to a local controller.
- Go to the controllers page.
- Click the "Register a controller" button.
- Fill out the form using these values:
  - Host: `jimm.jujucharms.com`
  - This controller uses an external identity provider: true
- Submit the form.
- The controller should get added, but the status will be "Authentication needed".
- A notification should appear at the top of the page as well as a pop up notification at the bottom right (this is so that it will appear if you're on a different page when this appears.
- Click the button/link in one of the notifications.
- In the tab that opens go through the SSO process and close the tab once complete.
- The new controller should now say "Connected" (it's possible that it might say error if the login took too long, if it does try refreshing the window).
- Refresh the window and the controller should authenticate and connect again automatically.

## Details

- https://warthogs.atlassian.net/browse/WD-6278
- Fixes: #1630.

## Screenshots

![Screen Recording 2023-09-14 at 3 19 50 pm](https://github.com/canonical/juju-dashboard/assets/361637/b2d293ab-51cb-4363-a645-e8da0174b5e3)

