### PR TITLE
WD-8431 - Fetch and store secrets

### DIFF
--- a/src/juju/api.test.ts
+++ b/src/juju/api.test.ts
@@ -61,6 +61,7 @@ import {
   stopModelWatcher,
   findAuditEvents,
   crossModelQuery,
+  connectToModel,
 } from "./api";
 import type { AllWatcherDelta } from "./types";
 import { DeltaChangeTypes, DeltaEntityTypes } from "./types";
@@ -939,6 +940,37 @@ describe("Juju API", () => {
           conn,
         }));
       const response = await connectAndLoginToModel("abc123", state);
+      expect(connectAndLogin).toHaveBeenCalledWith(
+        "wss://example.com/model/abc123/api",
+        {
+          username: credentials.user,
+          password: credentials.password,
+        },
+        expect.any(Object),
+        CLIENT_VERSION,
+      );
+      expect(response).toMatchObject(conn);
+    });
+  });
+
+  describe("connectToModel", () => {
+    it("can connect and log in", async () => {
+      const credentials = credentialFactory.build();
+      const conn = {
+        facades: {},
+      } as unknown as Connection;
+      const connectAndLogin = jest
+        .spyOn(jujuLib, "connectAndLogin")
+        .mockImplementation(async () => ({
+          logout: jest.fn(),
+          conn,
+        }));
+      const response = await connectToModel(
+        "abc123",
+        "wss://example.com/api",
+        credentials,
+        false,
+      );
       expect(connectAndLogin).toHaveBeenCalledWith(
         "wss://example.com/model/abc123/api",
         {

--- a/src/juju/api.ts
+++ b/src/juju/api.ts
@@ -22,6 +22,7 @@ import Cloud from "@canonical/jujulib/dist/api/facades/cloud";
 import Controller from "@canonical/jujulib/dist/api/facades/controller";
 import ModelManager from "@canonical/jujulib/dist/api/facades/model-manager";
 import Pinger from "@canonical/jujulib/dist/api/facades/pinger";
+import Secrets from "@canonical/jujulib/dist/api/facades/secrets";
 import { jujuUpdateAvailable } from "@canonical/jujulib/dist/api/versions";
 import type { ValueOf } from "@canonical/react-components";
 import Limiter from "async-limiter";
@@ -88,6 +89,7 @@ export function generateConnectionOptions(
     Controller,
     ModelManager,
     JIMM,
+    Secrets,
   ];
   if (usePinger) {
     facades.push(Pinger);
@@ -485,6 +487,28 @@ export function disableControllerUUIDMasking(conn: ConnectionWithFacades) {
   @param appState
   @returns conn The connection.
 */
+export async function connectToModel(
+  modelUUID: string,
+  wsControllerURL: string,
+  credentials?: Credential,
+  identityProviderAvailable = false,
+) {
+  const modelURL = wsControllerURL.replace("/api", `/model/${modelUUID}/api`);
+  const response = await connectAndLoginWithTimeout(
+    modelURL,
+    credentials,
+    generateConnectionOptions(true),
+    identityProviderAvailable,
+  );
+  return response.conn;
+}
+
+/**
+  Connect to the model representing the supplied modelUUID.
+  @param modelUUID
+  @param appState
+  @returns conn The connection.
+*/
 export async function connectAndLoginToModel(
   modelUUID: string,
   appState: RootState,
@@ -495,14 +519,12 @@ export async function connectAndLoginToModel(
   }
   const config = getConfig(appState);
   const credentials = getUserPass(appState, wsControllerURL);
-  const modelURL = wsControllerURL.replace("/api", `/model/${modelUUID}/api`);
-  const response = await connectAndLoginWithTimeout(
-    modelURL,
+  return connectToModel(
+    modelUUID,
+    wsControllerURL,
     credentials,
-    generateConnectionOptions(true),
-    config?.identityProviderAvailable ?? false,
+    config?.identityProviderAvailable,
   );
-  return response.conn;
 }
 
 /**

--- a/src/juju/apiHook.test.tsx
+++ b/src/juju/apiHook.test.tsx
@@ -1,0 +1,261 @@
+import * as jujuLib from "@canonical/jujulib";
+import type { Connection } from "@canonical/jujulib";
+import { renderHook, waitFor } from "@testing-library/react";
+import configureStore from "redux-mock-store";
+
+import { actions as jujuActions } from "store/juju";
+import type { RootState } from "store/store";
+import { rootStateFactory } from "testing/factories";
+import {
+  configFactory,
+  credentialFactory,
+  generalStateFactory,
+} from "testing/factories/general";
+import {
+  modelListInfoFactory,
+  listSecretResultFactory,
+} from "testing/factories/juju/juju";
+import { ComponentProviders, changeURL } from "testing/utils";
+
+import { LOGIN_TIMEOUT } from "./api";
+import { useModelConnection, useListSecrets } from "./apiHooks";
+
+const mockStore = configureStore<RootState, unknown>([]);
+
+jest.mock("@canonical/jujulib", () => ({
+  connectAndLogin: jest.fn(),
+}));
+
+describe("useModelConnection", () => {
+  let state: RootState;
+
+  beforeEach(() => {
+    state = rootStateFactory.build({
+      general: generalStateFactory.build({
+        credentials: {
+          "wss://example.com/api": credentialFactory.build(),
+        },
+        config: configFactory.build({
+          controllerAPIEndpoint: "wss://example.com/api",
+        }),
+      }),
+      juju: {
+        models: {
+          abc123: modelListInfoFactory.build({
+            wsControllerURL: "wss://example.com/api",
+          }),
+        },
+      },
+    });
+    jest.useFakeTimers({
+      legacyFakeTimers: true,
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
+  it("can connect and log in", async () => {
+    changeURL("/models/eggman@external/group-test/app/etcd");
+    const loginResponse = {
+      conn: {
+        facades: {
+          client: {
+            fullStatus: jest.fn().mockReturnValue({}),
+          },
+        },
+      } as unknown as Connection,
+      logout: jest.fn(),
+    };
+    jest
+      .spyOn(jujuLib, "connectAndLogin")
+      .mockImplementation(() => Promise.resolve(loginResponse));
+    const callback = jest.fn();
+    renderHook(() => useModelConnection(callback, "abc123"), {
+      wrapper: (props) => (
+        <ComponentProviders
+          {...props}
+          path="/models/:userName/:modelName/app/:appName"
+          store={mockStore(state)}
+        />
+      ),
+    });
+    await waitFor(() => {
+      expect(callback).toHaveBeenCalledWith(loginResponse.conn);
+    });
+  });
+
+  it("returns connection errors", async () => {
+    changeURL("/models/eggman@external/group-test/app/etcd");
+    jest
+      .spyOn(jujuLib, "connectAndLogin")
+      .mockImplementation(() => Promise.reject(new Error()));
+    const callback = jest.fn();
+    renderHook(() => useModelConnection(callback, "abc123"), {
+      wrapper: (props) => (
+        <ComponentProviders
+          {...props}
+          path="/models/:userName/:modelName/app/:appName"
+          store={mockStore(state)}
+        />
+      ),
+    });
+    await waitFor(() => {
+      expect(callback).toHaveBeenCalledWith(null, "Error during promise race.");
+    });
+  });
+
+  it("returns string connection errors", async () => {
+    changeURL("/models/eggman@external/group-test/app/etcd");
+    jest.spyOn(jujuLib, "connectAndLogin").mockImplementation(
+      async () =>
+        new Promise((resolve) => {
+          setTimeout(resolve, LOGIN_TIMEOUT + 10);
+        }),
+    );
+    const callback = jest.fn();
+    renderHook(() => useModelConnection(callback, "abc123"), {
+      wrapper: (props) => (
+        <ComponentProviders
+          {...props}
+          path="/models/:userName/:modelName/app/:appName"
+          store={mockStore(state)}
+        />
+      ),
+    });
+    jest.advanceTimersByTime(LOGIN_TIMEOUT);
+    await waitFor(() => {
+      expect(callback).toHaveBeenCalledWith(null, "timeout");
+    });
+  });
+});
+
+describe("useListSecrets", () => {
+  let state: RootState;
+
+  beforeEach(() => {
+    state = rootStateFactory.build({
+      general: generalStateFactory.build({
+        credentials: {
+          "wss://example.com/api": credentialFactory.build(),
+        },
+        config: configFactory.build({
+          controllerAPIEndpoint: "wss://example.com/api",
+        }),
+      }),
+      juju: {
+        models: {
+          abc123: modelListInfoFactory.build({
+            wsControllerURL: "wss://example.com/api",
+            uuid: "abc123",
+          }),
+        },
+      },
+    });
+  });
+
+  it("fetches secrets", async () => {
+    const store = mockStore(state);
+    changeURL("/models/eggman@external/group-test/app/etcd");
+    const secrets = [listSecretResultFactory.build()];
+    const loginResponse = {
+      conn: {
+        facades: {
+          secrets: {
+            listSecrets: jest
+              .fn()
+              .mockImplementation(() => Promise.resolve({ results: secrets })),
+          },
+        },
+      } as unknown as Connection,
+      logout: jest.fn(),
+    };
+    jest
+      .spyOn(jujuLib, "connectAndLogin")
+      .mockImplementation(() => Promise.resolve(loginResponse));
+    renderHook(() => useListSecrets("eggman@external", "test-model"), {
+      wrapper: (props) => (
+        <ComponentProviders
+          {...props}
+          path="/models/:userName/:modelName/app/:appName"
+          store={store}
+        />
+      ),
+    });
+    const updateAction = jujuActions.updateSecrets({
+      modelUUID: "abc123",
+      secrets: secrets,
+      wsControllerURL: "wss://example.com/api",
+    });
+    const loadingAction = jujuActions.secretsLoading({
+      modelUUID: "abc123",
+      wsControllerURL: "wss://example.com/api",
+    });
+    await waitFor(() => {
+      expect(
+        store
+          .getActions()
+          .find((dispatch) => dispatch.type === updateAction.type),
+      ).toMatchObject(updateAction);
+      expect(
+        store
+          .getActions()
+          .find((dispatch) => dispatch.type === loadingAction.type),
+      ).toMatchObject(loadingAction);
+    });
+  });
+
+  it("handles no connection", async () => {
+    const store = mockStore(state);
+    changeURL("/models/eggman@external/group-test/app/etcd");
+    const loginResponse = {
+      logout: jest.fn(),
+    };
+    jest
+      .spyOn(jujuLib, "connectAndLogin")
+      .mockImplementation(() => Promise.resolve(loginResponse));
+    renderHook(() => useListSecrets("eggman@external", "test-model"), {
+      wrapper: (props) => (
+        <ComponentProviders
+          {...props}
+          path="/models/:userName/:modelName/app/:appName"
+          store={store}
+        />
+      ),
+    });
+    await waitFor(() => {
+      expect(store.getActions()).toHaveLength(0);
+    });
+  });
+
+  it("returns errors", async () => {
+    const store = mockStore(state);
+    changeURL("/models/eggman@external/group-test/app/etcd");
+    jest
+      .spyOn(jujuLib, "connectAndLogin")
+      .mockImplementation(() => Promise.reject(new Error()));
+    renderHook(() => useListSecrets("eggman@external", "test-model"), {
+      wrapper: (props) => (
+        <ComponentProviders
+          {...props}
+          path="/models/:userName/:modelName/app/:appName"
+          store={store}
+        />
+      ),
+    });
+    const updateAction = jujuActions.setSecretsErrors({
+      modelUUID: "abc123",
+      errors: "Error during promise race.",
+      wsControllerURL: "wss://example.com/api",
+    });
+    await waitFor(() => {
+      expect(
+        store
+          .getActions()
+          .find((dispatch) => dispatch.type === updateAction.type),
+      ).toMatchObject(updateAction);
+    });
+  });
+});

--- a/src/juju/apiHooks.ts
+++ b/src/juju/apiHooks.ts
@@ -44,8 +44,7 @@ export const useModelConnection = (
     )
       .then(response)
       .catch((error) => {
-        const message = error instanceof Error ? error.message : error;
-        response(null, typeof message === "string" ? message : "Unknown error");
+        response(null, error instanceof Error ? error.message : error);
       });
   }, [
     response,
@@ -102,7 +101,7 @@ export const useListSecrets = (
           dispatch(
             jujuActions.setSecretsErrors({
               modelUUID,
-              errors: error,
+              errors: error instanceof Error ? error.message : error,
               wsControllerURL,
             }),
           );

--- a/src/juju/apiHooks.ts
+++ b/src/juju/apiHooks.ts
@@ -1,0 +1,115 @@
+import type {
+  SecretsFilter,
+  ListSecretsArgs,
+} from "@canonical/jujulib/dist/api/facades/secrets/SecretsV2";
+import { useEffect, useCallback } from "react";
+import { useSelector } from "react-redux";
+
+import { connectToModel } from "juju/api";
+import type { ConnectionWithFacades } from "juju/types";
+import {
+  getConfig,
+  getUserPass,
+  getWSControllerURL,
+} from "store/general/selectors";
+import { actions as jujuActions } from "store/juju";
+import { getModelByUUID, getModelUUIDFromList } from "store/juju/selectors";
+import { useAppSelector, useAppDispatch } from "store/store";
+
+export const useModelConnection = (
+  response: (
+    conn?: ConnectionWithFacades | null,
+    error?: string | null,
+  ) => void,
+  modelUUID?: string,
+) => {
+  const wsControllerURL = useAppSelector((state) =>
+    getModelByUUID(state, modelUUID),
+  )?.wsControllerURL;
+  const identityProviderAvailable =
+    useAppSelector(getConfig)?.identityProviderAvailable;
+  const credentials = useAppSelector((state) =>
+    getUserPass(state, wsControllerURL),
+  );
+
+  useEffect(() => {
+    if (!wsControllerURL || !modelUUID) {
+      return;
+    }
+    connectToModel(
+      modelUUID,
+      wsControllerURL,
+      credentials,
+      identityProviderAvailable,
+    )
+      .then(response)
+      .catch((error) => {
+        const message = error instanceof Error ? error.message : error;
+        response(null, typeof message === "string" ? message : "Unknown error");
+      });
+  }, [
+    response,
+    credentials,
+    identityProviderAvailable,
+    modelUUID,
+    wsControllerURL,
+  ]);
+};
+
+export const useListSecrets = (
+  userName?: string,
+  modelName?: string,
+  filter?: SecretsFilter,
+  showSecrets = false,
+) => {
+  const dispatch = useAppDispatch();
+  const modelUUID = useSelector(getModelUUIDFromList(modelName, userName));
+  const wsControllerURL = useAppSelector(getWSControllerURL);
+
+  const fetchSecrets = useCallback(
+    (connection?: ConnectionWithFacades | null, error?: string | null) => {
+      if (error && wsControllerURL) {
+        dispatch(
+          jujuActions.setSecretsErrors({
+            modelUUID,
+            errors: error,
+            wsControllerURL,
+          }),
+        );
+        return;
+      }
+      if (!connection || !wsControllerURL) {
+        return;
+      }
+      dispatch(jujuActions.secretsLoading({ modelUUID, wsControllerURL }));
+      connection?.facades.secrets
+        ?.listSecrets({
+          ...(filter ? { filter } : {}),
+          "show-secrets": showSecrets,
+          // The type provided by Juju's schema.json has the filter as required.
+        } as ListSecretsArgs)
+        .then((secrets) => {
+          dispatch(
+            jujuActions.updateSecrets({
+              modelUUID,
+              secrets: secrets?.results ?? [],
+              wsControllerURL,
+            }),
+          );
+          return;
+        })
+        .catch((error) => {
+          dispatch(
+            jujuActions.setSecretsErrors({
+              modelUUID,
+              errors: error,
+              wsControllerURL,
+            }),
+          );
+        });
+    },
+    [dispatch, filter, modelUUID, showSecrets, wsControllerURL],
+  );
+
+  useModelConnection(fetchSecrets, modelUUID);
+};

--- a/src/juju/types.ts
+++ b/src/juju/types.ts
@@ -12,6 +12,7 @@ import type ControllerV9 from "@canonical/jujulib/dist/api/facades/controller/Co
 import type ModelManagerV9 from "@canonical/jujulib/dist/api/facades/model-manager/ModelManagerV9";
 import type { ModelSLAInfo } from "@canonical/jujulib/dist/api/facades/model-manager/ModelManagerV9";
 import type PingerV1 from "@canonical/jujulib/dist/api/facades/pinger/PingerV1";
+import type SecretsV2 from "@canonical/jujulib/dist/api/facades/secrets/SecretsV2";
 
 import type JIMMV4 from "./jimm/JIMMV4";
 // See https://github.com/juju/juju/blob/main/rpc/params/multiwatcher.go
@@ -361,6 +362,7 @@ export type Facades = {
   controller?: ControllerV9;
   modelManager?: ModelManagerV9;
   pinger?: PingerV1;
+  secrets?: SecretsV2;
   jimM?: InstanceType<typeof JIMMV4>;
 };
 

--- a/src/pages/EntityDetails/Model/Model.test.tsx
+++ b/src/pages/EntityDetails/Model/Model.test.tsx
@@ -2,6 +2,7 @@ import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { TestId as InfoPanelTestId } from "components/InfoPanel/InfoPanel";
+import { TestId as SecretsTestId } from "pages/EntityDetails/Model/Secrets/Secrets";
 import type { RootState } from "store/store";
 import { jujuStateFactory, rootStateFactory } from "testing/factories";
 import {
@@ -60,6 +61,11 @@ jest.mock("juju/api", () => {
     queryActionsList: () => {
       return new Promise((resolve) => {
         resolve(mockActionResults);
+      });
+    },
+    connectToModel: () => {
+      return new Promise((resolve) => {
+        resolve({});
       });
     },
   };
@@ -435,7 +441,9 @@ describe("Model", () => {
       path,
     });
     expect(
-      within(screen.getByTestId(TestId.MAIN)).getByText("Secrets"),
+      within(screen.getByTestId(TestId.MAIN)).getByTestId(
+        SecretsTestId.SECRETS_TAB,
+      ),
     ).toBeInTheDocument();
   });
 

--- a/src/pages/EntityDetails/Model/Secrets/Secrets.test.tsx
+++ b/src/pages/EntityDetails/Model/Secrets/Secrets.test.tsx
@@ -1,12 +1,87 @@
 import { screen } from "@testing-library/react";
 
+import { TestId as LoadingTestId } from "components/LoadingSpinner/LoadingSpinner";
+import type { RootState } from "store/store";
+import { rootStateFactory } from "testing/factories";
+import {
+  configFactory,
+  credentialFactory,
+  generalStateFactory,
+} from "testing/factories/general";
+import {
+  modelListInfoFactory,
+  secretsStateFactory,
+  listSecretResultFactory,
+  modelSecretsFactory,
+} from "testing/factories/juju/juju";
 import { renderComponent } from "testing/utils";
 
-import Secrets from "./Secrets";
+import Secrets, { TestId } from "./Secrets";
 
 describe("Secrets", () => {
-  it("can display the action logs tab", async () => {
-    renderComponent(<Secrets />);
-    expect(screen.getByText("Secrets")).toBeInTheDocument();
+  let state: RootState;
+  const path = "/models/:userName/:modelName/app/:appName";
+  const url = "/models/eggman@external/test-model/app/easyrsa";
+
+  beforeEach(() => {
+    state = rootStateFactory.build({
+      general: generalStateFactory.build({
+        credentials: {
+          "wss://example.com/api": credentialFactory.build(),
+        },
+        config: configFactory.build({
+          controllerAPIEndpoint: "wss://example.com/api",
+        }),
+      }),
+      juju: {
+        models: {
+          abc123: modelListInfoFactory.build({
+            wsControllerURL: "wss://example.com/api",
+            uuid: "abc123",
+          }),
+        },
+        secrets: secretsStateFactory.build({
+          abc123: modelSecretsFactory.build({
+            items: [listSecretResultFactory.build()],
+            loaded: true,
+          }),
+        }),
+      },
+    });
+  });
+
+  it("displays the loading state", async () => {
+    state.juju.secrets = secretsStateFactory.build({
+      abc123: modelSecretsFactory.build({
+        loading: true,
+      }),
+    });
+    renderComponent(<Secrets />, { state, path, url });
+    expect(screen.queryByTestId(LoadingTestId.LOADING)).toBeInTheDocument();
+  });
+
+  it("displays errors", async () => {
+    state.juju.secrets = secretsStateFactory.build({
+      abc123: modelSecretsFactory.build({
+        errors: "failed to load",
+        loaded: true,
+      }),
+    });
+    renderComponent(<Secrets />, { state, path, url });
+    expect(
+      document.querySelector(".p-notification--negative"),
+    ).toHaveTextContent("failed to load");
+  });
+
+  it("displays a list of secrets", async () => {
+    renderComponent(<Secrets />, { state, path, url });
+    expect(screen.getByTestId(TestId.SECRETS_TABLE)).toBeInTheDocument();
+  });
+
+  it("cleans up secrets when unmounted", async () => {
+    const { result } = renderComponent(<Secrets />, { state, path, url });
+    expect(screen.getByTestId(TestId.SECRETS_TABLE)).toBeInTheDocument();
+    result.unmount();
+    expect(screen.queryByTestId(TestId.SECRETS_TABLE)).not.toBeInTheDocument();
   });
 });

--- a/src/pages/EntityDetails/Model/Secrets/Secrets.tsx
+++ b/src/pages/EntityDetails/Model/Secrets/Secrets.tsx
@@ -1,5 +1,77 @@
+import { Notification } from "@canonical/react-components";
+import type { ReactNode } from "react";
+import { useEffect } from "react";
+import { useParams } from "react-router-dom";
+
+import LoadingSpinner from "components/LoadingSpinner";
+import type { EntityDetailsRoute } from "components/Routes/Routes";
+import { useListSecrets } from "juju/apiHooks";
+import { actions as jujuActions } from "store/juju";
+import {
+  getSecretsLoaded,
+  getSecretsLoading,
+  getModelSecrets,
+  getModelByUUID,
+  getModelUUIDFromList,
+  getSecretsErrors,
+} from "store/juju/selectors";
+import { useAppDispatch, useAppSelector } from "store/store";
+
+export enum TestId {
+  SECRETS_TABLE = "secrets-table",
+  SECRETS_TAB = "secrets-tab",
+}
+
 const Secrets = () => {
-  return <div>Secrets</div>;
+  const { userName, modelName } = useParams<EntityDetailsRoute>();
+  const dispatch = useAppDispatch();
+  const modelUUID = useAppSelector(getModelUUIDFromList(modelName, userName));
+  const wsControllerURL = useAppSelector((state) =>
+    getModelByUUID(state, modelUUID),
+  )?.wsControllerURL;
+  const secrets = useAppSelector((state) => getModelSecrets(state, modelUUID));
+  const secretsErrors = useAppSelector((state) =>
+    getSecretsErrors(state, modelUUID),
+  );
+  const secretsLoaded = useAppSelector((state) =>
+    getSecretsLoaded(state, modelUUID),
+  );
+  const secretsLoading = useAppSelector((state) =>
+    getSecretsLoading(state, modelUUID),
+  );
+
+  useListSecrets(userName, modelName);
+
+  useEffect(
+    () => () => {
+      if (!modelUUID || !wsControllerURL) {
+        return;
+      }
+      dispatch(jujuActions.clearSecrets({ modelUUID, wsControllerURL }));
+    },
+    [dispatch, modelUUID, wsControllerURL],
+  );
+
+  let content: ReactNode;
+  if (secretsLoading || !secretsLoaded) {
+    content = <LoadingSpinner />;
+  } else if (secretsErrors) {
+    content = (
+      <Notification severity="negative" title="Error">
+        {secretsErrors}
+      </Notification>
+    );
+  } else {
+    content = (
+      <ul data-testid={TestId.SECRETS_TABLE}>
+        {secrets?.map((secret) => (
+          <li key={secret.uri}>{secret.label || secret.uri}</li>
+        ))}
+      </ul>
+    );
+  }
+
+  return <div data-testid={TestId.SECRETS_TAB}>{content}</div>;
 };
 
 export default Secrets;

--- a/src/store/juju/actions.test.ts
+++ b/src/store/juju/actions.test.ts
@@ -4,6 +4,7 @@ import {
 } from "testing/factories/juju/Charms";
 import { fullStatusFactory } from "testing/factories/juju/ClientV6";
 import { auditEventFactory } from "testing/factories/juju/jimm";
+import { listSecretResultFactory } from "testing/factories/juju/juju";
 
 import { actions } from "./slice";
 
@@ -237,6 +238,71 @@ describe("actions", () => {
     ).toStrictEqual({
       type: "juju/updateSelectedApplications",
       payload: { selectedApplications },
+    });
+  });
+
+  it("secretsLoading", () => {
+    expect(
+      actions.secretsLoading({
+        modelUUID: "abc123",
+        wsControllerURL: "wss://test.example.com",
+      }),
+    ).toStrictEqual({
+      type: "juju/secretsLoading",
+      payload: {
+        modelUUID: "abc123",
+        wsControllerURL: "wss://test.example.com",
+      },
+    });
+  });
+
+  it("updateSecrets", () => {
+    const secrets = [listSecretResultFactory.build()];
+    expect(
+      actions.updateSecrets({
+        modelUUID: "abc123",
+        secrets,
+        wsControllerURL: "wss://test.example.com",
+      }),
+    ).toStrictEqual({
+      type: "juju/updateSecrets",
+      payload: {
+        modelUUID: "abc123",
+        secrets,
+        wsControllerURL: "wss://test.example.com",
+      },
+    });
+  });
+
+  it("setSecretsErrors", () => {
+    expect(
+      actions.setSecretsErrors({
+        errors: "Uh oh!",
+        modelUUID: "abc123",
+        wsControllerURL: "wss://test.example.com",
+      }),
+    ).toStrictEqual({
+      type: "juju/setSecretsErrors",
+      payload: {
+        errors: "Uh oh!",
+        modelUUID: "abc123",
+        wsControllerURL: "wss://test.example.com",
+      },
+    });
+  });
+
+  it("clearSecrets", () => {
+    expect(
+      actions.clearSecrets({
+        modelUUID: "abc123",
+        wsControllerURL: "wss://test.example.com",
+      }),
+    ).toStrictEqual({
+      type: "juju/clearSecrets",
+      payload: {
+        modelUUID: "abc123",
+        wsControllerURL: "wss://test.example.com",
+      },
     });
   });
 });

--- a/src/store/juju/reducers.test.ts
+++ b/src/store/juju/reducers.test.ts
@@ -487,6 +487,26 @@ describe("reducers", () => {
     });
   });
 
+  it("secretsLoading handles no existing model", () => {
+    const state = jujuStateFactory.build({
+      secrets: secretsStateFactory.build(),
+    });
+    expect(
+      reducer(
+        state,
+        actions.secretsLoading({
+          modelUUID: "abc123",
+          wsControllerURL: "wss://test.example.com",
+        }),
+      ),
+    ).toStrictEqual({
+      ...state,
+      secrets: secretsStateFactory.build({
+        abc123: modelSecretsFactory.build({ loading: true }),
+      }),
+    });
+  });
+
   it("setSecretsErrors", () => {
     const state = jujuStateFactory.build({
       secrets: secretsStateFactory.build({
@@ -520,6 +540,32 @@ describe("reducers", () => {
     });
   });
 
+  it("setSecretsErrors handles no existing model", () => {
+    const state = jujuStateFactory.build({
+      secrets: secretsStateFactory.build(),
+    });
+    expect(
+      reducer(
+        state,
+        actions.setSecretsErrors({
+          errors: "Uh oh!",
+          modelUUID: "abc123",
+          wsControllerURL: "wss://test.example.com",
+        }),
+      ),
+    ).toStrictEqual({
+      ...state,
+      secrets: secretsStateFactory.build({
+        abc123: modelSecretsFactory.build({
+          items: null,
+          errors: "Uh oh!",
+          loaded: true,
+          loading: false,
+        }),
+      }),
+    });
+  });
+
   it("updateSecrets", () => {
     const state = jujuStateFactory.build({
       secrets: secretsStateFactory.build({
@@ -530,6 +576,33 @@ describe("reducers", () => {
           loading: true,
         }),
       }),
+    });
+    const items = [listSecretResultFactory.build()];
+    expect(
+      reducer(
+        state,
+        actions.updateSecrets({
+          secrets: items,
+          modelUUID: "abc123",
+          wsControllerURL: "wss://test.example.com",
+        }),
+      ),
+    ).toStrictEqual({
+      ...state,
+      secrets: secretsStateFactory.build({
+        abc123: modelSecretsFactory.build({
+          items,
+          errors: null,
+          loaded: true,
+          loading: false,
+        }),
+      }),
+    });
+  });
+
+  it("updateSecrets handles no existing model", () => {
+    const state = jujuStateFactory.build({
+      secrets: secretsStateFactory.build(),
     });
     const items = [listSecretResultFactory.build()];
     expect(

--- a/src/store/juju/reducers.test.ts
+++ b/src/store/juju/reducers.test.ts
@@ -13,6 +13,9 @@ import {
   modelListInfoFactory,
   auditEventsStateFactory,
   crossModelQueryStateFactory,
+  secretsStateFactory,
+  listSecretResultFactory,
+  modelSecretsFactory,
 } from "testing/factories/juju/juju";
 import {
   modelWatcherModelDataFactory,
@@ -459,6 +462,121 @@ describe("reducers", () => {
     ).toStrictEqual({
       ...state,
       selectedApplications,
+    });
+  });
+
+  it("secretsLoading", () => {
+    const state = jujuStateFactory.build({
+      secrets: secretsStateFactory.build({
+        abc123: modelSecretsFactory.build({ loading: false }),
+      }),
+    });
+    expect(
+      reducer(
+        state,
+        actions.secretsLoading({
+          modelUUID: "abc123",
+          wsControllerURL: "wss://test.example.com",
+        }),
+      ),
+    ).toStrictEqual({
+      ...state,
+      secrets: secretsStateFactory.build({
+        abc123: modelSecretsFactory.build({ loading: true }),
+      }),
+    });
+  });
+
+  it("setSecretsErrors", () => {
+    const state = jujuStateFactory.build({
+      secrets: secretsStateFactory.build({
+        abc123: modelSecretsFactory.build({
+          items: null,
+          errors: null,
+          loaded: false,
+          loading: true,
+        }),
+      }),
+    });
+    expect(
+      reducer(
+        state,
+        actions.setSecretsErrors({
+          errors: "Uh oh!",
+          modelUUID: "abc123",
+          wsControllerURL: "wss://test.example.com",
+        }),
+      ),
+    ).toStrictEqual({
+      ...state,
+      secrets: secretsStateFactory.build({
+        abc123: modelSecretsFactory.build({
+          items: null,
+          errors: "Uh oh!",
+          loaded: true,
+          loading: false,
+        }),
+      }),
+    });
+  });
+
+  it("updateSecrets", () => {
+    const state = jujuStateFactory.build({
+      secrets: secretsStateFactory.build({
+        abc123: modelSecretsFactory.build({
+          items: null,
+          errors: null,
+          loaded: false,
+          loading: true,
+        }),
+      }),
+    });
+    const items = [listSecretResultFactory.build()];
+    expect(
+      reducer(
+        state,
+        actions.updateSecrets({
+          secrets: items,
+          modelUUID: "abc123",
+          wsControllerURL: "wss://test.example.com",
+        }),
+      ),
+    ).toStrictEqual({
+      ...state,
+      secrets: secretsStateFactory.build({
+        abc123: modelSecretsFactory.build({
+          items,
+          errors: null,
+          loaded: true,
+          loading: false,
+        }),
+      }),
+    });
+  });
+
+  it("clearSecrets", () => {
+    const items = [listSecretResultFactory.build()];
+    const state = jujuStateFactory.build({
+      secrets: secretsStateFactory.build({
+        abc123: modelSecretsFactory.build({
+          items,
+          errors: "Uh oh!",
+          loaded: true,
+          loading: true,
+        }),
+      }),
+    });
+    expect(
+      reducer(
+        state,
+        actions.clearSecrets({
+          modelUUID: "abc123",
+          wsControllerURL: "wss://test.example.com",
+        }),
+      ),
+    ).toStrictEqual({
+      ...state,
+      secrets: secretsStateFactory.build(),
     });
   });
 });

--- a/src/store/juju/selectors.test.ts
+++ b/src/store/juju/selectors.test.ts
@@ -21,6 +21,9 @@ import {
   modelDataUnitFactory,
   auditEventsStateFactory,
   crossModelQueryStateFactory,
+  secretsStateFactory,
+  listSecretResultFactory,
+  modelSecretsFactory,
 } from "testing/factories/juju/juju";
 import {
   applicationInfoFactory,
@@ -89,6 +92,11 @@ import {
   getFullModelName,
   getControllersCount,
   getModelCredential,
+  getSecretsErrors,
+  getSecretsLoaded,
+  getSecretsLoading,
+  getSecretsState,
+  getModelSecrets,
 } from "./selectors";
 
 describe("selectors", () => {
@@ -276,6 +284,87 @@ describe("selectors", () => {
             }),
           }),
         }),
+      ),
+    ).toStrictEqual(true);
+  });
+
+  it("getSecretsState", () => {
+    const secrets = secretsStateFactory.build();
+    expect(
+      getSecretsState(
+        rootStateFactory.build({
+          juju: jujuStateFactory.build({
+            secrets,
+          }),
+        }),
+      ),
+    ).toStrictEqual(secrets);
+  });
+
+  it("getSecretsResults", () => {
+    const items = [listSecretResultFactory.build()];
+    expect(
+      getModelSecrets(
+        rootStateFactory.build({
+          juju: jujuStateFactory.build({
+            secrets: secretsStateFactory.build({
+              abc123: modelSecretsFactory.build({ items }),
+            }),
+          }),
+        }),
+        "abc123",
+      ),
+    ).toStrictEqual(items);
+  });
+
+  it("getSecretsErrors", () => {
+    const errors = "Uh oh!";
+    expect(
+      getSecretsErrors(
+        rootStateFactory.build({
+          juju: jujuStateFactory.build({
+            secrets: secretsStateFactory.build({
+              abc123: modelSecretsFactory.build({
+                errors,
+              }),
+            }),
+          }),
+        }),
+        "abc123",
+      ),
+    ).toStrictEqual(errors);
+  });
+
+  it("getSecretsLoaded", () => {
+    expect(
+      getSecretsLoaded(
+        rootStateFactory.build({
+          juju: jujuStateFactory.build({
+            secrets: secretsStateFactory.build({
+              abc123: modelSecretsFactory.build({
+                loaded: true,
+              }),
+            }),
+          }),
+        }),
+        "abc123",
+      ),
+    ).toStrictEqual(true);
+  });
+
+  it("getSecretsLoading", () => {
+    expect(
+      getSecretsLoading(
+        rootStateFactory.build({
+          juju: jujuStateFactory.build({
+            secrets: secretsStateFactory.build({
+              abc123: modelSecretsFactory.build({
+                loading: true,
+              }),
+            }),
+          }),
+        }),
+        "abc123",
       ),
     ).toStrictEqual(true);
   });

--- a/src/store/juju/selectors.ts
+++ b/src/store/juju/selectors.ts
@@ -166,6 +166,36 @@ export const getCrossModelQueryLoading = createSelector(
   (crossModelQuery) => crossModelQuery.loading,
 );
 
+export const getSecretsState = createSelector(
+  [slice],
+  (sliceState) => sliceState.secrets,
+);
+
+export const getModelSecretsState = createSelector(
+  [getSecretsState, (_state: RootState, modelUUID: string) => modelUUID],
+  (secrets, modelUUID) => secrets[modelUUID],
+);
+
+export const getModelSecrets = createSelector(
+  [getModelSecretsState],
+  (secrets) => secrets?.items,
+);
+
+export const getSecretsErrors = createSelector(
+  [getModelSecretsState],
+  (secrets) => secrets?.errors,
+);
+
+export const getSecretsLoaded = createSelector(
+  [getModelSecretsState],
+  (secrets) => secrets?.loaded,
+);
+
+export const getSecretsLoading = createSelector(
+  [getModelSecretsState],
+  (secrets) => secrets?.loading,
+);
+
 /**
   Fetches the model data from state.
   @param state The application state.

--- a/src/store/juju/slice.ts
+++ b/src/store/juju/slice.ts
@@ -4,6 +4,7 @@ import type {
   ModelInfoResults,
   UserModelList,
 } from "@canonical/jujulib/dist/api/facades/model-manager/ModelManagerV9";
+import type { ListSecretResult } from "@canonical/jujulib/dist/api/facades/secrets/SecretsV2";
 import type { PayloadAction } from "@reduxjs/toolkit";
 import { createSlice } from "@reduxjs/toolkit";
 
@@ -29,6 +30,13 @@ type WsControllerURLParam = {
   wsControllerURL: string;
 };
 
+const DEFAULT_MODEL_SECRETS = {
+  items: null,
+  errors: null,
+  loading: false,
+  loaded: false,
+};
+
 const slice = createSlice({
   name: "juju",
   initialState: {
@@ -50,6 +58,7 @@ const slice = createSlice({
     modelData: {},
     modelWatcherData: {},
     charms: [],
+    secrets: {},
     selectedApplications: [],
   } as JujuState,
   reducers: {
@@ -246,6 +255,61 @@ const slice = createSlice({
       action: PayloadAction<{ selectedApplications: ApplicationInfo[] }>,
     ) => {
       state.selectedApplications = action.payload.selectedApplications;
+    },
+    secretsLoading: (
+      state,
+      action: PayloadAction<
+        {
+          modelUUID: string;
+        } & WsControllerURLParam
+      >,
+    ) => {
+      if (!state.secrets[action.payload.modelUUID]) {
+        state.secrets[action.payload.modelUUID] = { ...DEFAULT_MODEL_SECRETS };
+      }
+      state.secrets[action.payload.modelUUID].loading = true;
+    },
+    updateSecrets: (
+      state,
+      action: PayloadAction<
+        {
+          modelUUID: string;
+          secrets: ListSecretResult[];
+        } & WsControllerURLParam
+      >,
+    ) => {
+      if (!state.secrets[action.payload.modelUUID]) {
+        state.secrets[action.payload.modelUUID] = { ...DEFAULT_MODEL_SECRETS };
+      }
+      state.secrets[action.payload.modelUUID].items = action.payload.secrets;
+      state.secrets[action.payload.modelUUID].loading = false;
+      state.secrets[action.payload.modelUUID].loaded = true;
+    },
+    setSecretsErrors: (
+      state,
+      action: PayloadAction<
+        {
+          modelUUID: string;
+          errors: string;
+        } & WsControllerURLParam
+      >,
+    ) => {
+      if (!state.secrets[action.payload.modelUUID]) {
+        state.secrets[action.payload.modelUUID] = { ...DEFAULT_MODEL_SECRETS };
+      }
+      state.secrets[action.payload.modelUUID].errors = action.payload.errors;
+      state.secrets[action.payload.modelUUID].loading = false;
+      state.secrets[action.payload.modelUUID].loaded = true;
+    },
+    clearSecrets: (
+      state,
+      action: PayloadAction<
+        {
+          modelUUID: string;
+        } & WsControllerURLParam
+      >,
+    ) => {
+      delete state.secrets[action.payload.modelUUID];
     },
   },
 });

--- a/src/store/juju/types.ts
+++ b/src/store/juju/types.ts
@@ -1,5 +1,6 @@
 import type { Charm } from "@canonical/jujulib/dist/api/facades/charms/CharmsV6";
 import type { ModelInfo } from "@canonical/jujulib/dist/api/facades/model-manager/ModelManagerV9";
+import type { ListSecretResult } from "@canonical/jujulib/dist/api/facades/secrets/SecretsV2";
 
 import type { ControllerInfo } from "juju/jimm/JIMMV3";
 import type { AuditEvent } from "juju/jimm/JIMMV3";
@@ -9,6 +10,7 @@ import type {
   FullStatusWithAnnotations,
   ModelWatcherData,
 } from "juju/types";
+import type { GenericItemsState, GenericState } from "store/types";
 
 export type ControllerLocation = {
   cloud?: string;
@@ -57,19 +59,28 @@ export type ModelsList = {
   [uuid: string]: ModelListInfo;
 };
 
-export type AuditEventsState = {
-  items: AuditEvent[] | null;
-  loaded: boolean;
-  loading: boolean;
+export type AuditEventsState = Omit<
+  GenericItemsState<AuditEvent, void>,
+  "errors"
+> & {
   limit: number;
 };
 
-export type CrossModelQueryState = {
+export type CrossModelQueryState = GenericState<
+  CrossModelQueryResponse["errors"] | string
+> & {
   results: CrossModelQueryResponse["results"] | null;
-  errors: CrossModelQueryResponse["errors"] | string | null;
-  loaded: boolean;
-  loading: boolean;
 };
+
+export type SecretsContent = GenericState<string> & {
+  content: string | null;
+};
+
+export type ModelSecrets = GenericItemsState<ListSecretResult, string> & {
+  content?: SecretsContent;
+};
+
+export type SecretsState = Record<string, ModelSecrets>;
 
 export type JujuState = {
   auditEvents: AuditEventsState;
@@ -80,5 +91,6 @@ export type JujuState = {
   modelData: ModelDataList;
   modelWatcherData?: ModelWatcherData;
   charms: Charm[];
+  secrets: SecretsState;
   selectedApplications: ApplicationInfo[];
 };

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -1,0 +1,9 @@
+export type GenericItemsState<I, E> = GenericState<E> & {
+  items: I[] | null;
+};
+
+export type GenericState<E> = {
+  errors: E | null;
+  loaded: boolean;
+  loading: boolean;
+};

--- a/src/testing/factories/juju/juju.ts
+++ b/src/testing/factories/juju/juju.ts
@@ -6,6 +6,7 @@ import type {
   UnitStatus,
 } from "@canonical/jujulib/dist/api/facades/client/ClientV6";
 import type { ModelInfo } from "@canonical/jujulib/dist/api/facades/model-manager/ModelManagerV9";
+import type { ListSecretResult } from "@canonical/jujulib/dist/api/facades/secrets/SecretsV2";
 import { Factory } from "fishery";
 
 import { DEFAULT_AUDIT_EVENTS_LIMIT } from "store/juju/slice";
@@ -17,6 +18,8 @@ import type {
   JujuState,
   ModelData,
   ModelListInfo,
+  ModelSecrets,
+  SecretsState,
 } from "store/juju/types";
 
 import { modelStatusInfoFactory, detailedStatusFactory } from "./ClientV6";
@@ -161,6 +164,16 @@ export const modelDataFactory = Factory.define<ModelData>(() => ({
   "remote-applications": {},
 }));
 
+export const listSecretResultFactory = Factory.define<ListSecretResult>(() => ({
+  "create-time": "2024-01-05T05:10:17Z",
+  "latest-revision": 1,
+  "owner-tag": "model-ab02a18f-1ea9-49cb-898d-cad17d330b21",
+  "update-time": "2024-01-05T05:10:17Z",
+  revisions: [],
+  uri: "secret:amboue9tqlp3g6kgq300",
+  version: 1,
+}));
+
 export const auditEventsStateFactory = Factory.define<AuditEventsState>(() => ({
   items: null,
   loaded: false,
@@ -177,6 +190,15 @@ export const crossModelQueryStateFactory = Factory.define<CrossModelQueryState>(
   }),
 );
 
+export const modelSecretsFactory = Factory.define<ModelSecrets>(() => ({
+  items: null,
+  errors: null,
+  loaded: false,
+  loading: false,
+}));
+
+export const secretsStateFactory = Factory.define<SecretsState>(() => ({}));
+
 export const jujuStateFactory = Factory.define<JujuState>(() => ({
   auditEvents: auditEventsStateFactory.build(),
   crossModelQuery: crossModelQueryStateFactory.build(),
@@ -186,5 +208,6 @@ export const jujuStateFactory = Factory.define<JujuState>(() => ({
   modelData: {},
   modelWatcherData: {},
   charms: [],
+  secrets: {},
   selectedApplications: [],
 }));


### PR DESCRIPTION
## Done

- Fetch and store secrets.

## QA

- Set up a controller with Juju 3.3.1.
- Add some secrets to a model with: `juju add-secret my-apitoken token=34ae35facd4`
- Open the dashboard and navigate to the model.
- Click on the Secrets tab.
- The secrets should get fetch and displayed in a list.

## Details

https://warthogs.atlassian.net/browse/WD-8431
