### PR TITLE
WD-7607 - fix: Specify cloud info for JIMM controllers

### DIFF
--- a/src/pages/ControllersIndex/ControllersIndex.test.tsx
+++ b/src/pages/ControllersIndex/ControllersIndex.test.tsx
@@ -77,7 +77,7 @@ describe("Controllers table", () => {
     );
   });
 
-  it("displays additional controllers from JIMM with correct cloud data", () => {
+  it("displays additional controllers from JIMM", () => {
     state.general.controllerConnections = {
       "wss://jimm.jujucharms.com/api": connectionInfoFactory.build(),
     };
@@ -85,11 +85,7 @@ describe("Controllers table", () => {
       controllers: {
         "wss://jimm.jujucharms.com/api": [
           controllerFactory.build(),
-          controllerInfoFactory.build({
-            additionalController: true,
-            "cloud-tag": "US",
-            "cloud-region": "East",
-          }),
+          controllerInfoFactory.build({ additionalController: true }),
         ],
       },
     });
@@ -102,7 +98,7 @@ describe("Controllers table", () => {
       [
         "controller1",
         "Connected",
-        "US/East",
+        "unknown/unknown",
         "0",
         "0",
         "0",
@@ -287,5 +283,70 @@ describe("Controllers table", () => {
     expect(
       screen.getByRole("link", { name: "Authenticate" })
     ).toBeInTheDocument();
+  });
+
+  it("displays correct cloud data for Juju controller", () => {
+    state.general.controllerConnections = {
+      "wss://jimm.jujucharms.com/api": connectionInfoFactory.build(),
+    };
+    state.juju = jujuStateFactory.build({
+      controllers: {
+        "wss://jimm.jujucharms.com/api": [
+          controllerFactory.build({
+            location: { cloud: "cloud-aws", region: "eu-central-1" },
+          }),
+        ],
+      },
+    });
+    renderComponent(<ControllersIndex />, { state });
+    const tables = screen.getAllByRole("grid");
+    const controllerRows = within(tables[0]).getAllByRole("row");
+    expect(controllerRows).toHaveLength(2);
+    expect(controllerRows[1]).toHaveTextContent(
+      [
+        "admin/jaas",
+        "Connected",
+        "cloud-aws/eu-central-1",
+        "0",
+        "0",
+        "0",
+        "0",
+        "1.2.3 ",
+        "Private",
+      ].join("")
+    );
+  });
+
+  it("displays correct cloud data for JIMM enabled controller", () => {
+    state.general.controllerConnections = {
+      "wss://jimm.jujucharms.com/api": connectionInfoFactory.build(),
+    };
+    state.juju = jujuStateFactory.build({
+      controllers: {
+        "wss://jimm.jujucharms.com/api": [
+          controllerInfoFactory.build({
+            "cloud-tag": "cloud-aws",
+            "cloud-region": "eu-central-1",
+          }),
+        ],
+      },
+    });
+    renderComponent(<ControllersIndex />, { state });
+    const tables = screen.getAllByRole("grid");
+    const controllerRows = within(tables[0]).getAllByRole("row");
+    expect(controllerRows).toHaveLength(2);
+    expect(controllerRows[1]).toHaveTextContent(
+      [
+        "controller1",
+        "Connected",
+        "cloud-aws/eu-central-1",
+        "0",
+        "0",
+        "0",
+        "0",
+        "1.2.3 ",
+        "Private",
+      ].join("")
+    );
   });
 });

--- a/src/pages/ControllersIndex/ControllersIndex.test.tsx
+++ b/src/pages/ControllersIndex/ControllersIndex.test.tsx
@@ -299,8 +299,7 @@ describe("Controllers table", () => {
         "0",
         "0",
         "0",
-        "1.2.3 ",
-        "Private",
+        "1.2.3",
       ].join("")
     );
   });
@@ -332,8 +331,7 @@ describe("Controllers table", () => {
         "0",
         "0",
         "0",
-        "1.2.3 ",
-        "Private",
+        "1.2.3",
       ].join("")
     );
   });

--- a/src/pages/ControllersIndex/ControllersIndex.test.tsx
+++ b/src/pages/ControllersIndex/ControllersIndex.test.tsx
@@ -77,7 +77,7 @@ describe("Controllers table", () => {
     );
   });
 
-  it("displays additional controllers from JIMM", () => {
+  it("displays additional controllers from JIMM with correct cloud data", () => {
     state.general.controllerConnections = {
       "wss://jimm.jujucharms.com/api": connectionInfoFactory.build(),
     };
@@ -85,7 +85,11 @@ describe("Controllers table", () => {
       controllers: {
         "wss://jimm.jujucharms.com/api": [
           controllerFactory.build(),
-          controllerInfoFactory.build({ additionalController: true }),
+          controllerInfoFactory.build({
+            additionalController: true,
+            "cloud-tag": "US",
+            "cloud-region": "East",
+          }),
         ],
       },
     });
@@ -98,7 +102,7 @@ describe("Controllers table", () => {
       [
         "controller1",
         "Connected",
-        "unknown/unknown",
+        "US/East",
         "0",
         "0",
         "0",

--- a/src/pages/ControllersIndex/ControllersIndex.tsx
+++ b/src/pages/ControllersIndex/ControllersIndex.tsx
@@ -178,10 +178,18 @@ function Details() {
 
   function generateRow(c: AnnotatedController, authenticated: boolean) {
     const isJAAS = isJAASFromUUID(c);
-    const cloud =
-      "location" in c && c?.location?.cloud ? c.location.cloud : "unknown";
-    const region =
-      "location" in c && c?.location?.region ? c.location.region : "unknown";
+    let cloud = "unknown";
+    if ("cloud-tag" in c && c["cloud-tag"]) {
+      cloud = c["cloud-tag"];
+    } else if ("location" in c && c.location?.cloud) {
+      cloud = c.location.cloud;
+    }
+    let region = "unknown";
+    if ("cloud-region" in c && c["cloud-region"]) {
+      region = c["cloud-region"];
+    } else if ("location" in c && c.location?.region) {
+      region = c.location.region;
+    }
     const cloudRegion = `${cloud}/${region}`;
     const access = ("Public" in c && c.Public) || isJAAS ? "Public" : "Private";
     const loginError = loginErrors?.[c.wsControllerURL];


### PR DESCRIPTION
## Done

- Specify cloud info for JIMM controllers

## QA

- Verify that, in the controllers table, JIMM enabled controllers have actual `CLOUD/REGION` info, instead of `unknown/unknown`.

## Details

- https://warthogs.atlassian.net/browse/WD-7607
