### PR TITLE
WD-8309 - feat: Display error when trying to retrieve models info

### DIFF
--- a/src/juju/api.test.ts
+++ b/src/juju/api.test.ts
@@ -369,9 +369,9 @@ describe("Juju API", () => {
         () => state,
       );
       jest.advanceTimersByTime(LOGIN_TIMEOUT);
-      await expect(response).resolves.toBeNull();
+      await expect(response).rejects.toStrictEqual(new Error("timeout"));
       expect(console.error).toHaveBeenCalledWith(
-        "error connecting to model:",
+        "Error connecting to model:",
         "abc123",
         new Error("timeout"),
       );
@@ -456,15 +456,18 @@ describe("Juju API", () => {
       jest
         .spyOn(jujuLib, "connectAndLogin")
         .mockImplementation(async () => loginResponse);
-      const response = await fetchModelStatus(
+      const response = fetchModelStatus(
         "abc123",
         "wss://example.com/api",
         () => state,
       );
-      expect(response).toBeUndefined();
+      await expect(response).rejects.toStrictEqual(
+        new Error("Unable to fetch the status. Uh oh!"),
+      );
       expect(console.error).toHaveBeenCalledWith(
-        "Unable to fetch the status.",
-        "Uh oh!",
+        "Error connecting to model:",
+        "abc123",
+        new Error("Unable to fetch the status. Uh oh!"),
       );
       console.error = consoleError;
     });
@@ -535,11 +538,19 @@ describe("Juju API", () => {
         .spyOn(jujuLib, "connectAndLogin")
         .mockImplementation(async () => loginResponse);
       const dispatch = jest.fn();
-      await fetchAndStoreModelStatus(
+      const response = fetchAndStoreModelStatus(
         "abc123",
         "wss://example.com/api",
         dispatch,
         () => state,
+      );
+      await expect(response).rejects.toStrictEqual(
+        new Error("Unable to fetch the status. "),
+      );
+      expect(console.error).toHaveBeenCalledWith(
+        "Error connecting to model:",
+        "abc123",
+        new Error("Unable to fetch the status. "),
       );
       expect(dispatch).not.toHaveBeenCalled();
       console.error = consoleError;

--- a/src/juju/api.test.ts
+++ b/src/juju/api.test.ts
@@ -61,7 +61,6 @@ import {
   stopModelWatcher,
   findAuditEvents,
   crossModelQuery,
-  Label as JujuAPILabel,
 } from "./api";
 import type { AllWatcherDelta } from "./types";
 import { DeltaChangeTypes, DeltaEntityTypes } from "./types";
@@ -768,7 +767,7 @@ describe("Juju API", () => {
         () => state,
       );
       await expect(response).rejects.toStrictEqual(
-        new Error(JujuAPILabel.ERROR_LOAD_SOME_MODELS),
+        new Error("Unable to load some models."),
       );
     });
 
@@ -813,7 +812,7 @@ describe("Juju API", () => {
         () => state,
       );
       await expect(response).rejects.toStrictEqual(
-        new Error(JujuAPILabel.ERROR_LOAD_ALL_MODELS),
+        new Error("Unable to load models."),
       );
     });
   });

--- a/src/juju/api.ts
+++ b/src/juju/api.ts
@@ -265,7 +265,7 @@ export async function fetchModelStatus(
           // a location to notify the user. In the new watcher model that's
           // being implemented we will be able to surface this error in the
           // model details page.
-          throw new Error(`Unable to fetch the status. ${status}`);
+          throw new Error(`Unable to fetch the status. ${status ?? ""}`);
         }
       }
 

--- a/src/juju/api.ts
+++ b/src/juju/api.ts
@@ -42,6 +42,7 @@ import type { Credential } from "store/general/types";
 import { actions as jujuActions } from "store/juju";
 import { addControllerCloudRegion } from "store/juju/thunks";
 import type { Controller as JujuController } from "store/juju/types";
+import { ModelsError } from "store/middleware/model-poller";
 import type { RootState, Store } from "store/store";
 
 import { getModelByUUID } from "../store/juju/selectors";
