### PR TITLE
Store inline errors by key

### DIFF
--- a/src/hooks/useInlineErrors.test.ts
+++ b/src/hooks/useInlineErrors.test.ts
@@ -1,0 +1,81 @@
+import { renderHook } from "@testing-library/react";
+
+import useInlineErrors from "./useInlineErrors";
+
+describe("useInlineErrors", () => {
+  it("can add an error", () => {
+    const { result, rerender } = renderHook(() => useInlineErrors());
+    let [errors, setError] = result.current;
+    setError("Error1", "Uh oh!");
+    rerender();
+    [errors] = result.current;
+    rerender();
+    [errors] = result.current;
+    expect(errors).toStrictEqual(["Uh oh!"]);
+  });
+
+  it("can update an error", () => {
+    const { result, rerender } = renderHook(() => useInlineErrors());
+    let [errors, setError] = result.current;
+    setError("Error1", "Uh oh!");
+    rerender();
+    [errors] = result.current;
+    expect(errors).toStrictEqual(["Uh oh!"]);
+    setError("Error1", "It just got worse");
+    rerender();
+    [errors] = result.current;
+    expect(errors).toStrictEqual(["It just got worse"]);
+  });
+
+  it("can clear an error", () => {
+    const { result, rerender } = renderHook(() => useInlineErrors());
+    let [errors, setError] = result.current;
+    setError("Error1", "Uh oh!");
+    rerender();
+    [errors] = result.current;
+    expect(errors).toStrictEqual(["Uh oh!"]);
+    setError("Error1", null);
+    rerender();
+    [errors] = result.current;
+    expect(errors).toStrictEqual([]);
+  });
+
+  it("returns errors", () => {
+    const { result, rerender } = renderHook(() => useInlineErrors());
+    let [errors, setError] = result.current;
+    setError("Error1", "Uh oh!");
+    rerender();
+    [errors] = result.current;
+    expect(errors).toStrictEqual(["Uh oh!"]);
+  });
+
+  it("does not return null errors", () => {
+    const { result, rerender } = renderHook(() => useInlineErrors());
+    let [errors, setError] = result.current;
+    setError("Error1", null);
+    rerender();
+    [errors] = result.current;
+    expect(errors).toStrictEqual([]);
+  });
+
+  it("can map errors", () => {
+    const { result, rerender } = renderHook(() =>
+      useInlineErrors({ Error1: (error) => `Mapped! ${error}` }),
+    );
+    let [errors, setError] = result.current;
+    setError("Error1", "Uh oh!");
+    rerender();
+    [errors] = result.current;
+    expect(errors).toStrictEqual(["Mapped! Uh oh!"]);
+  });
+
+  it("can check if an error exists", () => {
+    const { result, rerender } = renderHook(() => useInlineErrors());
+    let [, setError, hasError] = result.current;
+    expect(hasError("Error1")).toStrictEqual(false);
+    setError("Error1", "Uh oh!");
+    rerender();
+    [, , hasError] = result.current;
+    expect(hasError("Error1")).toStrictEqual(true);
+  });
+});

--- a/src/hooks/useInlineErrors.ts
+++ b/src/hooks/useInlineErrors.ts
@@ -35,7 +35,7 @@ function useInlineErrors(
     },
     [],
   );
-  const hasError = useCallback(
+  const hasInlineError = useCallback(
     (key: InlineError["key"]) =>
       !!inlineErrors.find(
         (inlineError) => inlineError.key === key && !!inlineError.error,
@@ -48,7 +48,7 @@ function useInlineErrors(
     }
     return nodes;
   }, []);
-  return [errors, setError, hasError];
+  return [errors, setError, hasInlineError];
 }
 
 export default useInlineErrors;

--- a/src/hooks/useInlineErrors.ts
+++ b/src/hooks/useInlineErrors.ts
@@ -1,0 +1,54 @@
+import type { ReactNode } from "react";
+import { useCallback, useState } from "react";
+
+type InlineError = {
+  key: string;
+  error: ReactNode;
+};
+
+type ErrorMapping = Record<
+  InlineError["key"],
+  (error: InlineError["error"]) => ReactNode
+>;
+
+type SetError = (key: InlineError["key"], error: InlineError["error"]) => void;
+
+type HasError = (key: InlineError["key"]) => boolean;
+
+function useInlineErrors(
+  mapping?: ErrorMapping,
+): [ReactNode[], SetError, HasError] {
+  const [inlineErrors, setInlineErrors] = useState<InlineError[]>([]);
+  const setError = useCallback(
+    (key: InlineError["key"], error: InlineError["error"]) => {
+      setInlineErrors((inlineErrors) => {
+        const existing = inlineErrors.find(
+          (inlineError) => inlineError.key === key,
+        );
+        if (!existing) {
+          inlineErrors.push({ key, error });
+        } else {
+          existing.error = error;
+        }
+        return inlineErrors;
+      });
+    },
+    [],
+  );
+  const hasError = useCallback(
+    (key: InlineError["key"]) =>
+      !!inlineErrors.find(
+        (inlineError) => inlineError.key === key && !!inlineError.error,
+      ),
+    [inlineErrors],
+  );
+  const errors = inlineErrors.reduce<ReactNode[]>((nodes, { key, error }) => {
+    if (error) {
+      nodes.push(mapping && key in mapping ? mapping[key](error) : error);
+    }
+    return nodes;
+  }, []);
+  return [errors, setError, hasError];
+}
+
+export default useInlineErrors;

