### PR TITLE
WD-7494 - Make action logs table responsive

### DIFF
--- a/src/components/Status/Status.test.tsx
+++ b/src/components/Status/Status.test.tsx
@@ -25,6 +25,12 @@ describe("Status", () => {
     expect(status).toHaveClass("is-middle");
   });
 
+  it("can be inline", () => {
+    render(<Status status="middle" inline />);
+    const status = screen.getByText("middle");
+    expect(status).toHaveClass("status-icon--inline");
+  });
+
   it("can display a count", () => {
     render(<Status status="middle" count={23} />);
     expect(screen.getByText(/(23)/)).toBeInTheDocument();

--- a/src/components/Status/Status.tsx
+++ b/src/components/Status/Status.tsx
@@ -5,6 +5,7 @@ import type { PropsWithChildren } from "react";
 type Props = {
   status?: string;
   count?: number | null;
+  inline?: boolean;
   useIcon?: boolean;
   actionsLogs?: boolean;
   className?: string | null;
@@ -14,6 +15,7 @@ const Status = ({
   status = "unknown",
   children,
   count,
+  inline,
   useIcon = true,
   actionsLogs = false,
   className = null,
@@ -27,6 +29,7 @@ const Status = ({
     <span
       className={classNames(className, {
         "status-icon": useIcon,
+        "status-icon--inline": inline,
         [`is-${status.toLowerCase()}`]: useIcon && status,
       })}
     >

--- a/src/pages/EntityDetails/Model/Logs/ActionLogs/ActionLogs.test.tsx
+++ b/src/pages/EntityDetails/Model/Logs/ActionLogs/ActionLogs.test.tsx
@@ -283,6 +283,23 @@ describe("Action Logs", () => {
     expect(within(rows[2]).getByText("error message")).toBeInTheDocument();
   });
 
+  it("does not display a toggle when there is neither STOUT or STDERR", async () => {
+    const mockActionResults = actionResultsFactory.build({
+      results: [
+        actionResultFactory.build({
+          log: undefined,
+          status: "completed",
+        }),
+      ],
+    });
+    jest.spyOn(juju, "queryActionsList").mockResolvedValue(mockActionResults);
+    renderComponent(<ActionLogs />, { path, url, state });
+    const rows = await screen.findAllByRole("row");
+    expect(
+      within(rows[2]).queryByRole("button", { name: Label.OUTPUT })
+    ).not.toBeInTheDocument();
+  });
+
   it("only shows the action result button when there is a result", async () => {
     renderComponent(<ActionLogs />, { path, url, state });
     const showOutputBtns = await screen.findAllByTestId("show-output");

--- a/src/pages/EntityDetails/Model/Logs/ActionLogs/ActionLogs.test.tsx
+++ b/src/pages/EntityDetails/Model/Logs/ActionLogs/ActionLogs.test.tsx
@@ -144,25 +144,14 @@ describe("Action Logs", () => {
   it("requests the action logs data on load", async () => {
     renderComponent(<ActionLogs />, { path, url, state });
     const expected = [
-      ["easyrsa", "1/list-disks", "completed", "", "", "", ""],
-      [
-        "└easyrsa/0",
-        "",
-        "completed",
-        "2",
-        "log message 1",
-        "over 1 year ago",
-        "Output",
-        "Result",
-      ],
+      ["easyrsa", "1/list-disks", "completed", "", ""],
+      ["└easyrsa/0", "2", "completed", "log message 1", "over 1 year ago"],
       [
         "└easyrsa/1",
-        "",
-        "completed",
         "3",
+        "completed",
         "log message 1log message 2error message",
         "over 1 year ago",
-        "Output",
       ],
     ];
     const rows = await screen.findAllByRole("row");
@@ -175,25 +164,14 @@ describe("Action Logs", () => {
   it("fails gracefully if app does not exist in model data", async () => {
     renderComponent(<ActionLogs />, { path, url, state });
     const expected = [
-      ["easyrsa", "1/list-disks", "completed", "", "", "", ""],
-      [
-        "└easyrsa/0",
-        "",
-        "completed",
-        "2",
-        "log message 1",
-        "over 1 year ago",
-        "Output",
-        "Result",
-      ],
+      ["easyrsa", "1/list-disks", "completed", "", ""],
+      ["└easyrsa/0", "2", "completed", "log message 1", "over 1 year ago"],
       [
         "└easyrsa/1",
-        "",
-        "completed",
         "3",
+        "completed",
         "log message 1log message 2error message",
         "over 1 year ago",
-        "Output",
       ],
     ];
     const rows = await screen.findAllByRole("row");
@@ -236,23 +214,12 @@ describe("Action Logs", () => {
     const expected = [
       [
         "└easyrsa/1",
-        "",
-        "completed",
         "3",
+        "completed",
         "log message 1log message 2error message",
         "1 day ago",
-        "Output",
       ],
-      [
-        "└easyrsa/0",
-        "",
-        "completed",
-        "2",
-        "log message 1",
-        "over 1 year ago",
-        "Output",
-        "Result",
-      ],
+      ["└easyrsa/0", "2", "completed", "log message 1", "over 1 year ago"],
     ];
     const tableBody = await screen.findAllByRole("rowgroup");
     const rows = await within(tableBody[1]).findAllByRole("row");
@@ -283,15 +250,7 @@ describe("Action Logs", () => {
     renderComponent(<ActionLogs />, { path, url, state });
     const expected = [
       ["easyrsa", "1/list-disks", "completed", "", "", "", ""],
-      [
-        "└easyrsa/0",
-        "",
-        "completed",
-        "2",
-        "log message 1",
-        "Unknown",
-        "Output",
-      ],
+      ["└easyrsa/0", "2", "completed", "log message 1", "Unknown"],
     ];
     const rows = await screen.findAllByRole("row");
     // Start at row 1 because row 0 is the header row.

--- a/src/pages/EntityDetails/Model/Logs/ActionLogs/_action-logs.scss
+++ b/src/pages/EntityDetails/Model/Logs/ActionLogs/_action-logs.scss
@@ -6,13 +6,13 @@
   .entity-details__action-logs {
     td,
     th {
-      // Completion time column.
+      // Completion time.
       &:nth-child(5) {
         width: 15%;
       }
 
       @include mobile-and-medium {
-        // Completion time column.
+        // Completion time.
         &:nth-child(5) {
           display: none;
         }
@@ -24,7 +24,7 @@
           width: 25%;
         }
 
-        // log messages column
+        // Log messages.
         &:nth-child(4) {
           display: none;
         }

--- a/src/pages/EntityDetails/Model/Logs/ActionLogs/_action-logs.scss
+++ b/src/pages/EntityDetails/Model/Logs/ActionLogs/_action-logs.scss
@@ -1,21 +1,33 @@
 @import "../../../../../scss/settings";
 @import "vanilla-framework/scss/vanilla";
+@import "../../../../../scss/breakpoints";
 
 @mixin action-logs {
   .entity-details__action-logs {
-    table {
-      // Operation ID column
-      th:nth-child(2) {
+    td,
+    th {
+      // Completion time column.
+      &:nth-child(5) {
         width: 15%;
       }
 
-      // log messages column
-      th:nth-child(5),
-      // Completion time column.
-      th:nth-child(6),
-      // control buttons column
-      th:nth-child(7) {
-        width: 20%;
+      @include mobile-and-medium {
+        // Completion time column.
+        &:nth-child(5) {
+          display: none;
+        }
+      }
+
+      @include mobile {
+        // Status.
+        &:nth-child(3) {
+          width: 25%;
+        }
+
+        // log messages column
+        &:nth-child(4) {
+          display: none;
+        }
       }
     }
   }
@@ -26,12 +38,6 @@
 
   .action-logs__stderr {
     color: $color-negative;
-  }
-
-  .entity-details__action-buttons {
-    & > * {
-      margin-right: $sp-small !important;
-    }
   }
 }
 

--- a/src/scss/_utils.scss
+++ b/src/scss/_utils.scss
@@ -35,13 +35,21 @@
     gap: $sp-medium;
   }
 
+  &--gap-small {
+    gap: $sp-small;
+  }
+
   &--block {
     flex: 1 auto;
   }
-}
 
-.u-flex-grow {
-  flex-grow: 1;
+  &-grow {
+    flex-grow: 1;
+  }
+
+  &-shrink {
+    flex-shrink: 1;
+  }
 }
 
 // Extend has-icon to work outside of buttons

--- a/src/scss/custom/_status_icons.scss
+++ b/src/scss/custom/_status_icons.scss
@@ -11,6 +11,10 @@
     top: -6px;
   }
 
+  &--inline {
+    display: inline;
+  }
+
   &.is-spinner::before {
     content: none;
   }


### PR DESCRIPTION
## Done

- Make action logs table responsive.

## QA

- Go to the 'Action logs' tab in a model.
- If you don't have a model with action logs you might need to run some actions on an app.
- Check that the action logs table appears OK at all screen sizes.

## Details

- https://warthogs.atlassian.net/browse/WD-7494

## Screenshots

<img width="448" alt="Screenshot 2023-11-28 at 1 24 43 pm" src="https://github.com/canonical/juju-dashboard/assets/361637/a91694e5-2ade-471b-821c-4bd1a6d68dc4">
<img width="1260" alt="Screenshot 2023-11-28 at 1 24 56 pm" src="https://github.com/canonical/juju-dashboard/assets/361637/af6064f4-4e6e-4be9-98f0-0bd482620c30">
<img width="944" alt="Screenshot 2023-11-28 at 1 25 11 pm" src="https://github.com/canonical/juju-dashboard/assets/361637/03336b6c-2684-4fb1-9241-2a64053d5102">

