### PR TITLE
WD-7500 - Make machines table responsive

### DIFF
--- a/src/pages/EntityDetails/_entity-details.scss
+++ b/src/pages/EntityDetails/_entity-details.scss
@@ -363,29 +363,29 @@
   .entity-details__machines {
     th,
     td {
+      // Name.
       &:nth-child(1) {
         width: 15%;
       }
 
-      &:nth-child(2) {
-        width: 25%;
+      @include mobile-and-medium {
+        // AZ.
+        &:nth-child(4),
+        // Message.
+        &:nth-child(6) {
+          display: none;
+        }
       }
 
-      &:nth-child(3) {
-        width: 10%;
-      }
-
-      &:nth-child(4) {
-        width: 15%;
-      }
-
-      &:nth-child(5) {
-        width: 15%;
-      }
-
-      &:nth-child(6) {
-        max-width: 150px;
-        width: 20%;
+      @include mobile {
+        // AZ.
+        &:nth-child(4),
+        // Instance ID.
+        &:nth-child(5),
+        // Message.
+        &:nth-child(6) {
+          display: none;
+        }
       }
     }
   }

--- a/src/pages/EntityDetails/_entity-details.scss
+++ b/src/pages/EntityDetails/_entity-details.scss
@@ -378,12 +378,8 @@
       }
 
       @include mobile {
-        // AZ.
-        &:nth-child(4),
         // Instance ID.
-        &:nth-child(5),
-        // Message.
-        &:nth-child(6) {
+        &:nth-child(5) {
           display: none;
         }
       }

--- a/src/tables/tableRows.tsx
+++ b/src/tables/tableRows.tsx
@@ -528,8 +528,14 @@ export function generateMachineRows(
             ),
             className: "u-capitalise",
           },
-          { content: az },
-          { content: machine["instance-id"] },
+          { content: <TruncatedTooltip message={az}>{az}</TruncatedTooltip> },
+          {
+            content: (
+              <TruncatedTooltip message={machine["instance-id"]}>
+                {machine["instance-id"]}
+              </TruncatedTooltip>
+            ),
+          },
           {
             content: (
               <TruncatedTooltip message={message}>{message}</TruncatedTooltip>


### PR DESCRIPTION
## Done

- Make machines table responsive.

## QA

- Go to the 'Machines' tab in a model.
- Check that the table of machines looks OK at all screen sizes.

## Details

- https://warthogs.atlassian.net/browse/WD-7500

## Screenshots

<img width="381" alt="Screenshot 2023-11-29 at 11 02 28 am" src="https://github.com/canonical/juju-dashboard/assets/361637/bf787f8c-978e-4ba5-b3e2-591c7550b651">
<img width="913" alt="Screenshot 2023-11-29 at 11 02 49 am" src="https://github.com/canonical/juju-dashboard/assets/361637/c352dedd-b4a5-4e98-9188-5ceb72a3e930">
<img width="1512" alt="Screenshot 2023-11-29 at 11 03 00 am" src="https://github.com/canonical/juju-dashboard/assets/361637/ad8fd065-2dd6-43a2-84e3-19bd85b526f7">

