### PR TITLE
WD-7495 - Make model tables responsive

### DIFF
--- a/src/components/ModelTableList/CloudGroup.test.tsx
+++ b/src/components/ModelTableList/CloudGroup.test.tsx
@@ -84,7 +84,7 @@ describe("CloudGroup", () => {
     expect(within(tables[0]).getAllByRole("row")).toHaveLength(3);
   });
 
-  it("model access buttons are present in cloud group", () => {
+  it("model access button is present in cloud group", () => {
     state.general = generalStateFactory.build({
       config: configFactory.build({
         controllerAPIEndpoint: "wss://jimm.jujucharms.com/api",
@@ -115,13 +115,11 @@ describe("CloudGroup", () => {
     };
     renderComponent(<CloudGroup filters={filters} />, { state });
     const firstContentRow = screen.getAllByRole("row")[1];
-    const modelAccessButton = within(firstContentRow).getAllByRole("button", {
-      name: "Access",
-    });
-    expect(modelAccessButton.length).toBe(2);
-    expect(within(firstContentRow).getAllByRole("gridcell")[8]).toHaveClass(
-      "sm-screen-access-cell"
-    );
+    expect(
+      within(firstContentRow).getByRole("button", {
+        name: "Access",
+      })
+    ).toBeInTheDocument();
     expect(within(firstContentRow).getAllByRole("gridcell")[7]).toHaveClass(
       "lrg-screen-access-cell"
     );

--- a/src/components/ModelTableList/CloudGroup.tsx
+++ b/src/components/ModelTableList/CloudGroup.tsx
@@ -5,6 +5,7 @@ import { useSelector } from "react-redux";
 
 import ModelDetailsLink from "components/ModelDetailsLink";
 import Status from "components/Status";
+import TruncatedTooltip from "components/TruncatedTooltip";
 import { useQueryParams } from "hooks/useQueryParams";
 import {
   getActiveUsers,
@@ -68,12 +69,14 @@ export default function CloudGroup({ filters }: Props) {
           {
             "data-testid": "column-name",
             content: model.info ? (
-              <ModelDetailsLink
-                modelName={model.info.name}
-                ownerTag={model.info?.["owner-tag"]}
-              >
-                {model.info.name}
-              </ModelDetailsLink>
+              <TruncatedTooltip message={model.info.name}>
+                <ModelDetailsLink
+                  modelName={model.info.name}
+                  ownerTag={model.info?.["owner-tag"]}
+                >
+                  {model.info.name}
+                </ModelDetailsLink>
+              </TruncatedTooltip>
             ) : null,
           },
           {
@@ -88,7 +91,9 @@ export default function CloudGroup({ filters }: Props) {
           },
           {
             "data-testid": "column-owner",
-            content: owner,
+            content: (
+              <TruncatedTooltip message={owner}>{owner}</TruncatedTooltip>
+            ),
           },
           {
             "data-testid": "column-status",
@@ -97,15 +102,25 @@ export default function CloudGroup({ filters }: Props) {
           },
           {
             "data-testid": "column-region",
-            content: region,
+            content: (
+              <TruncatedTooltip message={region}>{region}</TruncatedTooltip>
+            ),
           },
           {
             "data-testid": "column-credential",
-            content: credential,
+            content: (
+              <TruncatedTooltip message={credential}>
+                {credential}
+              </TruncatedTooltip>
+            ),
           },
           {
             "data-testid": "column-controller",
-            content: controller,
+            content: (
+              <TruncatedTooltip message={controller}>
+                {controller}
+              </TruncatedTooltip>
+            ),
           },
           // We're not currently able to get a last-accessed or updated from JAAS.
           {
@@ -128,21 +143,6 @@ export default function CloudGroup({ filters }: Props) {
                 ? "has-permission"
                 : ""
             }`,
-          },
-          {
-            content: (
-              <>
-                {model?.info
-                  ? canAdministerModel(activeUser, model.info.users) && (
-                      <AccessButton
-                        setPanelQs={setPanelQs}
-                        modelName={model.info.name}
-                      />
-                    )
-                  : null}
-              </>
-            ),
-            className: "sm-screen-access-cell",
           },
         ],
         sortData: {
@@ -171,10 +171,7 @@ export default function CloudGroup({ filters }: Props) {
     );
   }
   return (
-    <div
-      className="cloud-group u-overflow--auto"
-      data-testid={TestId.CLOUD_GROUP}
-    >
+    <div className="cloud-group" data-testid={TestId.CLOUD_GROUP}>
       {cloudTables}
     </div>
   );

--- a/src/components/ModelTableList/OwnerGroup.test.tsx
+++ b/src/components/ModelTableList/OwnerGroup.test.tsx
@@ -85,7 +85,7 @@ describe("OwnerGroup", () => {
     expect(screen.getAllByRole("row").length).toBe(4);
   });
 
-  it("model access buttons are present in owners group", () => {
+  it("model access button is present in owners group", () => {
     state.general = generalStateFactory.build({
       config: configFactory.build({
         controllerAPIEndpoint: "wss://jimm.jujucharms.com/api",
@@ -116,13 +116,11 @@ describe("OwnerGroup", () => {
     };
     renderComponent(<OwnerGroup filters={filters} />, { state });
     const firstContentRow = screen.getAllByRole("row")[1];
-    const modelAccessButton = within(firstContentRow).getAllByRole("button", {
-      name: "Access",
-    });
-    expect(modelAccessButton.length).toBe(2);
-    expect(within(firstContentRow).getAllByRole("gridcell")[7]).toHaveClass(
-      "sm-screen-access-cell"
-    );
+    expect(
+      within(firstContentRow).getByRole("button", {
+        name: "Access",
+      })
+    ).toBeInTheDocument();
     expect(within(firstContentRow).getAllByRole("gridcell")[6]).toHaveClass(
       "lrg-screen-access-cell"
     );

--- a/src/components/ModelTableList/OwnerGroup.tsx
+++ b/src/components/ModelTableList/OwnerGroup.tsx
@@ -64,12 +64,14 @@ export default function OwnerGroup({ filters }: Props) {
           {
             "data-testid": "column-name",
             content: model.info ? (
-              <ModelDetailsLink
-                modelName={model.info.name}
-                ownerTag={model.info?.["owner-tag"]}
-              >
-                {model.info.name}
-              </ModelDetailsLink>
+              <TruncatedTooltip message={model.info.name}>
+                <ModelDetailsLink
+                  modelName={model.info.name}
+                  ownerTag={model.info?.["owner-tag"]}
+                >
+                  {model.info.name}
+                </ModelDetailsLink>
+              </TruncatedTooltip>
             ) : null,
           },
           {
@@ -97,11 +99,19 @@ export default function OwnerGroup({ filters }: Props) {
           },
           {
             "data-testid": "column-credential",
-            content: credential,
+            content: (
+              <TruncatedTooltip message={credential}>
+                {credential}
+              </TruncatedTooltip>
+            ),
           },
           {
             "data-testid": "column-controller",
-            content: controller,
+            content: (
+              <TruncatedTooltip message={controller}>
+                {controller}
+              </TruncatedTooltip>
+            ),
           },
           {
             "data-testid": "column-updated",
@@ -123,21 +133,6 @@ export default function OwnerGroup({ filters }: Props) {
                 ? "has-permission"
                 : ""
             }`,
-          },
-          {
-            content: (
-              <>
-                {model.info
-                  ? canAdministerModel(activeUser, model?.info?.users) && (
-                      <AccessButton
-                        setPanelQs={setPanelQs}
-                        modelName={model.info.name}
-                      />
-                    )
-                  : null}
-              </>
-            ),
-            className: "sm-screen-access-cell",
           },
         ],
         sortData: {
@@ -166,10 +161,7 @@ export default function OwnerGroup({ filters }: Props) {
     );
   }
   return (
-    <div
-      className="owners-group u-overflow--auto"
-      data-testid={TestId.OWNER_GROUP}
-    >
+    <div className="owners-group" data-testid={TestId.OWNER_GROUP}>
       {ownerTables}
     </div>
   );

--- a/src/components/ModelTableList/StatusGroup.test.tsx
+++ b/src/components/ModelTableList/StatusGroup.test.tsx
@@ -123,7 +123,7 @@ describe("StatusGroup", () => {
     );
   });
 
-  it("model access buttons are present in status group", () => {
+  it("model access button is present in status group", () => {
     state.general = generalStateFactory.build({
       config: configFactory.build({
         controllerAPIEndpoint: "wss://jimm.jujucharms.com/api",
@@ -154,13 +154,11 @@ describe("StatusGroup", () => {
     };
     renderComponent(<StatusGroup filters={filters} />, { state });
     const firstContentRow = screen.getAllByRole("row")[1];
-    const modelAccessButton = within(firstContentRow).getAllByRole("button", {
-      name: "Access",
-    });
-    expect(modelAccessButton.length).toBe(2);
-    expect(within(firstContentRow).getAllByRole("gridcell")[7]).toHaveClass(
-      "sm-screen-access-cell"
-    );
+    expect(
+      within(firstContentRow).getByRole("button", {
+        name: "Access",
+      })
+    ).toBeInTheDocument();
     expect(within(firstContentRow).getAllByRole("gridcell")[6]).toHaveClass(
       "lrg-screen-access-cell"
     );

--- a/src/components/ModelTableList/StatusGroup.tsx
+++ b/src/components/ModelTableList/StatusGroup.tsx
@@ -102,14 +102,14 @@ const generateWarningMessage = (model: ModelData) => {
 const generateModelNameCell = (model: ModelData, groupLabel: string) => {
   return (
     <>
-      <div>
+      <TruncatedTooltip message={model.model.name}>
         <ModelDetailsLink
           modelName={model.model.name}
           ownerTag={model.info?.["owner-tag"]}
         >
           {model.model.name}
         </ModelDetailsLink>
-      </div>
+      </TruncatedTooltip>
       {groupLabel === "blocked" ? generateWarningMessage(model) : null}
     </>
   );
@@ -164,7 +164,9 @@ function generateModelTableDataByStatus(
           },
           {
             "data-testid": "column-owner",
-            content: <>{owner}</>,
+            content: (
+              <TruncatedTooltip message={owner}>{owner}</TruncatedTooltip>
+            ),
           },
           {
             "data-testid": "column-cloud",
@@ -176,11 +178,19 @@ function generateModelTableDataByStatus(
           },
           {
             "data-testid": "column-credential",
-            content: credential,
+            content: (
+              <TruncatedTooltip message={credential}>
+                {credential}
+              </TruncatedTooltip>
+            ),
           },
           {
             "data-testid": "column-controller",
-            content: controller,
+            content: (
+              <TruncatedTooltip message={controller}>
+                {controller}
+              </TruncatedTooltip>
+            ),
           },
           // We're not currently able to get a last-accessed or updated from JAAS.
           {
@@ -201,19 +211,6 @@ function generateModelTableDataByStatus(
                 ? "has-permission"
                 : ""
             }`,
-          },
-          {
-            content: (
-              <>
-                {canAdministerModel(activeUser, model?.info?.users) && (
-                  <AccessButton
-                    setPanelQs={setPanelQs}
-                    modelName={model.model.name}
-                  />
-                )}
-              </>
-            ),
-            className: "sm-screen-access-cell",
           },
         ],
         sortData: {
@@ -254,15 +251,13 @@ export default function StatusGroup({ filters }: { filters: Filters }) {
   const emptyStateMsg = "There are no models with this status";
 
   return (
-    <div
-      className="status-group u-overflow--auto"
-      data-testid={TestId.STATUS_GROUP}
-    >
+    <div className="status-group" data-testid={TestId.STATUS_GROUP}>
       {blockedRows.length ? (
         <MainTable
           headers={generateTableHeaders("Blocked", blockedRows.length, {
             showCloud: true,
             showOwner: true,
+            showHeaderStatus: true,
           })}
           rows={blockedRows}
           sortable

--- a/src/components/ModelTableList/_model-table-list.scss
+++ b/src/components/ModelTableList/_model-table-list.scss
@@ -16,12 +16,6 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-
-    @media (max-width: $breakpoint-large) {
-      display: inline-block;
-      max-width: 200px;
-      padding-right: 1rem;
-    }
   }
 }
 
@@ -34,7 +28,6 @@
     width: 100%;
   }
 
-  .sm-screen-access-cell,
   .lrg-screen-access-cell {
     button {
       margin-left: auto;
@@ -44,19 +37,7 @@
     }
   }
 
-  // model row hover on large screens
-  @include mobile {
-    .sm-screen-access-cell .model-access {
-      display: block;
-    }
-  }
-
   @include desktop {
-    .sm-screen-access-cell,
-    .sm-screen-access-header {
-      display: none;
-    }
-
     tr:hover {
       .model-access {
         display: block;
@@ -67,6 +48,85 @@
 
       .has-permission .model-access-alt {
         display: none;
+      }
+    }
+  }
+
+  .status-group {
+    td,
+    th {
+      @include mobile-and-medium {
+        // Credential
+        &:nth-child(5),
+        // Controller
+        &:nth-child(6) {
+          display: none;
+        }
+      }
+
+      @include mobile {
+        // Summary icons
+        &:nth-child(2) {
+          display: none;
+        }
+        // Last updated
+        &:nth-child(7) {
+          display: none;
+        }
+      }
+    }
+  }
+
+  .owners-group {
+    td,
+    th {
+      @include mobile-and-medium {
+        // Credential
+        &:nth-child(5),
+        // Controller
+        &:nth-child(6) {
+          display: none;
+        }
+      }
+
+      @include mobile {
+        // Summary icons
+        &:nth-child(2) {
+          display: none;
+        }
+        // Last updated
+        &:nth-child(7) {
+          display: none;
+        }
+      }
+    }
+  }
+
+  .cloud-group {
+    td,
+    th {
+      @include mobile-and-medium {
+        // Credential
+        &:nth-child(6),
+        // Controller
+        &:nth-child(7) {
+          display: none;
+        }
+      }
+
+      @include mobile {
+        // Summary icons
+        &:nth-child(2) {
+          display: none;
+        }
+        // Status
+        &:nth-child(4) {
+          display: none;
+        }
+        // Last updated
+        &:nth-child(8) {
+          display: none;
+        }
       }
     }
   }

--- a/src/components/ModelTableList/_model-table-list.scss
+++ b/src/components/ModelTableList/_model-table-list.scss
@@ -66,9 +66,7 @@
 
       @include mobile {
         // Summary icons
-        &:nth-child(2) {
-          display: none;
-        }
+        &:nth-child(2),
         // Last updated
         &:nth-child(7) {
           display: none;
@@ -91,9 +89,7 @@
 
       @include mobile {
         // Summary icons
-        &:nth-child(2) {
-          display: none;
-        }
+        &:nth-child(2),
         // Last updated
         &:nth-child(7) {
           display: none;
@@ -116,13 +112,9 @@
 
       @include mobile {
         // Summary icons
-        &:nth-child(2) {
-          display: none;
-        }
+        &:nth-child(2),
         // Status
-        &:nth-child(4) {
-          display: none;
-        }
+        &:nth-child(4),
         // Last updated
         &:nth-child(8) {
           display: none;

--- a/src/components/ModelTableList/shared.test.tsx
+++ b/src/components/ModelTableList/shared.test.tsx
@@ -151,13 +151,13 @@ describe("shared", () => {
   describe("generateTableHeaders", () => {
     it("can display an owner column", () => {
       const headers = generateTableHeaders("status", 5, { showOwner: true });
-      expect(headers).toHaveLength(8);
+      expect(headers).toHaveLength(7);
       expect(headers[2].content).toBe("Owner");
     });
 
     it("can display a status column", () => {
       const headers = generateTableHeaders("status", 5, { showStatus: true });
-      expect(headers).toHaveLength(8);
+      expect(headers).toHaveLength(7);
       expect(headers[2].content).toBe("Status");
     });
 
@@ -166,7 +166,7 @@ describe("shared", () => {
         showOwner: true,
         showStatus: true,
       });
-      expect(headers).toHaveLength(9);
+      expect(headers).toHaveLength(8);
       expect(headers[2].content).toBe("Owner");
       expect(headers[3].content).toBe("Status");
     });

--- a/src/components/ModelTableList/shared.tsx
+++ b/src/components/ModelTableList/shared.tsx
@@ -60,6 +60,7 @@ export type TableHeaderOptions = {
   showCloud?: boolean;
   showOwner?: boolean;
   showStatus?: boolean;
+  showHeaderStatus?: boolean;
 };
 
 /**
@@ -75,7 +76,11 @@ export const generateTableHeaders = (
 ) => {
   const rows = [
     {
-      content: <Status status={label} count={count} />,
+      content: options?.showHeaderStatus ? (
+        <Status status={label} count={count} />
+      ) : (
+        `${label} (${count})`
+      ),
       sortKey: "name",
     },
     { content: "", sortKey: "summary" }, // The unit/machines/apps counts
@@ -90,11 +95,6 @@ export const generateTableHeaders = (
       content: "Last Updated",
       sortKey: "lastUpdated",
       className: "u-align--right",
-    },
-    {
-      content: "",
-      sortKey: "",
-      className: "sm-screen-access-header",
     },
   ];
   // Remove any null headers that aren't being shown.

--- a/src/pages/ControllersIndex/ControllersIndex.tsx
+++ b/src/pages/ControllersIndex/ControllersIndex.tsx
@@ -306,7 +306,7 @@ function Details() {
         </div>
       </div>
       <ControllersOverview />
-      <div className="l-controllers-table u-overflow--auto">
+      <div className="l-controllers-table">
         {rows.length > 0 && (
           <>
             <h5 className="u-hide--large">{Label.DEFAULT}</h5>

--- a/src/pages/EntityDetails/App/App.tsx
+++ b/src/pages/EntityDetails/App/App.tsx
@@ -302,7 +302,7 @@ export default function App(): JSX.Element {
         ) : null}
         <EntityInfo data={appEntityData} />
       </div>
-      <div className="entity-details__main u-overflow--auto">
+      <div className="entity-details__main">
         {!hideMachines && (
           <SegmentedControl
             buttons={["Units", "Machines"].map((tab) => ({

--- a/src/pages/EntityDetails/Machine/Machine.tsx
+++ b/src/pages/EntityDetails/Machine/Machine.tsx
@@ -100,7 +100,7 @@ export default function Machine() {
         <InfoPanel />
         <EntityInfo data={MachineEntityData} />
       </div>
-      <div className="entity-details__main u-overflow--auto">
+      <div className="entity-details__main">
         <div>
           <div className="entity-detail__tables">
             <MainTable

--- a/src/pages/EntityDetails/Model/Model.tsx
+++ b/src/pages/EntityDetails/Model/Model.tsx
@@ -18,6 +18,7 @@ import {
   getModelUnits,
   getModelUUIDFromList,
 } from "store/juju/selectors";
+import { getModelCredential } from "store/juju/selectors";
 import { extractCloudName } from "store/juju/utils/models";
 import { useAppSelector } from "store/store";
 import {
@@ -117,6 +118,9 @@ const Model = () => {
   );
 
   const modelInfoData = useSelector(getModelInfo(modelUUID));
+  const credential = useAppSelector((state) =>
+    getModelCredential(state, modelUUID)
+  );
   const modelAccess = useAppSelector((state) =>
     getModelAccess(state, modelUUID)
   );
@@ -148,13 +152,15 @@ const Model = () => {
                 modelInfoData["cloud"],
                 modelInfoData["cloud-region"]
               ),
+              owner: modelInfoData.owner,
+              credential,
               version: modelInfoData.version,
               sla: modelInfoData.sla?.level,
             }}
           />
         )}
       </div>
-      <div className="entity-details__main u-overflow--auto">
+      <div className="entity-details__main">
         {shouldShow("apps", query.activeView) && <ApplicationsTab />}
         {shouldShow("machines", query.activeView) &&
           (machinesTableRows.length > 0 ? (

--- a/src/pages/EntityDetails/Unit/Unit.tsx
+++ b/src/pages/EntityDetails/Unit/Unit.tsx
@@ -101,7 +101,7 @@ export default function Unit() {
         <InfoPanel />
         <EntityInfo data={unitEntityData} />
       </div>
-      <div className="entity-details__main u-overflow--auto">
+      <div className="entity-details__main">
         <div className="slide-panel__tables">
           {modelData?.type !== "kubernetes" && (
             <MainTable

--- a/src/pages/Logs/Logs.tsx
+++ b/src/pages/Logs/Logs.tsx
@@ -8,9 +8,7 @@ const Logs = (): JSX.Element => (
     <ActionBar>
       <AuditLogsTableActions />
     </ActionBar>
-    <div className="u-overflow--auto">
-      <AuditLogsTable />
-    </div>
+    <AuditLogsTable />
   </BaseLayout>
 );
 

--- a/src/store/juju/selectors.test.ts
+++ b/src/store/juju/selectors.test.ts
@@ -88,6 +88,7 @@ import {
   getUsers,
   getFullModelName,
   getControllersCount,
+  getModelCredential,
 } from "./selectors";
 
 describe("selectors", () => {
@@ -1136,6 +1137,42 @@ describe("selectors", () => {
         "abc123"
       )
     ).toBe("superuser");
+  });
+
+  it("getModelCredential", () => {
+    expect(
+      getModelCredential(
+        rootStateFactory.build({
+          general: generalStateFactory.build({
+            controllerConnections: {
+              "wss://example.com/api": {
+                user: {
+                  "display-name": "eggman",
+                  identity: "user-eggman@external",
+                  "controller-access": "superuser",
+                  "model-access": "",
+                },
+              },
+            },
+          }),
+          juju: jujuStateFactory.build({
+            modelData: {
+              abc123: modelDataFactory.build({
+                info: modelDataInfoFactory.build({
+                  "cloud-credential-tag": "cloudcred-google_eggman_juju",
+                }),
+              }),
+            },
+            models: {
+              abc123: modelListInfoFactory.build({
+                wsControllerURL: "wss://example.com/api",
+              }),
+            },
+          }),
+        }),
+        "abc123"
+      )
+    ).toBe("eggman");
   });
 
   it("getModelControllerDataByUUID", () => {

--- a/src/store/juju/selectors.ts
+++ b/src/store/juju/selectors.ts
@@ -354,6 +354,11 @@ export const getActiveUser = createSelector(
   }
 );
 
+export const getModelCredential = createSelector(
+  [getModelDataByUUID],
+  (model) => extractCredentialName(model?.info?.["cloud-credential-tag"])
+);
+
 export const getModelAccess = createSelector(
   [
     getModelByUUID,


### PR DESCRIPTION
## Done

- Update the model status, owner and cloud tables to be responsive.

## QA

- Go to models.
- Switch between the Status, Cloud and Owner tables and make sure that the tables look OK at each 

## Details

- https://warthogs.atlassian.net/browse/WD-7495
- https://warthogs.atlassian.net/browse/WD-7496
- https://warthogs.atlassian.net/browse/WD-7497

## Screenshots

<img width="1510" alt="Screenshot 2023-11-27 at 3 16 21 pm" src="https://github.com/canonical/juju-dashboard/assets/361637/564f985a-0f34-4017-b4cf-54d09d92f08a">
<img width="832" alt="Screenshot 2023-11-27 at 3 16 44 pm" src="https://github.com/canonical/juju-dashboard/assets/361637/42c44c1b-1faa-41b2-b153-04b952bfd27a">
<img width="388" alt="Screenshot 2023-11-27 at 3 16 57 pm" src="https://github.com/canonical/juju-dashboard/assets/361637/83e8d262-ace6-4d70-9f41-7af7cf6df8bd">