--- a/src/panels/ActionsPanel/ActionsPanel.tsx
+++ b/src/panels/ActionsPanel/ActionsPanel.tsx
@@ -15,6 +15,7 @@ import LoadingHandler from "components/LoadingHandler/LoadingHandler";
 import Panel from "components/Panel";
 import RadioInputBox from "components/RadioInputBox/RadioInputBox";
 import type { EntityDetailsRoute } from "components/Routes/Routes";
+import useInlineErrors from "hooks/useInlineErrors";
 import { executeActionOnUnits, getActionsForApplication } from "juju/api";
 import PanelInlineErrors from "panels/PanelInlineErrors";
 import { usePanelQueryParams } from "panels/hooks";
@@ -87,6 +88,11 @@ type ActionsQueryParams = {
   units: string[];
 };
 
+enum InlineErrors {
+  GET_ACTION = "get-action",
+  EXECUTE_ACTION = "execute-action",
+}
+
 export default function ActionsPanel(): JSX.Element {
   const appStore = useAppStore();
   const appState = appStore.getState();
@@ -106,12 +112,22 @@ export default function ActionsPanel(): JSX.Element {
     string | undefined,
     SetSelectedAction,
   ] = useState<string>();
-  // First element in inLineErrors array corresponds to the get actions for
-  // application error. Second element corresponds to execute action error.
-  const [inlineErrors, setInlineErrors] = useState<(string | null)[]>([
-    null,
-    null,
-  ]);
+  const [inlineErrors, setInlineErrors, hasError] = useInlineErrors({
+    [InlineErrors.GET_ACTION]: (error) => (
+      // If get actions for application fails, we add a button for
+      // refetching the actions data to the first inline error.
+      <>
+        {error} Try{" "}
+        <Button
+          appearance="link"
+          onClick={() => getActionsForApplicationCallback()}
+        >
+          refetching
+        </Button>{" "}
+        the actions data.
+      </>
+    ),
+  });
   const [isExecutingAction, setIsExecutingAction] = useState<boolean>(false);
   const scrollArea = useRef<HTMLDivElement>(null);
   const { Portal } = usePortal();
@@ -132,26 +148,18 @@ export default function ActionsPanel(): JSX.Element {
           if (actions?.results?.[0]?.actions) {
             setActionData(actions.results[0].actions);
           }
-          setInlineErrors((prevInlineErrors) => {
-            const newInlineErrors = [...prevInlineErrors];
-            newInlineErrors[0] = null;
-            return newInlineErrors;
-          });
+          setInlineErrors(InlineErrors.GET_ACTION, null);
           return;
         })
         .catch((error) => {
-          setInlineErrors((prevInlineErrors) => {
-            const newInlineErrors = [...prevInlineErrors];
-            newInlineErrors[0] = Label.GET_ACTIONS_ERROR;
-            return newInlineErrors;
-          });
+          setInlineErrors(InlineErrors.GET_ACTION, Label.GET_ACTIONS_ERROR);
           console.error(Label.GET_ACTIONS_ERROR, error);
         })
         .finally(() => {
           setFetchingActionData(false);
         });
     }
-  }, [appName, appStore, modelUUID]);
+  }, [appName, appStore, modelUUID, setInlineErrors]);
 
   useEffect(() => {
     getActionsForApplicationCallback();
@@ -257,11 +265,10 @@ export default function ActionsPanel(): JSX.Element {
                     return;
                   })
                   .catch((error) => {
-                    setInlineErrors((prevInlineError) => {
-                      const newInlineErrors = [...prevInlineError];
-                      newInlineErrors[1] = Label.EXECUTE_ACTION_ERROR;
-                      return newInlineErrors;
-                    });
+                    setInlineErrors(
+                      InlineErrors.EXECUTE_ACTION,
+                      Label.EXECUTE_ACTION_ERROR,
+                    );
                     setIsExecutingAction(false);
                     console.error(Label.EXECUTE_ACTION_ERROR, error);
                   });
@@ -306,28 +313,7 @@ export default function ActionsPanel(): JSX.Element {
       ref={scrollArea}
     >
       <PanelInlineErrors
-        inlineErrors={
-          inlineErrors[0]
-            ? inlineErrors.map((error, index) =>
-                index === 0 ? (
-                  // If get actions for application fails, we add a button for
-                  // refetching the actions data to the first inline error.
-                  <>
-                    {error} Try{" "}
-                    <Button
-                      appearance="link"
-                      onClick={() => getActionsForApplicationCallback()}
-                    >
-                      refetching
-                    </Button>{" "}
-                    the actions data.
-                  </>
-                ) : (
-                  error
-                ),
-              )
-            : inlineErrors
-        }
+        inlineErrors={inlineErrors}
         scrollArea={scrollArea.current}
       />
       <p data-testid="actions-panel-unit-list">
@@ -336,7 +322,9 @@ export default function ActionsPanel(): JSX.Element {
       <LoadingHandler
         hasData={!!data}
         loading={fetchingActionData}
-        noDataMessage={inlineErrors[0] ? "" : Label.NO_ACTIONS_PROVIDED}
+        noDataMessage={
+          hasError(InlineErrors.GET_ACTION) ? "" : Label.NO_ACTIONS_PROVIDED
+        }
       >
         {Object.keys(actionData).map((actionName) => (
           <RadioInputBox


### PR DESCRIPTION
## Done

- Add a hook to store inline errors by key.
- Update ActionPanel to use the hook.

## QA

- Open the action panel.
- Check that inline errors appear like they did before (you might need to throw some errors in the component).
