### PR TITLE
WD-6700 - Fix position of panels in Safari

### DIFF
--- a/src/components/Aside/_aside.scss
+++ b/src/components/Aside/_aside.scss
@@ -10,6 +10,10 @@
   // The aside is within the main element so any long content will make the
   // aside scroll up with the page so this needs to be prevented.
   position: fixed;
+  // Fix the panel position in Safari. This is required because
+  // this element has `position: fixed` so that the panel doesn't move when
+  // scrolling the page.
+  right: 0;
 
   // Panel should appear above the side/top menus and other content.
   z-index: z("zelda") + 1 !important;


### PR DESCRIPTION
## Done

- Fix position of panels in Safari.

## QA

- Open the dashboard in Safari.
- Go to the controllers page.
- Click "Register a controller".
- The panel should appear on the right of the screen.
- Check this still works in Firefox/Chrome.

## Details

- https://warthogs.atlassian.net/browse/WD-6700
- Fixes: #1643.