@@ -65,11 +66,6 @@ export const LOGIN_TIMEOUT = 5000;
 // See the API server code for more details:
 // https://github.com/juju/juju/blob/e2c7b4c88e516976666e3d0c9479d0d3c704e643/apiserver/restrict_newer_client.go#L21C1-L29
 export const CLIENT_VERSION = "3.0.0";
-
-export enum Label {
-  ERROR_LOAD_ALL_MODELS = "Unable to load models.",
-  ERROR_LOAD_SOME_MODELS = "Unable to load some models.",
-}
 
 /**
   Return a common connection option config.
@@ -402,8 +398,8 @@ export async function fetchAllModelStatuses(
         ? reject(
             new Error(
               modelErrorCount === modelUUIDList.length
-                ? Label.ERROR_LOAD_ALL_MODELS
-                : Label.ERROR_LOAD_SOME_MODELS,
+                ? ModelsError.LOAD_ALL_MODELS
+                : ModelsError.LOAD_SOME_MODELS,
             ),
           )
         : resolve();

--- a/src/pages/ModelsIndex/ModelsIndex.test.tsx
+++ b/src/pages/ModelsIndex/ModelsIndex.test.tsx
@@ -2,6 +2,7 @@ import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { TestId } from "components/LoadingSpinner/LoadingSpinner";
+import { Label as JujuAPILabel } from "juju/api";
 import type { RootState } from "store/store";
 import {
   detailedStatusFactory,
@@ -172,5 +173,29 @@ describe("Models Index page", () => {
       custom: "",
     });
     expect(window.location.search).toBe(`?${params.toString()}`);
+  });
+
+  it("should display the error notification", async () => {
+    state.juju.modelsError = JujuAPILabel.ERROR_LOAD_ALL_MODELS;
+    renderComponent(<ModelsIndex />, { state });
+    expect(
+      screen.getByText(new RegExp(JujuAPILabel.ERROR_LOAD_ALL_MODELS)),
+    ).toBeInTheDocument();
+  });
+
+  it("should refresh the window when pressing the button in error notification", async () => {
+    const location = window.location;
+    Object.defineProperty(window, "location", {
+      value: { ...location, reload: jest.fn() },
+    });
+
+    state.juju.modelsError = JujuAPILabel.ERROR_LOAD_ALL_MODELS;
+    renderComponent(<ModelsIndex />, { state });
+    await userEvent.click(screen.getByRole("button", { name: "refreshing" }));
+    expect(window.location.reload).toHaveBeenCalled();
+
+    Object.defineProperty(window, "location", {
+      value: location,
+    });
   });
 });

--- a/src/pages/ModelsIndex/ModelsIndex.test.tsx
+++ b/src/pages/ModelsIndex/ModelsIndex.test.tsx
@@ -2,7 +2,6 @@ import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { TestId } from "components/LoadingSpinner/LoadingSpinner";
-import { Label as JujuAPILabel } from "juju/api";
 import type { RootState } from "store/store";
 import {
   detailedStatusFactory,
@@ -176,11 +175,9 @@ describe("Models Index page", () => {
   });
 
   it("should display the error notification", async () => {
-    state.juju.modelsError = JujuAPILabel.ERROR_LOAD_ALL_MODELS;
+    state.juju.modelsError = "Oops!";
     renderComponent(<ModelsIndex />, { state });
-    expect(
-      screen.getByText(new RegExp(JujuAPILabel.ERROR_LOAD_ALL_MODELS)),
-    ).toBeInTheDocument();
+    expect(screen.getByText(new RegExp(/Oops!/))).toBeInTheDocument();
   });
 
   it("should refresh the window when pressing the button in error notification", async () => {
@@ -189,7 +186,7 @@ describe("Models Index page", () => {
       value: { ...location, reload: jest.fn() },
     });
 
-    state.juju.modelsError = JujuAPILabel.ERROR_LOAD_ALL_MODELS;
+    state.juju.modelsError = "Oops!";
     renderComponent(<ModelsIndex />, { state });
     await userEvent.click(screen.getByRole("button", { name: "refreshing" }));
     expect(window.location.reload).toHaveBeenCalled();

--- a/src/pages/ModelsIndex/ModelsIndex.tsx
+++ b/src/pages/ModelsIndex/ModelsIndex.tsx
@@ -1,4 +1,8 @@
-import { SearchAndFilter } from "@canonical/react-components";
+import {
+  Button,
+  Notification,
+  SearchAndFilter,
+} from "@canonical/react-components";
 import type { SearchAndFilterChip } from "@canonical/react-components/dist/components/SearchAndFilter/types";
 import type { ReactNode } from "react";
 import { useSelector } from "react-redux";
@@ -16,6 +20,7 @@ import {
   getGroupedModelStatusCounts,
   getModelData,
   getModelListLoaded,
+  getModelsError,
   hasModels,
 } from "store/juju/selectors";
 import { pluralize } from "store/juju/utils/models";
@@ -55,6 +60,7 @@ export default function Models() {
     custom: queryParams.custom,
   };
 
+  const modelsError = useAppSelector(getModelsError);
   const modelsLoaded = useAppSelector(getModelListLoaded);
   const hasSomeModels = useSelector(hasModels);
   // loop model data and pull out filter panel data
@@ -196,6 +202,15 @@ export default function Models() {
       titleComponent="div"
       titleClassName="u-no-max-width u-full-width"
     >
+      {modelsError ? (
+        <Notification severity="negative" title="Error">
+          {modelsError} Try{" "}
+          <Button appearance="link" onClick={() => window.location.reload()}>
+            refreshing
+          </Button>{" "}
+          the page.
+        </Notification>
+      ) : null}
       {content}
     </BaseLayout>
   );

--- a/src/store/juju/actions.test.ts
+++ b/src/store/juju/actions.test.ts
@@ -95,6 +95,21 @@ describe("actions", () => {
     });
   });
 
+  it("updateModelsError", () => {
+    expect(
+      actions.updateModelsError({
+        modelsError: null,
+        wsControllerURL: "wss://test.example.com",
+      }),
+    ).toStrictEqual({
+      type: "juju/updateModelsError",
+      payload: {
+        modelsError: null,
+        wsControllerURL: "wss://test.example.com",
+      },
+    });
+  });
+
   it("clearModelData", () => {
     expect(actions.clearModelData()).toStrictEqual({
       type: "juju/clearModelData",

--- a/src/store/juju/reducers.test.ts
+++ b/src/store/juju/reducers.test.ts
@@ -160,6 +160,26 @@ describe("reducers", () => {
     });
   });
 
+  it("updateModelsError", () => {
+    const state = jujuStateFactory.build({
+      modelData: {
+        abc123: model,
+      },
+    });
+    expect(
+      reducer(
+        state,
+        actions.updateModelsError({
+          modelsError: null,
+          wsControllerURL: "wss://example.com",
+        }),
+      ),
+    ).toStrictEqual({
+      ...state,
+      modelsError: null,
+    });
+  });
+
   it("clearModelData", () => {
     const state = jujuStateFactory.build({
       modelData: {

--- a/src/store/juju/selectors.ts
+++ b/src/store/juju/selectors.ts
@@ -176,6 +176,11 @@ export const getModelData = createSelector(
   (sliceState) => sliceState.modelData ?? null,
 );
 
+export const getModelsError = createSelector(
+  [slice],
+  (sliceState) => sliceState.modelsError,
+);
+
 /**
   Fetches the controller data from state.
   @param state The application state.

--- a/src/store/juju/slice.ts
+++ b/src/store/juju/slice.ts
@@ -46,6 +46,7 @@ const slice = createSlice({
     },
     controllers: null,
     models: {},
+    modelsError: null,
     modelsLoaded: false,
     modelData: {},
     modelWatcherData: {},
@@ -128,9 +129,20 @@ const slice = createSlice({
         state.modelData[modelInfo.uuid].info = modelInfo;
       }
     },
+    updateModelsError: (
+      state,
+      action: PayloadAction<
+        {
+          modelsError: string | null;
+        } & WsControllerURLParam
+      >,
+    ) => {
+      state.modelsError = action.payload.modelsError;
+    },
     clearModelData: (state) => {
       state.modelData = {};
       state.models = {};
+      state.modelsError = null;
       state.modelsLoaded = false;
     },
     clearControllerData: (state) => {

--- a/src/store/juju/types.ts
+++ b/src/store/juju/types.ts
@@ -76,6 +76,7 @@ export type JujuState = {
   crossModelQuery: CrossModelQueryState;
   controllers: Controllers | null;
   models: ModelsList;
+  modelsError: string | null;
   modelsLoaded: boolean;
   modelData: ModelDataList;
   modelWatcherData?: ModelWatcherData;

--- a/src/store/middleware/model-poller.test.ts
+++ b/src/store/middleware/model-poller.test.ts
@@ -74,7 +74,9 @@ describe("model poller", () => {
     jest.useFakeTimers();
     next = jest.fn();
     fakeStore = {
-      getState: jest.fn(() => ({})),
+      getState: jest.fn(() => ({
+        juju: jujuStateFactory.build(),
+      })),
       dispatch: jest.fn(),
     };
     conn = {

--- a/src/store/middleware/model-poller.ts
+++ b/src/store/middleware/model-poller.ts
@@ -11,7 +11,6 @@ import {
   loginWithBakery,
   setModelSharingPermissions,
 } from "juju/api";
-import { Label as JujuAPILabel } from "juju/api";
 import type { CrossModelQueryFullResponse } from "juju/jimm/JIMMV4";
 import { JIMMRelation } from "juju/jimm/JIMMV4";
 import type { ConnectionWithFacades } from "juju/types";
@@ -25,6 +24,13 @@ import { isSpecificAction } from "types";
 export enum LoginError {
   LOG = "Unable to log into controller",
   NO_INFO = "Unable to retrieve controller details",
+}
+
+export enum ModelsError {
+  LOAD_ALL_MODELS = "Unable to load models.",
+  LOAD_SOME_MODELS = "Unable to load some models.",
+  LOAD_LATEST_MODELS = "Unable to load latest model data.",
+  LIST_OR_UPDATE_MODELS = "Unable to list or update models.",
 }
 
 const checkJIMMRelation = async (
@@ -222,14 +228,14 @@ export const modelPollerMiddleware: Middleware<
               let errorMessage;
               if (
                 error instanceof Error &&
-                (error.message === JujuAPILabel.ERROR_LOAD_ALL_MODELS ||
-                  error.message === JujuAPILabel.ERROR_LOAD_SOME_MODELS)
+                (error.message === ModelsError.LOAD_ALL_MODELS ||
+                  error.message === ModelsError.LOAD_SOME_MODELS)
               ) {
                 errorMessage = pollCount
-                  ? "Unable to load latest model data."
+                  ? ModelsError.LOAD_LATEST_MODELS
                   : error.message;
               } else {
-                errorMessage = "Unable to list or update models.";
+                errorMessage = ModelsError.LIST_OR_UPDATE_MODELS;
               }
               console.error(errorMessage, error);
               reduxStore.dispatch(

--- a/src/testing/factories/juju/juju.ts
+++ b/src/testing/factories/juju/juju.ts
@@ -183,6 +183,7 @@ export const jujuStateFactory = Factory.define<JujuState>(() => ({
   controllers: null,
   models: {},
   modelsLoaded: false,
+  modelsError: null,
   modelData: {},
   modelWatcherData: {},
   charms: [],


### PR DESCRIPTION
## Done

- Throw the “Unable to fetch the status.” error instead of using return. Afterward, throw the error, so that it is further caught in `fetchAllModelStatuses()`.
- If less than 10% of models error out, no error is processed in `fetchAllModelStatuses()`. Else, throw the error back, so that it is further caught in `modelPollerMiddleware()`.
- When trying to retrieve models info in `modelPollerMiddleware()`, send "Unable to load models." error if it is the first polling and all models error out, "Unable to load some models." error if it is the first polling and some models error out, "Unable to load latest model data." if it is later polling and the error appears in `fetchAllModelStatuses()` call, else send "Unable to list or update models." error. The error should be sent to `juju -> modelsErrors` in Redux store.
- Display the previously mentioned error inline in `pages/ModelsIndex/ModelsIndex.tsx`.

## QA

- Modify the code of `modelPollerMiddleware()` to throw an error on line 217.
- Verify that the error gets displayed on `Models` page and logged into the console.

## Details

- https://warthogs.atlassian.net/browse/WD-8309

## Screenshots

![Screenshot from 2024-01-23 19-39-26](https://github.com/canonical/juju-dashboard/assets/108150922/3f4e5046-0447-4035-9bee-055d33619dcb)


