### PR TITLE
WD-7493 - Make audit logs table responsive

### DIFF
--- a/src/components/AuditLogsTable/AuditLogsTable.tsx
+++ b/src/components/AuditLogsTable/AuditLogsTable.tsx
@@ -24,6 +24,8 @@ import AuditLogsTablePagination from "./AuditLogsTablePagination";
 import { DEFAULT_PAGE } from "./consts";
 import { useFetchAuditEvents } from "./hooks";
 
+import "./_audit-logs-table.scss";
+
 const COLUMN_DATA: Column[] = [
   {
     Header: "user",
@@ -126,6 +128,7 @@ const AuditLogsTable = () => {
         <LoadingSpinner />
       ) : (
         <ModularTable
+          className="audit-logs-table"
           columns={columnData}
           // Table will display at most (limit) entries.
           data={hasNextPage ? tableData.slice(0, -1) : tableData}

--- a/src/components/AuditLogsTable/_audit-logs-table.scss
+++ b/src/components/AuditLogsTable/_audit-logs-table.scss
@@ -1,0 +1,23 @@
+@import "vanilla-framework/scss/vanilla";
+@import "../../scss/breakpoints";
+
+.audit-logs-table {
+  td,
+  th {
+    // Facade version.
+    &:nth-child(6) {
+      width: 10%;
+    }
+
+    @include mobile {
+      // Model.
+      &:nth-child(2),
+      // Facade name.
+      &:nth-child(4),
+      // Facade version.
+      &:nth-child(6) {
+        display: none;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Done

[List of work items including drive-bys]- Make audit logs table responsive

## QA

- Connect to JIMM.
- Go to the logs page.
- Check that the table looks OK at all window sizes.


## Details

https://warthogs.atlassian.net/browse/WD-7493

## Screenshots

<img width="412" alt="Screenshot 2023-11-29 at 10 20 14 am" src="https://github.com/canonical/juju-dashboard/assets/361637/7365ecd7-dabe-451f-a5a5-51dc88bf1b30">
<img width="1512" alt="Screenshot 2023-11-29 at 10 20 35 am" src="https://github.com/canonical/juju-dashboard/assets/361637/fa8daa9e-a477-4ca4-bd39-1b9b6967a70c">
<img width="788" alt="Screenshot 2023-11-29 at 10 20 24 am" src="https://github.com/canonical/juju-dashboard/assets/361637/90f12296-73c4-4ff4-b28f-2ad6380cac2b">

