### PR TITLE
WD-8412 - Hide secrets tab

### DIFF
--- a/src/pages/EntityDetails/EntityDetails.test.tsx
+++ b/src/pages/EntityDetails/EntityDetails.test.tsx
@@ -11,7 +11,11 @@ import {
   configFactory,
 } from "testing/factories/general";
 import { modelListInfoFactory } from "testing/factories/juju/juju";
-import { controllerFactory } from "testing/factories/juju/juju";
+import {
+  controllerFactory,
+  modelFeaturesStateFactory,
+  modelFeaturesFactory,
+} from "testing/factories/juju/juju";
 import {
   applicationInfoFactory,
   modelWatcherModelDataFactory,
@@ -116,7 +120,7 @@ describe("Entity Details Container", () => {
   it("lists the correct tabs", () => {
     renderComponent(<EntityDetails />, { path, url, state });
     expect(screen.getByTestId("view-selector")).toHaveTextContent(
-      /^ApplicationsIntegrationsLogsSecretsMachines$/,
+      /^ApplicationsIntegrationsLogsMachines$/,
     );
   });
 
@@ -135,11 +139,28 @@ describe("Entity Details Container", () => {
     };
     renderComponent(<EntityDetails />, { path, url, state });
     expect(screen.getByTestId("view-selector")).toHaveTextContent(
-      /^ApplicationsIntegrationsLogsSecrets$/,
+      /^ApplicationsIntegrationsLogs$/,
+    );
+  });
+
+  it("lists the secrets tab", () => {
+    state.juju.modelFeatures = modelFeaturesStateFactory.build({
+      abc123: modelFeaturesFactory.build({
+        listSecrets: true,
+      }),
+    });
+    renderComponent(<EntityDetails />, { path, url, state });
+    expect(screen.getByTestId("view-selector")).toHaveTextContent(
+      /^ApplicationsIntegrationsLogsSecretsMachines$/,
     );
   });
 
   it("clicking the tabs changes the visible section", async () => {
+    state.juju.modelFeatures = modelFeaturesStateFactory.build({
+      abc123: modelFeaturesFactory.build({
+        listSecrets: true,
+      }),
+    });
     renderComponent(<EntityDetails />, { path, url, state });
     const viewSelector = screen.getByTestId("view-selector");
     const sections = [

--- a/src/pages/EntityDetails/EntityDetails.tsx
+++ b/src/pages/EntityDetails/EntityDetails.tsx
@@ -16,6 +16,7 @@ import useWindowTitle from "hooks/useWindowTitle";
 import BaseLayout from "layout/BaseLayout/BaseLayout";
 import { getIsJuju, getUserPass } from "store/general/selectors";
 import {
+  getCanListSecrets,
   getControllerDataByUUID,
   getModelInfo,
   getModelListLoaded,
@@ -81,7 +82,9 @@ const EntityDetails = ({ modelWatcherError }: Props) => {
     getControllerDataByUUID(controllerUUID),
   );
   const entityType = getEntityType(routeParams);
-
+  const canListSecrets = useAppSelector((state) =>
+    getCanListSecrets(state, modelUUID),
+  );
   const credentials = useAppSelector((state) =>
     getUserPass(state, primaryControllerData?.[0]),
   );
@@ -138,14 +141,17 @@ const EntityDetails = ({ modelWatcherError }: Props) => {
         to: urls.model.tab({ userName, modelName, tab: ModelTab.LOGS }),
         component: Link,
       },
-      {
+    ];
+
+    if (canListSecrets) {
+      items.push({
         active: activeView === "secrets",
         label: "Secrets",
         onClick: (e: MouseEvent) => handleNavClick(e),
         to: urls.model.tab({ userName, modelName, tab: ModelTab.SECRETS }),
         component: Link,
-      },
-    ];
+      });
+    }
 
     if (modelInfo?.type !== "kubernetes") {
       items.push({

--- a/src/pages/EntityDetails/Model/Model.test.tsx
+++ b/src/pages/EntityDetails/Model/Model.test.tsx
@@ -25,6 +25,8 @@ import {
   modelDataFactory,
   modelDataInfoFactory,
   modelListInfoFactory,
+  modelFeaturesStateFactory,
+  modelFeaturesFactory,
 } from "testing/factories/juju/juju";
 import {
   applicationInfoFactory,
@@ -435,6 +437,11 @@ describe("Model", () => {
   });
 
   it("can display the secrets tab via the URL", async () => {
+    state.juju.modelFeatures = modelFeaturesStateFactory.build({
+      abc123: modelFeaturesFactory.build({
+        listSecrets: true,
+      }),
+    });
     renderComponent(<Model />, {
       state,
       url: "/models/eggman@external/test1?activeView=secrets",
@@ -445,6 +452,24 @@ describe("Model", () => {
         SecretsTestId.SECRETS_TAB,
       ),
     ).toBeInTheDocument();
+  });
+
+  it("does not display the secrets tab if the feature is not available", async () => {
+    state.juju.modelFeatures = modelFeaturesStateFactory.build({
+      abc123: modelFeaturesFactory.build({
+        listSecrets: false,
+      }),
+    });
+    renderComponent(<Model />, {
+      state,
+      url: "/models/eggman@external/test1?activeView=secrets",
+      path,
+    });
+    expect(
+      within(screen.getByTestId(TestId.MAIN)).queryByTestId(
+        SecretsTestId.SECRETS_TAB,
+      ),
+    ).not.toBeInTheDocument();
   });
 
   it("renders the details pane for models shared-with-me", () => {

--- a/src/pages/EntityDetails/Model/Model.tsx
+++ b/src/pages/EntityDetails/Model/Model.tsx
@@ -18,7 +18,7 @@ import {
   getModelUnits,
   getModelUUIDFromList,
 } from "store/juju/selectors";
-import { getModelCredential } from "store/juju/selectors";
+import { getModelCredential, getCanListSecrets } from "store/juju/selectors";
 import { extractCloudName } from "store/juju/utils/models";
 import { useAppSelector } from "store/store";
 import {
@@ -93,6 +93,9 @@ const Model = () => {
   const relations = useSelector(getModelRelations(modelUUID));
   const machines = useSelector(getModelMachines(modelUUID));
   const units = useSelector(getModelUnits(modelUUID));
+  const canListSecrets = useAppSelector((state) =>
+    getCanListSecrets(state, modelUUID),
+  );
   const canConfigureModel = useCanConfigureModel();
 
   const machinesTableRows = useMemo(() => {
@@ -245,7 +248,9 @@ const Model = () => {
           </>
         )}
         {shouldShow("logs", query.activeView) && <Logs />}
-        {shouldShow("secrets", query.activeView) && <Secrets />}
+        {shouldShow("secrets", query.activeView) && canListSecrets ? (
+          <Secrets />
+        ) : null}
       </div>
     </>
   );

--- a/src/store/juju/actions.test.ts
+++ b/src/store/juju/actions.test.ts
@@ -255,6 +255,26 @@ describe("actions", () => {
       payload: { selectedApplications },
     });
   });
+  it("updateModelFeatures", () => {
+    expect(
+      actions.updateModelFeatures({
+        modelUUID: "abc123",
+        features: {
+          listSecrets: true,
+        },
+        wsControllerURL: "wss://test.example.com",
+      }),
+    ).toStrictEqual({
+      type: "juju/updateModelFeatures",
+      payload: {
+        modelUUID: "abc123",
+        features: {
+          listSecrets: true,
+        },
+        wsControllerURL: "wss://test.example.com",
+      },
+    });
+  });
 
   it("secretsLoading", () => {
     expect(

--- a/src/store/juju/reducers.test.ts
+++ b/src/store/juju/reducers.test.ts
@@ -16,6 +16,7 @@ import {
   secretsStateFactory,
   listSecretResultFactory,
   modelSecretsFactory,
+  modelFeaturesStateFactory,
 } from "testing/factories/juju/juju";
 import {
   modelWatcherModelDataFactory,
@@ -461,6 +462,30 @@ describe("reducers", () => {
         charmInfoFactory.build({ url: "ch:postgres" }),
       ],
     });
+  });
+
+  it("updateModelFeatures", () => {
+    const state = jujuStateFactory.build();
+    expect(
+      reducer(
+        state,
+        actions.updateModelFeatures({
+          modelUUID: "abc123",
+          features: {
+            listSecrets: true,
+          },
+          wsControllerURL: "wss://test.example.com",
+        }),
+      ),
+    ).toStrictEqual(
+      jujuStateFactory.build({
+        modelFeatures: modelFeaturesStateFactory.build({
+          abc123: {
+            listSecrets: true,
+          },
+        }),
+      }),
+    );
   });
 
   it("updateSelectedApplications", () => {

--- a/src/store/juju/selectors.test.ts
+++ b/src/store/juju/selectors.test.ts
@@ -24,6 +24,8 @@ import {
   secretsStateFactory,
   listSecretResultFactory,
   modelSecretsFactory,
+  modelFeaturesFactory,
+  modelFeaturesStateFactory,
 } from "testing/factories/juju/juju";
 import {
   applicationInfoFactory,
@@ -97,6 +99,10 @@ import {
   getSecretsLoading,
   getSecretsState,
   getModelSecrets,
+  getModelFeaturesState,
+  getCanListSecrets,
+  getModelFeatures,
+  getCanManageSecrets,
 } from "./selectors";
 
 describe("selectors", () => {
@@ -361,6 +367,74 @@ describe("selectors", () => {
               abc123: modelSecretsFactory.build({
                 loading: true,
               }),
+            }),
+          }),
+        }),
+        "abc123",
+      ),
+    ).toStrictEqual(true);
+  });
+
+  it("getModelFeaturesState", () => {
+    const modelFeatures = modelFeaturesStateFactory.build();
+    expect(
+      getModelFeaturesState(
+        rootStateFactory.build({
+          juju: jujuStateFactory.build({
+            modelFeatures,
+          }),
+        }),
+      ),
+    ).toStrictEqual(modelFeatures);
+  });
+
+  it("getModelFeatures", () => {
+    const modelFeatures = modelFeaturesFactory.build({
+      listSecrets: true,
+      manageSecrets: true,
+    });
+    expect(
+      getModelFeatures(
+        rootStateFactory.build({
+          juju: jujuStateFactory.build({
+            modelFeatures: modelFeaturesStateFactory.build({
+              abc123: modelFeatures,
+            }),
+          }),
+        }),
+        "abc123",
+      ),
+    ).toStrictEqual(modelFeatures);
+  });
+
+  it("getCanListSecrets", () => {
+    const modelFeatures = modelFeaturesFactory.build({
+      listSecrets: true,
+    });
+    expect(
+      getCanListSecrets(
+        rootStateFactory.build({
+          juju: jujuStateFactory.build({
+            modelFeatures: modelFeaturesStateFactory.build({
+              abc123: modelFeatures,
+            }),
+          }),
+        }),
+        "abc123",
+      ),
+    ).toStrictEqual(true);
+  });
+
+  it("getCanManageSecrets", () => {
+    const modelFeatures = modelFeaturesFactory.build({
+      manageSecrets: true,
+    });
+    expect(
+      getCanManageSecrets(
+        rootStateFactory.build({
+          juju: jujuStateFactory.build({
+            modelFeatures: modelFeaturesStateFactory.build({
+              abc123: modelFeatures,
             }),
           }),
         }),

--- a/src/store/juju/selectors.ts
+++ b/src/store/juju/selectors.ts
@@ -196,6 +196,26 @@ export const getSecretsLoading = createSelector(
   (secrets) => secrets?.loading,
 );
 
+export const getModelFeaturesState = createSelector(
+  [slice],
+  (sliceState) => sliceState.modelFeatures,
+);
+
+export const getModelFeatures = createSelector(
+  [getModelFeaturesState, (_state: RootState, modelUUID: string) => modelUUID],
+  (modelFeatures, modelUUID) => modelFeatures[modelUUID],
+);
+
+export const getCanListSecrets = createSelector(
+  [getModelFeatures],
+  (modelFeatures) => modelFeatures?.listSecrets,
+);
+
+export const getCanManageSecrets = createSelector(
+  [getModelFeatures],
+  (modelFeatures) => modelFeatures?.manageSecrets,
+);
+
 /**
   Fetches the model data from state.
   @param state The application state.

--- a/src/store/juju/slice.ts
+++ b/src/store/juju/slice.ts
@@ -22,7 +22,7 @@ import type {
 import { processDeltas } from "juju/watchers";
 import { extractCloudName } from "store/juju/utils/models";
 
-import type { Controllers, JujuState } from "./types";
+import type { Controllers, JujuState, ModelFeatures } from "./types";
 
 export const DEFAULT_AUDIT_EVENTS_LIMIT = 50;
 
@@ -57,6 +57,7 @@ const slice = createSlice({
     modelsError: null,
     modelsLoaded: false,
     modelData: {},
+    modelFeatures: {},
     modelWatcherData: {},
     charms: [],
     secrets: {},
@@ -138,6 +139,17 @@ const slice = createSlice({
         state.modelData[modelInfo.uuid].info = modelInfo;
       }
     },
+    updateModelFeatures: (
+      state,
+      action: PayloadAction<
+        {
+          modelUUID: string;
+          features: ModelFeatures;
+        } & WsControllerURLParam
+      >,
+    ) => {
+      state.modelFeatures[action.payload.modelUUID] = action.payload.features;
+    },
     updateModelsError: (
       state,
       action: PayloadAction<
@@ -151,6 +163,7 @@ const slice = createSlice({
     clearModelData: (state) => {
       state.modelData = {};
       state.models = {};
+      state.modelFeatures = {};
       state.modelsError = null;
       state.modelsLoaded = false;
     },

--- a/src/store/juju/types.ts
+++ b/src/store/juju/types.ts
@@ -82,6 +82,13 @@ export type ModelSecrets = GenericItemsState<ListSecretResult, string> & {
 
 export type SecretsState = Record<string, ModelSecrets>;
 
+export type ModelFeatures = {
+  listSecrets?: boolean;
+  manageSecrets?: boolean;
+};
+
+export type ModelFeaturesState = Record<string, ModelFeatures>;
+
 export type JujuState = {
   auditEvents: AuditEventsState;
   crossModelQuery: CrossModelQueryState;
@@ -90,6 +97,7 @@ export type JujuState = {
   modelsError: string | null;
   modelsLoaded: boolean;
   modelData: ModelDataList;
+  modelFeatures: ModelFeaturesState;
   modelWatcherData?: ModelWatcherData;
   charms: Charm[];
   secrets: SecretsState;

--- a/src/store/middleware/model-poller.ts
+++ b/src/store/middleware/model-poller.ts
@@ -134,6 +134,7 @@ export const modelPollerMiddleware: Middleware<
         const jimmVersion = conn.facades.jimM?.version ?? 0;
         const auditLogsAvailable = jimmVersion >= 4;
         const identity = conn.info.user?.identity;
+        console.log(conn.facades);
         let auditLogsAllowed = false;
         if (auditLogsAvailable && identity) {
           try {
@@ -200,6 +201,7 @@ export const modelPollerMiddleware: Middleware<
               const models = await conn.facades.modelManager?.listModels({
                 tag: identity,
               });
+              console.log("models", models);
               if (models) {
                 reduxStore.dispatch(
                   jujuActions.updateModelList({ models, wsControllerURL }),

--- a/src/testing/factories/juju/juju.ts
+++ b/src/testing/factories/juju/juju.ts
@@ -17,6 +17,8 @@ import type {
   CrossModelQueryState,
   JujuState,
   ModelData,
+  ModelFeatures,
+  ModelFeaturesState,
   ModelListInfo,
   ModelSecrets,
   SecretsState,
@@ -199,6 +201,12 @@ export const modelSecretsFactory = Factory.define<ModelSecrets>(() => ({
 
 export const secretsStateFactory = Factory.define<SecretsState>(() => ({}));
 
+export const modelFeaturesFactory = Factory.define<ModelFeatures>(() => ({}));
+
+export const modelFeaturesStateFactory = Factory.define<ModelFeaturesState>(
+  () => ({}),
+);
+
 export const jujuStateFactory = Factory.define<JujuState>(() => ({
   auditEvents: auditEventsStateFactory.build(),
   crossModelQuery: crossModelQueryStateFactory.build(),
@@ -207,6 +215,7 @@ export const jujuStateFactory = Factory.define<JujuState>(() => ({
   modelsLoaded: false,
   modelsError: null,
   modelData: {},
+  modelFeatures: {},
   modelWatcherData: {},
   charms: [],
   secrets: {},


### PR DESCRIPTION
## Done

- Hide the secrets tab if the model doesn't support it.

## QA

- Connect to a Juju 3.3 controller.
- Go to a model details page.
- You should see a secrets tab.
- Connect to a Juju 2.9 controller.
- Go to a model details page.
- You should not see a secrets tab.

## Details

https://warthogs.atlassian.net/browse/WD-8412
