### PR TITLE
WD-8617 - fix: Fix displaying the first colorless part of the message in WebCLI

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -52,7 +52,8 @@
     "default-case": 0,
     "no-param-reassign": 0,
     "no-case-declarations": 0,
-    "prefer-destructuring": 0
+    "prefer-destructuring": 0,
+    "promise/catch-or-return": ["error", { "allowFinally": true }]
   },
   "settings": {
     "import/resolver": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@canonical/react-components": "0.47.1",
     "@reduxjs/toolkit": "2.0.1",
     "@sentry/browser": "7.93.0",
+    "ansi-to-html": "0.7.2",
     "async-limiter": "2.0.0",
     "classnames": "2.5.1",
     "clone-deep": "4.0.1",

--- a/src/components/WebCLI/Output.test.tsx
+++ b/src/components/WebCLI/Output.test.tsx
@@ -1,0 +1,52 @@
+import { screen } from "@testing-library/react";
+
+import { renderComponent } from "testing/utils";
+
+import Output from "./Output";
+
+describe("Output", () => {
+  it("should display content and not display help message", () => {
+    renderComponent(
+      <Output
+        content="Output"
+        helpMessage="Help message"
+        showHelp={false}
+        setShouldShowHelp={jest.fn()}
+      />,
+    );
+    expect(screen.getByText("Output")).toBeInTheDocument();
+    expect(screen.queryByText("Help message")).not.toBeInTheDocument();
+  });
+
+  it("should not display content and display help message", () => {
+    renderComponent(
+      <Output
+        content="Output"
+        helpMessage="Help message"
+        showHelp={true}
+        setShouldShowHelp={jest.fn()}
+      />,
+    );
+    expect(screen.queryByRole("Output")).not.toBeInTheDocument();
+    expect(screen.getByText("Help message")).toBeInTheDocument();
+  });
+
+  it("should display the content with correct color", () => {
+    renderComponent(
+      <Output
+        content="Regular output[31mRed output[34mBlue output"
+        helpMessage="Help message"
+        showHelp={false}
+        setShouldShowHelp={jest.fn()}
+      />,
+    );
+    expect(screen.getByText("Regular output")).toBeInTheDocument();
+    expect(screen.getByText("Red output")).toHaveStyle({
+      color: "rgb(205,49,49)",
+    });
+    expect(screen.getByText("Blue output")).toHaveStyle({
+      color: "rgb(26,114,200)",
+    });
+    expect(screen.queryByText("Help message")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/WebCLI/Output.test.tsx
+++ b/src/components/WebCLI/Output.test.tsx
@@ -2,7 +2,7 @@ import { screen } from "@testing-library/react";
 
 import { renderComponent } from "testing/utils";
 
-import Output, { ansiColors } from "./Output";
+import Output from "./Output";
 
 describe("Output", () => {
   it("should display content and not display help message", () => {
@@ -31,22 +31,26 @@ describe("Output", () => {
     expect(screen.getByText("Help message")).toBeInTheDocument();
   });
 
-  it("should display the content with correct color", () => {
+  it("should display the content with correct formatting", () => {
+    const content = `\u001b[1;39mApp\n\u001b[0m\u001b[33munknown`;
     renderComponent(
       <Output
-        content="Regular output[31mRed output[34mBlue output"
+        content={content}
         helpMessage="Help message"
         showHelp={false}
         setShouldShowHelp={jest.fn()}
       />,
     );
-    expect(screen.getByText("Regular output")).toBeInTheDocument();
-    expect(screen.getByText("Red output")).toHaveStyle({
-      color: `rgb(${ansiColors[31]})`,
+    const boldElements = screen.getAllByText(/.*/, { selector: "b" });
+    expect(boldElements).toHaveLength(1);
+    expect(boldElements[0].childNodes).toHaveLength(1);
+    const appSpanElement = boldElements[0].childNodes[0];
+    expect(appSpanElement).toHaveTextContent("App");
+    expect(appSpanElement).toHaveStyle({
+      color: "#FFF",
     });
-    expect(screen.getByText("Blue output")).toHaveStyle({
-      color: `rgb(${ansiColors[34]})`,
+    expect(screen.getByText("unknown")).toHaveStyle({
+      color: "#A50",
     });
-    expect(screen.queryByText("Help message")).not.toBeInTheDocument();
   });
 });

--- a/src/components/WebCLI/Output.test.tsx
+++ b/src/components/WebCLI/Output.test.tsx
@@ -2,7 +2,7 @@ import { screen } from "@testing-library/react";
 
 import { renderComponent } from "testing/utils";
 
-import Output from "./Output";
+import Output, { ansiColors } from "./Output";
 
 describe("Output", () => {
   it("should display content and not display help message", () => {
@@ -42,10 +42,10 @@ describe("Output", () => {
     );
     expect(screen.getByText("Regular output")).toBeInTheDocument();
     expect(screen.getByText("Red output")).toHaveStyle({
-      color: "rgb(205,49,49)",
+      color: `rgb(${ansiColors[31]})`,
     });
     expect(screen.getByText("Blue output")).toHaveStyle({
-      color: "rgb(26,114,200)",
+      color: `rgb(${ansiColors[34]})`,
     });
     expect(screen.queryByText("Help message")).not.toBeInTheDocument();
   });

--- a/src/components/WebCLI/Output.tsx
+++ b/src/components/WebCLI/Output.tsx
@@ -57,16 +57,13 @@ const colorize = (content: string) => {
   }
 
   let colorizedContent = "";
-  let previousIndex = 0;
   colors.forEach((color, index) => {
     const ansiCode = color[0];
     const ansiCodeNumber = ansiCode.replace("[", "").replace("m", "");
 
-    if (color.index !== 0 && previousIndex === 0) {
+    if (color.index !== 0 && index === 0) {
       // Add the content up until the first colour without wrapping it.
-      colorizedContent =
-        colorizedContent + content.substring(previousIndex, color.index);
-      previousIndex = color.index ?? 0;
+      colorizedContent += content.substring(0, color.index);
     }
     const endIndex = colors[index + 1]?.index || content.length;
     let part = content
@@ -77,14 +74,13 @@ const colorize = (content: string) => {
       part = `<span style="${style}">${part}</span>`;
     }
     colorizedContent = colorizedContent + part;
-    previousIndex = color.index ?? 0;
   });
   return colorizedContent;
 };
 
 const DEFAULT_HEIGHT = 300;
 // 20 is a magic number, sometimes the browser stops firing the drag at
-// an inoportune time and the element isn't left completely closed.
+// an inopportune time and the element isn't left completely closed.
 const CONSIDER_CLOSED = 20;
 const HELP_HEIGHT = 50;
 const dragHandles = ["webcli__output-dragarea", "webcli__output-handle"];

--- a/src/components/WebCLI/Output.tsx
+++ b/src/components/WebCLI/Output.tsx
@@ -16,7 +16,7 @@ type Props = {
 
 // Colors taken from the VSCode section of
 // https://en.wikipedia.org/wiki/ANSI_escape_code#3/4_bit
-const ansiColors = {
+export const ansiColors = {
   0: null, // reset
   30: "0,0,0", // Black
   31: "205,49,49", // Red

--- a/src/components/WebCLI/__snapshots__/WebCLI.test.tsx.snap
+++ b/src/components/WebCLI/__snapshots__/WebCLI.test.tsx.snap
@@ -6,7 +6,7 @@ Model       Controller       Cloud/Region     Version    SLA          Timestamp
 controller  google-us-east1  google/us-east1  2.9-beta1  unsupported  17:44:14Z
 
 Machine  State    DNS             Inst id        Series  AZ          Message
-0        started  35.190.153.209  juju-3686b9-0  focal   us-east1-b  RUNNING
+0        started  35.190.153.209  juju-3686b9-0  focal   us-east1-b  RUNNING
 "
 `;
 

--- a/src/panels/ActionsPanel/ActionsPanel.tsx
+++ b/src/panels/ActionsPanel/ActionsPanel.tsx
@@ -126,7 +126,6 @@ export default function ActionsPanel(): JSX.Element {
   const getActionsForApplicationCallback = useCallback(() => {
     setFetchingActionData(true);
     if (appName && modelUUID) {
-      // eslint-disable-next-line promise/catch-or-return
       getActionsForApplication(appName, modelUUID, appStore.getState())
         .then((actions) => {
           if (actions?.results?.[0]?.actions) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4752,6 +4752,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansi-to-html@npm:0.7.2":
+  version: 0.7.2
+  resolution: "ansi-to-html@npm:0.7.2"
+  dependencies:
+    entities: "npm:^2.2.0"
+  bin:
+    ansi-to-html: bin/ansi-to-html
+  checksum: 031da78f716e7c6b0e391c64f7bc5e95f2d37123dcc3237d8c592dc35830dd0da05e0c3f3e3f8179856cfe5fd85c689d2ad85024b71b50014da9ef6e8fa021cf
+  languageName: node
+  linkType: hard
+
 "any-promise@npm:^1.0.0":
   version: 1.3.0
   resolution: "any-promise@npm:1.3.0"
@@ -7335,7 +7346,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"entities@npm:^2.0.0":
+"entities@npm:^2.0.0, entities@npm:^2.2.0":
   version: 2.2.0
   resolution: "entities@npm:2.2.0"
   checksum: 7fba6af1f116300d2ba1c5673fc218af1961b20908638391b4e1e6d5850314ee2ac3ec22d741b3a8060479911c99305164aed19b6254bde75e7e6b1b2c3f3aa3
@@ -11064,6 +11075,7 @@ __metadata:
     "@types/redux-mock-store": "npm:1.0.6"
     "@typescript-eslint/eslint-plugin": "npm:6.18.1"
     "@typescript-eslint/parser": "npm:6.18.1"
+    ansi-to-html: "npm:0.7.2"
     async-limiter: "npm:2.0.0"
     classnames: "npm:2.5.1"
     clone-deep: "npm:4.0.1"


### PR DESCRIPTION
## Done

- Issue resolved: Until now, if the content in the `WebCLI` started straight away with a color, we displayed twice the beginning of the content. The second time it was displayed without color and with the color encoding appended to it (see screenshots).

## Details

- https://warthogs.atlassian.net/browse/WD-8617

## Screenshots
Before:
![Screenshot from 2024-02-02 12-48-11](https://github.com/canonical/juju-dashboard/assets/108150922/f8038f16-7bab-416f-b4a6-e2a76a786cb7)
After:
![Screenshot from 2024-02-02 12-48-33](https://github.com/canonical/juju-dashboard/assets/108150922/6bc6c9e7-b977-472d-8efa-7a1d63f1d132)



