### PR TITLE
WD-8294 - feat: Display connection and polling of models error

### DIFF
--- a/src/store/app/thunks.test.ts
+++ b/src/store/app/thunks.test.ts
@@ -12,7 +12,7 @@ import {
   jujuStateFactory,
 } from "testing/factories/juju/juju";
 
-import { logOut, connectAndStartPolling, connectAndListModels } from "./thunks";
+import { logOut, connectAndStartPolling } from "./thunks";
 
 describe("thunks", () => {
   it("logOut", async () => {
@@ -40,19 +40,6 @@ describe("thunks", () => {
   });
 
   it("connectAndStartPolling", async () => {
-    const action = connectAndStartPolling();
-    const dispatch = jest.fn();
-    const getState = jest.fn(() => rootStateFactory.build());
-    await action(dispatch, getState, null);
-    const dispatchedThunk = await dispatch.mock.calls[1][0](
-      dispatch,
-      getState,
-      null,
-    );
-    expect(dispatchedThunk.type).toBe("app/connectAndListModels/fulfilled");
-  });
-
-  it("connectAndListModels", async () => {
     const dispatch = jest.fn();
     const getState = jest.fn(() =>
       rootStateFactory.build({
@@ -87,7 +74,7 @@ describe("thunks", () => {
         }),
       }),
     );
-    const action = connectAndListModels();
+    const action = connectAndStartPolling();
     await action(dispatch, getState, null);
     expect(dispatch).toHaveBeenCalledWith(
       appActions.connectAndPollControllers({

--- a/src/store/app/thunks.test.ts
+++ b/src/store/app/thunks.test.ts
@@ -1,6 +1,7 @@
 import { actions as appActions } from "store/app";
 import { actions as generalActions } from "store/general";
 import { actions as jujuActions } from "store/juju";
+import type { RootState } from "store/store";
 import { rootStateFactory } from "testing/factories";
 import {
   credentialFactory,
@@ -16,9 +17,43 @@ import { logOut, connectAndStartPolling } from "./thunks";
 
 describe("thunks", () => {
   const consoleError = console.error;
+  let state: RootState;
+
   beforeEach(() => {
     console.error = jest.fn();
+    state = rootStateFactory.build({
+      general: generalStateFactory.build({
+        config: configFactory.build({
+          isJuju: true,
+        }),
+        controllerConnections: {
+          "wss://example.com": {
+            user: {
+              "display-name": "eggman",
+              identity: "user-eggman@external",
+              "controller-access": "",
+              "model-access": "",
+            },
+          },
+        },
+        credentials: {
+          "wss://example.com": credentialFactory.build(),
+        },
+      }),
+      juju: jujuStateFactory.build({
+        controllers: {
+          "wss://example.com": [
+            controllerFactory.build({
+              path: "/",
+              uuid: "uuid123",
+              version: "1",
+            }),
+          ],
+        },
+      }),
+    });
   });
+
   afterEach(() => {
     console.error = consoleError;
   });
@@ -49,39 +84,7 @@ describe("thunks", () => {
 
   it("connectAndStartPolling", async () => {
     const dispatch = jest.fn();
-    const getState = jest.fn(() =>
-      rootStateFactory.build({
-        general: generalStateFactory.build({
-          config: configFactory.build({
-            isJuju: true,
-          }),
-          controllerConnections: {
-            "wss://example.com": {
-              user: {
-                "display-name": "eggman",
-                identity: "user-eggman@external",
-                "controller-access": "",
-                "model-access": "",
-              },
-            },
-          },
-          credentials: {
-            "wss://example.com": credentialFactory.build(),
-          },
-        }),
-        juju: jujuStateFactory.build({
-          controllers: {
-            "wss://example.com": [
-              controllerFactory.build({
-                path: "/",
-                uuid: "uuid123",
-                version: "1",
-              }),
-            ],
-          },
-        }),
-      }),
-    );
+    const getState = jest.fn(() => state);
     const action = connectAndStartPolling();
     await action(dispatch, getState, null);
     expect(dispatch).toHaveBeenCalledWith(
@@ -102,39 +105,7 @@ describe("thunks", () => {
         // eslint-disable-next-line no-throw-literal
         throw "Error while dispatching connectAndPollControllers!";
       });
-    const getState = jest.fn(() =>
-      rootStateFactory.build({
-        general: generalStateFactory.build({
-          config: configFactory.build({
-            isJuju: true,
-          }),
-          controllerConnections: {
-            "wss://example.com": {
-              user: {
-                "display-name": "eggman",
-                identity: "user-eggman@external",
-                "controller-access": "",
-                "model-access": "",
-              },
-            },
-          },
-          credentials: {
-            "wss://example.com": credentialFactory.build(),
-          },
-        }),
-        juju: jujuStateFactory.build({
-          controllers: {
-            "wss://example.com": [
-              controllerFactory.build({
-                path: "/",
-                uuid: "uuid123",
-                version: "1",
-              }),
-            ],
-          },
-        }),
-      }),
-    );
+    const getState = jest.fn(() => state);
     const action = connectAndStartPolling();
     await action(dispatch, getState, null);
     expect(dispatch).toHaveBeenCalledWith(
@@ -163,39 +134,7 @@ describe("thunks", () => {
       .mockImplementationOnce(() => {
         throw new Error("Error while dispatching connectAndPollControllers!");
       });
-    const getState = jest.fn(() =>
-      rootStateFactory.build({
-        general: generalStateFactory.build({
-          config: configFactory.build({
-            isJuju: true,
-          }),
-          controllerConnections: {
-            "wss://example.com": {
-              user: {
-                "display-name": "eggman",
-                identity: "user-eggman@external",
-                "controller-access": "",
-                "model-access": "",
-              },
-            },
-          },
-          credentials: {
-            "wss://example.com": credentialFactory.build(),
-          },
-        }),
-        juju: jujuStateFactory.build({
-          controllers: {
-            "wss://example.com": [
-              controllerFactory.build({
-                path: "/",
-                uuid: "uuid123",
-                version: "1",
-              }),
-            ],
-          },
-        }),
-      }),
-    );
+    const getState = jest.fn(() => state);
     const action = connectAndStartPolling();
     await action(dispatch, getState, null);
     expect(dispatch).toHaveBeenCalledWith(
@@ -225,39 +164,7 @@ describe("thunks", () => {
         // eslint-disable-next-line no-throw-literal
         throw ["Unknown error."];
       });
-    const getState = jest.fn(() =>
-      rootStateFactory.build({
-        general: generalStateFactory.build({
-          config: configFactory.build({
-            isJuju: true,
-          }),
-          controllerConnections: {
-            "wss://example.com": {
-              user: {
-                "display-name": "eggman",
-                identity: "user-eggman@external",
-                "controller-access": "",
-                "model-access": "",
-              },
-            },
-          },
-          credentials: {
-            "wss://example.com": credentialFactory.build(),
-          },
-        }),
-        juju: jujuStateFactory.build({
-          controllers: {
-            "wss://example.com": [
-              controllerFactory.build({
-                path: "/",
-                uuid: "uuid123",
-                version: "1",
-              }),
-            ],
-          },
-        }),
-      }),
-    );
+    const getState = jest.fn(() => state);
     const action = connectAndStartPolling();
     await action(dispatch, getState, null);
     expect(dispatch).toHaveBeenCalledWith(

--- a/src/store/app/thunks.test.ts
+++ b/src/store/app/thunks.test.ts
@@ -12,7 +12,7 @@ import {
   jujuStateFactory,
 } from "testing/factories/juju/juju";
 
-import { logOut, connectAndStartPolling, Label } from "./thunks";
+import { logOut, connectAndStartPolling } from "./thunks";
 
 describe("thunks", () => {
   it("logOut", async () => {
@@ -137,12 +137,12 @@ describe("thunks", () => {
       }),
     );
     expect(console.error).toHaveBeenCalledWith(
-      Label.CONNECT_AND_START_POLLING_ERROR,
+      "Error while triggering the connection and polling of models.",
       new Error("Error while dispatching connectAndPollControllers!"),
     );
     expect(dispatch).toHaveBeenCalledWith(
       generalActions.storeConnectionError(
-        Label.CONNECT_AND_START_POLLING_ERROR,
+        "Unable to connect: Error while dispatching connectAndPollControllers!",
       ),
     );
     console.error = consoleError;

--- a/src/store/app/thunks.ts
+++ b/src/store/app/thunks.ts
@@ -15,10 +15,6 @@ import type { RootState } from "store/store";
 
 import type { ControllerArgs } from "./actions";
 
-export enum Label {
-  CONNECT_AND_START_POLLING_ERROR = "Error while triggering the connection and polling of models.",
-}
-
 export const logOut = createAsyncThunk<
   void,
   void,
@@ -81,14 +77,25 @@ export const connectAndStartPolling = createAsyncThunk<
         isJuju: config?.isJuju ?? false,
       }),
     );
+    throw new Error("dummy error");
   } catch (error) {
     // a common error logged to the console by this is:
     // Error while triggering the connection and polling of models. cannot send request {"type":"ModelManager","request":"ListModels","version":5,"params":...}: connection state 3 is not open
-    console.error(Label.CONNECT_AND_START_POLLING_ERROR, error);
+    console.error(
+      "Error while triggering the connection and polling of models.",
+      error,
+    );
+    let errorMessage;
+    if (error instanceof Error) {
+      errorMessage = error.message;
+    } else if (typeof error === "string") {
+      errorMessage = error;
+    } else {
+      errorMessage =
+        "Something went wrong. View the console log for more details.";
+    }
     thunkAPI.dispatch(
-      generalActions.storeConnectionError(
-        Label.CONNECT_AND_START_POLLING_ERROR,
-      ),
+      generalActions.storeConnectionError(`Unable to connect: ${errorMessage}`),
     );
   }
 });

--- a/src/store/app/thunks.ts
+++ b/src/store/app/thunks.ts
@@ -52,21 +52,6 @@ export const connectAndStartPolling = createAsyncThunk<
   }
 >("app/connectAndStartPolling", async (_, thunkAPI) => {
   try {
-    await thunkAPI.dispatch(connectAndListModels());
-  } catch (error) {
-    // XXX Add to Sentry.
-    console.error("Error while trying to connect and list models.", error);
-  }
-});
-
-export const connectAndListModels = createAsyncThunk<
-  void,
-  void,
-  {
-    state: RootState;
-  }
->("app/connectAndListModels", async (_, thunkAPI) => {
-  try {
     const storeState = thunkAPI.getState();
     const config = getConfig(storeState);
     const wsControllerURL = getWSControllerURL(storeState);
@@ -93,10 +78,14 @@ export const connectAndListModels = createAsyncThunk<
       }),
     );
   } catch (error) {
-    // XXX Surface error to UI.
     // XXX Send to sentry if it's an error that's not connection related
     // a common error returned by this is:
     // Something went wrong:  cannot send request {"type":"ModelManager","request":"ListModels","version":5,"params":...}: connection state 3 is not open
     console.error("Something went wrong: ", error);
+    thunkAPI.dispatch(
+      generalActions.storeConnectionError(
+        "Error while triggering the connection and polling of models.",
+      ),
+    );
   }
 });

--- a/src/store/app/thunks.ts
+++ b/src/store/app/thunks.ts
@@ -15,6 +15,10 @@ import type { RootState } from "store/store";
 
 import type { ControllerArgs } from "./actions";
 
+enum Label {
+  CONNECT_AND_START_POLLING_ERROR = "Error while triggering the connection and polling of models.",
+}
+
 export const logOut = createAsyncThunk<
   void,
   void,
@@ -81,13 +85,10 @@ export const connectAndStartPolling = createAsyncThunk<
     // XXX Send to sentry if it's an error that's not connection related
     // a common error logged to the console by this is:
     // Error while triggering the connection and polling of models. cannot send request {"type":"ModelManager","request":"ListModels","version":5,"params":...}: connection state 3 is not open
-    console.error(
-      "Error while triggering the connection and polling of models.",
-      error,
-    );
+    console.error(Label.CONNECT_AND_START_POLLING_ERROR, error);
     thunkAPI.dispatch(
       generalActions.storeConnectionError(
-        "Error while triggering the connection and polling of models.",
+        Label.CONNECT_AND_START_POLLING_ERROR,
       ),
     );
   }

--- a/src/store/app/thunks.ts
+++ b/src/store/app/thunks.ts
@@ -77,7 +77,6 @@ export const connectAndStartPolling = createAsyncThunk<
         isJuju: config?.isJuju ?? false,
       }),
     );
-    throw new Error("dummy error");
   } catch (error) {
     // a common error logged to the console by this is:
     // Error while triggering the connection and polling of models. cannot send request {"type":"ModelManager","request":"ListModels","version":5,"params":...}: connection state 3 is not open

--- a/src/store/app/thunks.ts
+++ b/src/store/app/thunks.ts
@@ -79,9 +79,12 @@ export const connectAndStartPolling = createAsyncThunk<
     );
   } catch (error) {
     // XXX Send to sentry if it's an error that's not connection related
-    // a common error returned by this is:
-    // Something went wrong:  cannot send request {"type":"ModelManager","request":"ListModels","version":5,"params":...}: connection state 3 is not open
-    console.error("Something went wrong: ", error);
+    // a common error logged to the console by this is:
+    // Error while triggering the connection and polling of models. cannot send request {"type":"ModelManager","request":"ListModels","version":5,"params":...}: connection state 3 is not open
+    console.error(
+      "Error while triggering the connection and polling of models.",
+      error,
+    );
     thunkAPI.dispatch(
       generalActions.storeConnectionError(
         "Error while triggering the connection and polling of models.",

--- a/src/store/app/thunks.ts
+++ b/src/store/app/thunks.ts
@@ -15,7 +15,7 @@ import type { RootState } from "store/store";
 
 import type { ControllerArgs } from "./actions";
 
-enum Label {
+export enum Label {
   CONNECT_AND_START_POLLING_ERROR = "Error while triggering the connection and polling of models.",
 }
 
@@ -82,7 +82,6 @@ export const connectAndStartPolling = createAsyncThunk<
       }),
     );
   } catch (error) {
-    // XXX Send to sentry if it's an error that's not connection related
     // a common error logged to the console by this is:
     // Error while triggering the connection and polling of models. cannot send request {"type":"ModelManager","request":"ListModels","version":5,"params":...}: connection state 3 is not open
     console.error(Label.CONNECT_AND_START_POLLING_ERROR, error);

--- a/src/store/middleware/check-auth.ts
+++ b/src/store/middleware/check-auth.ts
@@ -86,9 +86,6 @@ export const checkAuthMiddleware: Middleware<
     ];
 
     const thunkAllowlist = [
-      appThunks.connectAndListModels.fulfilled.type,
-      appThunks.connectAndListModels.pending.type,
-      appThunks.connectAndListModels.rejected.type,
       appThunks.connectAndStartPolling.fulfilled.type,
       appThunks.connectAndStartPolling.pending.type,
       appThunks.connectAndStartPolling.rejected.type,


### PR DESCRIPTION
## Done

- When `connectAndStartPolling()` fails, the error is sent to Redux store, and caught and displayed in `ConnectionError` component.

## QA

- Modify the end of the `try` block in `connectAndStartPolling()` by throwing a dummy error there e.g. `throw new Error("Dummy error.");`.
- Log into the Juju Dashboard and check that just the `ConnectionError` component renders, same as in the attached screenshot.
- Check that the error is logged in the console as `Error while triggering the connection and polling of models. Error: Dummy error.` followed by the stack trace.

## Details

- https://warthogs.atlassian.net/browse/WD-8294

## Screenshots

![Screenshot from 2024-01-23 11-37-55](https://github.com/canonical/juju-dashboard/assets/108150922/8e40b039-ffcb-4279-b2c7-0e3a64e5b8a5)

