### PR TITLE
WD-7282 - fix: Display dashboard with 0 controllers

### DIFF
--- a/src/juju/api.test.ts
+++ b/src/juju/api.test.ts
@@ -766,6 +766,36 @@ describe("Juju API", () => {
       );
     });
 
+    it("can fetch controllers via JIMM with 0 controllers", async () => {
+      const dispatch = jest.fn();
+      const conn = {
+        facades: {
+          jimM: {
+            listControllers: jest.fn().mockResolvedValueOnce({
+              controllers: null,
+            }),
+          },
+        },
+      } as unknown as Connection;
+      jest
+        .spyOn(jujuLibVersions, "jujuUpdateAvailable")
+        .mockImplementationOnce(async () => true)
+        .mockImplementationOnce(async () => false);
+      await fetchControllerList(
+        "wss://example.com/api",
+        conn,
+        true,
+        dispatch,
+        () => rootStateFactory.build()
+      );
+      expect(dispatch).toHaveBeenCalledWith(
+        jujuActions.updateControllerList({
+          wsControllerURL: "wss://example.com/api",
+          controllers: [],
+        })
+      );
+    });
+
     it("can fetch the controller from Juju", async () => {
       const dispatch = jest.fn();
       const conn = {

--- a/src/juju/api.ts
+++ b/src/juju/api.ts
@@ -415,7 +415,7 @@ export async function fetchControllerList(
             ...controller,
             additionalController,
           }))
-        : null;
+        : [];
     } catch (error) {
       dispatch(
         generalActions.storeConnectionError(

--- a/src/juju/api.ts
+++ b/src/juju/api.ts
@@ -410,10 +410,12 @@ export async function fetchControllerList(
   if (conn.facades.jimM) {
     try {
       const response = await conn.facades.jimM?.listControllers();
-      controllers = response.controllers.map((controller) => ({
-        ...controller,
-        additionalController,
-      }));
+      controllers = response.controllers
+        ? response.controllers.map((controller) => ({
+            ...controller,
+            additionalController,
+          }))
+        : null;
     } catch (error) {
       dispatch(
         generalActions.storeConnectionError(

--- a/src/juju/jimm/JIMMV3.ts
+++ b/src/juju/jimm/JIMMV3.ts
@@ -93,7 +93,7 @@ class JIMMV3 {
     });
   }
 
-  listControllers(): Promise<{ controllers: ControllerInfo[] }> {
+  listControllers(): Promise<{ controllers: ControllerInfo[] | null }> {
     return new Promise((resolve, reject) => {
       const req = {
         type: "JIMM",

--- a/src/pages/ControllersIndex/ControllersIndex.tsx
+++ b/src/pages/ControllersIndex/ControllersIndex.tsx
@@ -25,7 +25,11 @@ import {
   getLoginErrors,
   getVisitURLs,
 } from "store/general/selectors";
-import { getControllerData, getModelData } from "store/juju/selectors";
+import {
+  getControllersCount,
+  getControllerData,
+  getModelData,
+} from "store/juju/selectors";
 import type { AdditionalController, Controller } from "store/juju/types";
 import { isJAASFromUUID } from "store/juju/utils/controllers";
 import { useAppSelector } from "store/store";
@@ -58,24 +62,22 @@ function Details() {
   const controllerMap: Record<string, AnnotatedController> = {};
   const additionalControllers: string[] = [];
   if (controllerData) {
-    Object.entries(controllerData).forEach(
-      ([wsControllerURL, controllers], i) => {
-        controllers.forEach((controller) => {
-          const id = "uuid" in controller ? controller.uuid : wsControllerURL;
-          if (controller.additionalController) {
-            additionalControllers.push(id);
-          }
-          controllerMap[id] = {
-            ...controller,
-            models: 0,
-            machines: 0,
-            applications: 0,
-            units: 0,
-            wsControllerURL,
-          };
-        });
-      }
-    );
+    Object.entries(controllerData).forEach(([wsControllerURL, controllers]) => {
+      controllers.forEach((controller) => {
+        const id = "uuid" in controller ? controller.uuid : wsControllerURL;
+        if (controller.additionalController) {
+          additionalControllers.push(id);
+        }
+        controllerMap[id] = {
+          ...controller,
+          models: 0,
+          machines: 0,
+          applications: 0,
+          units: 0,
+          wsControllerURL,
+        };
+      });
+    });
     if (modelData) {
       for (const modelUUID in modelData) {
         const model = modelData[modelUUID];
@@ -308,11 +310,7 @@ function Details() {
 }
 
 export default function ControllersIndex() {
-  const controllerData = useSelector(getControllerData);
-  let controllerCount = 0;
-  if (controllerData) {
-    controllerCount = Object.keys(controllerData).length;
-  }
+  const controllersCount = useSelector(getControllersCount);
   const modelData = useSelector(getModelData);
   let modelCount = 0;
   if (modelData) {
@@ -324,7 +322,7 @@ export default function ControllersIndex() {
       <Header>
         <div className="entity-details__header">
           <strong className="controllers--count">
-            {controllerCount} controllers,{" "}
+            {controllersCount} controllers,{" "}
             <Link to={urls.models.index}>{modelCount} models</Link>
           </strong>
         </div>

--- a/src/store/juju/selectors.test.ts
+++ b/src/store/juju/selectors.test.ts
@@ -87,6 +87,7 @@ import {
   getFullModelNames,
   getUsers,
   getFullModelName,
+  getControllersCount,
 } from "./selectors";
 
 describe("selectors", () => {
@@ -318,6 +319,53 @@ describe("selectors", () => {
         })
       )
     ).toStrictEqual(controllers);
+  });
+
+  describe("getControllersCount", () => {
+    it("without controllers", () => {
+      expect(
+        getControllersCount(
+          rootStateFactory.build({
+            juju: jujuStateFactory.build({
+              controllers: null,
+            }),
+          })
+        )
+      ).toStrictEqual(0);
+    });
+
+    it("with controllers", () => {
+      const controllers = {
+        "wss://example.com": [
+          controllerFactory.build({
+            path: "/",
+            uuid: "abc123",
+            version: "1",
+          }),
+          controllerFactory.build({
+            path: "/",
+            uuid: "abc123",
+            version: "2",
+          }),
+        ],
+        "wss://example2.com": [
+          controllerFactory.build({
+            path: "/",
+            uuid: "abc123",
+            version: "3",
+          }),
+        ],
+      };
+      expect(
+        getControllersCount(
+          rootStateFactory.build({
+            juju: jujuStateFactory.build({
+              controllers,
+            }),
+          })
+        )
+      ).toStrictEqual(3);
+    });
   });
 
   it("getModelWatcherDataByUUID", () => {

--- a/src/store/juju/selectors.ts
+++ b/src/store/juju/selectors.ts
@@ -187,8 +187,8 @@ export const getControllerData = createSelector(
 export const getControllersCount = createSelector([slice], (sliceState) => {
   const controllerData = sliceState.controllers;
   return controllerData
-    ? Object.entries(controllerData).reduce(
-        (count, [, controllers]) => count + controllers.length,
+    ? Object.values(controllerData).reduce(
+        (count, controllers) => count + controllers.length,
         0
       )
     : 0;

--- a/src/store/juju/selectors.ts
+++ b/src/store/juju/selectors.ts
@@ -184,6 +184,16 @@ export const getControllerData = createSelector(
   (sliceState) => sliceState.controllers
 );
 
+export const getControllersCount = createSelector([slice], (sliceState) => {
+  const controllerData = sliceState.controllers;
+  return controllerData
+    ? Object.entries(controllerData).reduce(
+        (count, [, controllers]) => count + controllers.length,
+        0
+      )
+    : 0;
+});
+
 const getModelWatcherData = createSelector(
   [slice],
   (sliceState) => sliceState.modelWatcherData


### PR DESCRIPTION
## Done

- Display dashboard as usual instead of error message when there are 0 controllers.

## QA

- Login with a user that has 0 controllers.
- Check that the dashboard loads as usual instead of a `Notification` component with an error message being displayed on the whole page.

## Details

- https://warthogs.atlassian.net/browse/WD-7282
- Fixes: https://github.com/canonical/juju-dashboard/issues/1652
