### PR TITLE
WD-5398 - Restrict log access

### DIFF
--- a/src/components/PrimaryNav/PrimaryNav.test.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.test.tsx
@@ -171,11 +171,10 @@ describe("Primary Nav", () => {
   it("should have all navigation buttons", () => {
     renderComponent(<PrimaryNav />);
     const navigationButtons = document.querySelectorAll(".p-list__link");
-    expect(navigationButtons).toHaveLength(4);
+    expect(navigationButtons).toHaveLength(3);
     expect(navigationButtons[0]).toHaveTextContent("Models");
     expect(navigationButtons[1]).toHaveTextContent("Controllers");
-    expect(navigationButtons[2]).toHaveTextContent("Logs");
-    expect(navigationButtons[3]).toHaveTextContent("Report a bug");
+    expect(navigationButtons[2]).toHaveTextContent("Report a bug");
   });
 
   it("should not show LogsLink navigation button under Juju", () => {
@@ -192,6 +191,24 @@ describe("Primary Nav", () => {
     expect(navigationButtons[0]).toHaveTextContent("Models");
     expect(navigationButtons[1]).toHaveTextContent("Controllers");
     expect(navigationButtons[2]).toHaveTextContent("Report a bug");
+  });
+
+  it("should show LogsLink navigation button if the controller supports it", () => {
+    const state = rootStateFactory.build({
+      general: generalStateFactory.build({
+        config: configFactory.build({
+          controllerAPIEndpoint: "wss://controller.example.com",
+          isJuju: false,
+        }),
+        controllerFeatures: controllerFeaturesStateFactory.build({
+          "wss://controller.example.com": controllerFeaturesFactory.build({
+            auditLogs: true,
+          }),
+        }),
+      }),
+    });
+    renderComponent(<PrimaryNav />, { state });
+    expect(screen.getByRole("link", { name: Label.LOGS })).toBeInTheDocument();
   });
 
   it("should not show Advanced search navigation button under Juju", () => {

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -7,7 +7,7 @@ import Logo from "components/Logo/Logo";
 import UserMenu from "components/UserMenu/UserMenu";
 import {
   getAppVersion,
-  getIsJuju,
+  isAuditLogsEnabled,
   isCrossModelQueriesEnabled,
 } from "store/general/selectors";
 import {
@@ -24,6 +24,7 @@ import PrimaryNavLink from "./PrimaryNavLink";
 
 export enum Label {
   ADVANCED_SEARCH = "Advanced search",
+  LOGS = "Logs",
 }
 
 const ModelsLink = () => {
@@ -74,7 +75,7 @@ const ControllersLink = () => {
 };
 
 const LogsLink = () => (
-  <PrimaryNavLink to={urls.logs} iconName="topic" title="Logs" />
+  <PrimaryNavLink to={urls.logs} iconName="topic" title={Label.LOGS} />
 );
 
 const AdvancedSearchLink = () => (
@@ -90,8 +91,7 @@ const PrimaryNav = () => {
   const [updateAvailable, setUpdateAvailable] = useState(false);
   const versionRequested = useRef(false);
   const crossModelQueriesEnabled = useAppSelector(isCrossModelQueriesEnabled);
-
-  const isJuju = useSelector(getIsJuju);
+  const auditLogsEnabled = useAppSelector(isAuditLogsEnabled);
 
   useEffect(() => {
     if (appVersion && !versionRequested.current) {
@@ -119,7 +119,7 @@ const PrimaryNav = () => {
         <li className="p-list__item">
           <ControllersLink />
         </li>
-        {!isJuju && (
+        {auditLogsEnabled && (
           <li className="p-list__item">
             <LogsLink />
           </li>

--- a/src/components/Routes/Routes.tsx
+++ b/src/components/Routes/Routes.tsx
@@ -1,5 +1,4 @@
 import { useEffect } from "react";
-import { useSelector } from "react-redux";
 import {
   Navigate,
   Route,
@@ -16,7 +15,10 @@ import ModelDetails from "pages/ModelDetails/ModelDetails";
 import ModelsIndex from "pages/ModelsIndex/ModelsIndex";
 import PageNotFound from "pages/PageNotFound/PageNotFound";
 import Settings from "pages/Settings/Settings";
-import { getIsJuju, isCrossModelQueriesEnabled } from "store/general/selectors";
+import {
+  isCrossModelQueriesEnabled,
+  isAuditLogsEnabled,
+} from "store/general/selectors";
 import { useAppSelector } from "store/store";
 import urls from "urls";
 
@@ -32,8 +34,7 @@ export function Routes() {
   const sendAnalytics = useAnalytics();
   const location = useLocation();
   const crossModelQueriesEnabled = useAppSelector(isCrossModelQueriesEnabled);
-
-  const isJuju = useSelector(getIsJuju);
+  const auditLogsEnabled = useAppSelector(isAuditLogsEnabled);
 
   useEffect(() => {
     // Send an analytics event when the URL changes.
@@ -78,7 +79,7 @@ export function Routes() {
         }
       />
       <Route path="*" element={<PageNotFound />} />
-      {!isJuju && (
+      {auditLogsEnabled && (
         <Route
           path={urls.logs}
           element={

--- a/src/juju/jimm/JIMMV4.test.ts
+++ b/src/juju/jimm/JIMMV4.test.ts
@@ -15,6 +15,28 @@ describe("JIMMV4", () => {
     connectionInfo = connectionInfoFactory.build();
   });
 
+  it("checkRelation", async () => {
+    const jimm = new JIMMV4(transport, connectionInfo);
+    const params = {
+      object: "user-eggman@external",
+      relation: "member",
+      target_object: "group-administrators",
+    };
+    jimm.checkRelation(params);
+    expect(transport.write).toHaveBeenCalledWith(
+      {
+        type: "JIMM",
+        request: "CheckRelation",
+        version: 4,
+        params: {
+          tuple: params,
+        },
+      },
+      expect.any(Function),
+      expect.any(Function)
+    );
+  });
+
   it("crossModelQuery", async () => {
     const jimm = new JIMMV4(transport, connectionInfo);
     jimm.crossModelQuery(".");

--- a/src/juju/jimm/JIMMV4.ts
+++ b/src/juju/jimm/JIMMV4.ts
@@ -31,9 +31,11 @@ export type RelationshipTuple = {
 
 // As typed in JIMM:
 // https://github.com/canonical/jimm/blob/c1e1642ac701bcbef2fdd8f4e347de9dcf16ac50/api/params/params.go#L324
-export type CheckRelationResponse = {
-  allowed: boolean;
-};
+export type CheckRelationResponse =
+  | {
+      allowed: boolean;
+    }
+  | string;
 
 export const isCrossModelQueryResponse = (
   response: CrossModelQueryFullResponse

--- a/src/juju/jimm/JIMMV4.ts
+++ b/src/juju/jimm/JIMMV4.ts
@@ -21,6 +21,20 @@ export type CrossModelQueryResponse = {
 // sometimes be a string.
 export type CrossModelQueryFullResponse = CrossModelQueryResponse | string;
 
+// As typed in JIMM:
+// https://github.com/canonical/jimm/blob/c1e1642ac701bcbef2fdd8f4e347de9dcf16ac50/api/params/params.go#L296
+export type RelationshipTuple = {
+  object: string;
+  relation: string;
+  target_object: string;
+};
+
+// As typed in JIMM:
+// https://github.com/canonical/jimm/blob/c1e1642ac701bcbef2fdd8f4e347de9dcf16ac50/api/params/params.go#L324
+export type CheckRelationResponse = {
+  allowed: boolean;
+};
+
 export const isCrossModelQueryResponse = (
   response: CrossModelQueryFullResponse
 ): response is CrossModelQueryResponse =>
@@ -41,6 +55,18 @@ class JIMMV4 extends JIMMV3 {
 
     // Automatically bind all methods to instances.
     autoBind(this);
+  }
+
+  checkRelation(tuple: RelationshipTuple): Promise<CheckRelationResponse> {
+    return new Promise((resolve, reject) => {
+      const req = {
+        type: "JIMM",
+        request: "CheckRelation",
+        version: 4,
+        params: { tuple },
+      };
+      this._transport.write(req, resolve, reject);
+    });
   }
 
   crossModelQuery(query: string): Promise<CrossModelQueryFullResponse> {

--- a/src/juju/jimm/JIMMV4.ts
+++ b/src/juju/jimm/JIMMV4.ts
@@ -21,11 +21,16 @@ export type CrossModelQueryResponse = {
 // sometimes be a string.
 export type CrossModelQueryFullResponse = CrossModelQueryResponse | string;
 
+export enum JIMMRelation {
+  AUDIT_LOG_VIEWER = "audit_log_viewer",
+  ADMINISTRATOR = "administrator",
+}
+
 // As typed in JIMM:
 // https://github.com/canonical/jimm/blob/c1e1642ac701bcbef2fdd8f4e347de9dcf16ac50/api/params/params.go#L296
 export type RelationshipTuple = {
   object: string;
-  relation: string;
+  relation: JIMMRelation | string;
   target_object: string;
 };
 

--- a/src/store/general/selectors.test.ts
+++ b/src/store/general/selectors.test.ts
@@ -26,6 +26,7 @@ import {
   getControllerFeatureEnabled,
   getLoginErrors,
   isCrossModelQueriesEnabled,
+  isAuditLogsEnabled,
 } from "./selectors";
 
 describe("selectors", () => {
@@ -234,6 +235,46 @@ describe("selectors", () => {
             controllerFeatures: controllerFeaturesStateFactory.build({
               "wss://controller.example.com": controllerFeaturesFactory.build({
                 crossModelQueries: true,
+              }),
+            }),
+          }),
+        })
+      )
+    ).toStrictEqual(false);
+  });
+
+  it("isAuditLogsEnabled", () => {
+    expect(
+      isAuditLogsEnabled(
+        rootStateFactory.build({
+          general: generalStateFactory.build({
+            config: configFactory.build({
+              controllerAPIEndpoint: "wss://controller.example.com",
+              isJuju: false,
+            }),
+            controllerFeatures: controllerFeaturesStateFactory.build({
+              "wss://controller.example.com": controllerFeaturesFactory.build({
+                auditLogs: true,
+              }),
+            }),
+          }),
+        })
+      )
+    ).toStrictEqual(true);
+  });
+
+  it("isAuditLogsEnabled is not enabled when using Juju controller", () => {
+    expect(
+      isAuditLogsEnabled(
+        rootStateFactory.build({
+          general: generalStateFactory.build({
+            config: configFactory.build({
+              controllerAPIEndpoint: "wss://controller.example.com",
+              isJuju: true,
+            }),
+            controllerFeatures: controllerFeaturesStateFactory.build({
+              "wss://controller.example.com": controllerFeaturesFactory.build({
+                auditLogs: true,
               }),
             }),
           }),

--- a/src/store/general/selectors.ts
+++ b/src/store/general/selectors.ts
@@ -160,6 +160,12 @@ export const getWSControllerURL = createSelector(
   (config) => config?.controllerAPIEndpoint
 );
 
+export const isAuditLogsEnabled = createSelector(
+  [getIsJuju, getWSControllerURL, (state) => state],
+  (isJuju, wsControllerURL, state) =>
+    !isJuju && getControllerFeatureEnabled(state, wsControllerURL, "auditLogs")
+);
+
 export const isCrossModelQueriesEnabled = createSelector(
   [getIsJuju, getWSControllerURL, (state) => state],
   (isJuju, wsControllerURL, state) =>

--- a/src/store/general/types.ts
+++ b/src/store/general/types.ts
@@ -22,8 +22,9 @@ export type Credential = {
 export type Credentials = Record<string, Credential>;
 
 export type ControllerFeatures = {
-  // TODO: this feature flag can be removed once JIMM facade 4 is available on
+  // TODO: the crossModelQueries and auditLogs feature flags can be removed once JIMM facade 4 is available on
   // production JAAS.
+  auditLogs?: boolean;
   crossModelQueries?: boolean;
 };
 

--- a/src/store/middleware/model-poller.test.ts
+++ b/src/store/middleware/model-poller.test.ts
@@ -2,6 +2,7 @@ import type { Client, Connection, Transport } from "@canonical/jujulib";
 import type { AnyAction, MiddlewareAPI } from "redux";
 
 import * as jujuModule from "juju/api";
+import type { RelationshipTuple } from "juju/jimm/JIMMV4";
 import { actions as appActions, thunks as appThunks } from "store/app";
 import type { ControllerArgs } from "store/app/actions";
 import { actions as generalActions } from "store/general";
@@ -107,6 +108,9 @@ describe("model poller", () => {
     };
     const middleware = modelPollerMiddleware(fakeStore);
     await middleware(next)(action);
+    // For some reason the async functions don't finish when using fake timers, so
+    // force the test to wait for the next process:
+    await new Promise(jest.requireActual("timers").setImmediate);
     return middleware;
   };
 
@@ -197,6 +201,34 @@ describe("model poller", () => {
     );
   });
 
+  it("disables the controller features if JIMM < 4", async () => {
+    conn.facades.modelManager.listModels.mockResolvedValue({
+      "user-models": [],
+    });
+    conn.facades.jimM = {
+      checkRelation: jest.fn().mockImplementation(async () => ({
+        allowed: true,
+      })),
+      version: 3,
+    };
+    jest.spyOn(jujuModule, "loginWithBakery").mockImplementation(async () => ({
+      conn,
+      intervalId,
+      juju,
+    }));
+    await runMiddleware();
+    expect(next).not.toHaveBeenCalled();
+    expect(fakeStore.dispatch).toHaveBeenCalledWith(
+      generalActions.updateControllerFeatures({
+        wsControllerURL,
+        features: {
+          auditLogs: false,
+          crossModelQueries: false,
+        },
+      })
+    );
+  });
+
   it("updates the controller features if JIMM >= 4", async () => {
     conn.facades.modelManager.listModels.mockResolvedValue({
       "user-models": [],
@@ -225,14 +257,20 @@ describe("model poller", () => {
     );
   });
 
-  it("does not enable audit logs if the user is not an administrator", async () => {
+  it("enables audit logs if the user has audit log permissions", async () => {
     conn.facades.modelManager.listModels.mockResolvedValue({
       "user-models": [],
     });
     conn.facades.jimM = {
-      checkRelation: jest.fn().mockImplementation(async () => ({
-        allowed: false,
-      })),
+      checkRelation: jest
+        .fn()
+        .mockImplementation(async (payload: RelationshipTuple) => {
+          if (payload.relation === "audit_log_viewer") {
+            return {
+              allowed: true,
+            };
+          }
+        }),
       version: 4,
     };
     jest.spyOn(jujuModule, "loginWithBakery").mockImplementation(async () => ({
@@ -246,7 +284,46 @@ describe("model poller", () => {
       generalActions.updateControllerFeatures({
         wsControllerURL,
         features: {
-          auditLogs: false,
+          auditLogs: true,
+          crossModelQueries: true,
+        },
+      })
+    );
+  });
+
+  it("enables audit logs if the user is an administrator", async () => {
+    conn.facades.modelManager.listModels.mockResolvedValue({
+      "user-models": [],
+    });
+    conn.facades.jimM = {
+      checkRelation: jest
+        .fn()
+        .mockImplementation(async (payload: RelationshipTuple) => {
+          if (payload.relation === "audit_log_viewer") {
+            return {
+              allowed: false,
+            };
+          }
+          if (payload.relation === "administrator") {
+            return {
+              allowed: true,
+            };
+          }
+        }),
+      version: 4,
+    };
+    jest.spyOn(jujuModule, "loginWithBakery").mockImplementation(async () => ({
+      conn,
+      intervalId,
+      juju,
+    }));
+    await runMiddleware();
+    expect(next).not.toHaveBeenCalled();
+    expect(fakeStore.dispatch).toHaveBeenCalledWith(
+      generalActions.updateControllerFeatures({
+        wsControllerURL,
+        features: {
+          auditLogs: true,
           crossModelQueries: true,
         },
       })
@@ -338,9 +415,6 @@ describe("model poller", () => {
       juju,
     }));
     await runMiddleware();
-    // For some reason the listModels call doesn't resolve before the test
-    // finishes so force the test to wait for the next process:
-    await new Promise(jest.requireActual("timers").setImmediate);
     expect(next).not.toHaveBeenCalled();
     expect(fakeStore.dispatch).toHaveBeenCalledWith(
       jujuActions.updateModelList({
@@ -369,9 +443,6 @@ describe("model poller", () => {
       juju,
     }));
     await runMiddleware();
-    // For some reason the listModels call doesn't resolve before the test
-    // finishes so force the test to wait for the next process:
-    await new Promise(jest.requireActual("timers").setImmediate);
     jest.advanceTimersByTime(30000);
     // Resolve the async calls again.
     await new Promise(jest.requireActual("timers").setImmediate);
@@ -400,9 +471,6 @@ describe("model poller", () => {
       juju,
     }));
     await runMiddleware();
-    // For some reason the listModels call doesn't resolve before the test
-    // finishes so force the test to wait for the next process:
-    await new Promise(jest.requireActual("timers").setImmediate);
     jest.advanceTimersByTime(30000);
     // Resolve the async calls again.
     await new Promise(jest.requireActual("timers").setImmediate);

--- a/src/store/middleware/model-poller.ts
+++ b/src/store/middleware/model-poller.ts
@@ -12,6 +12,7 @@ import {
   setModelSharingPermissions,
 } from "juju/api";
 import type { CrossModelQueryFullResponse } from "juju/jimm/JIMMV4";
+import { JIMMRelation } from "juju/jimm/JIMMV4";
 import type { ConnectionWithFacades } from "juju/types";
 import { actions as appActions, thunks as appThunks } from "store/app";
 import { actions as generalActions } from "store/general";
@@ -125,13 +126,13 @@ export const modelPollerMiddleware: Middleware<
               auditLogsAllowed = await checkJIMMRelation(
                 conn,
                 identity,
-                "audit_log_viewer"
+                JIMMRelation.AUDIT_LOG_VIEWER
               );
               if (!auditLogsAllowed) {
                 auditLogsAllowed = await checkJIMMRelation(
                   conn,
                   identity,
-                  "administrator"
+                  JIMMRelation.ADMINISTRATOR
                 );
               }
             } catch (error) {

--- a/src/testing/factories/general.ts
+++ b/src/testing/factories/general.ts
@@ -23,6 +23,7 @@ export const credentialFactory = Factory.define<Credential>(() => ({
 
 export const controllerFeaturesFactory = Factory.define<ControllerFeatures>(
   () => ({
+    auditLogs: false,
     crossModelQueries: false,
   })
 );


### PR DESCRIPTION
## Done

- Check if user is an administrator when logging in.
- Only show audit logs link and route if the user is as an admin.

## QA

- Connect to staging.
- Load the dashboard and you should see the Logs link in the sidebar.
- Click Logs and it should show you the logs page.
- Connect to production JAAS.
- Load the dashboard and there should be no Logs link.

## Details

- https://warthogs.atlassian.net/browse/WD-5398

