### PR TITLE
WD-8401 - Remove secrets

### DIFF
--- a/src/pages/EntityDetails/Model/Secrets/SecretsTable/SecretsTable.test.tsx
+++ b/src/pages/EntityDetails/Model/Secrets/SecretsTable/SecretsTable.test.tsx
@@ -151,4 +151,24 @@ describe("SecretsTable", () => {
       }),
     );
   });
+
+  it("can display the remove secret panel", async () => {
+    state.juju.secrets = secretsStateFactory.build({
+      abc123: modelSecretsFactory.build({
+        items: [listSecretResultFactory.build({ uri: "secret:aabbccdd" })],
+        loaded: true,
+      }),
+    });
+    renderComponent(<SecretsTable />, { state, path, url });
+    expect(window.location.search).toEqual("");
+    await userEvent.click(
+      screen.getByRole("button", { name: Label.ACTION_MENU }),
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: Label.REMOVE_BUTTON }),
+    );
+    expect(window.location.search).toEqual(
+      "?panel=remove-secret&secret=secret%3Aaabbccdd",
+    );
+  });
 });

--- a/src/pages/EntityDetails/Model/Secrets/SecretsTable/SecretsTable.tsx
+++ b/src/pages/EntityDetails/Model/Secrets/SecretsTable/SecretsTable.tsx
@@ -3,6 +3,7 @@ import {
   Button,
   Icon,
   Tooltip,
+  ContextualMenu,
 } from "@canonical/react-components";
 import type { ReactNode } from "react";
 import { useMemo } from "react";
@@ -15,6 +16,7 @@ import RelativeDate from "components/RelativeDate";
 import type { EntityDetailsRoute } from "components/Routes/Routes";
 import TruncatedTooltip from "components/TruncatedTooltip";
 import { copyToClipboard } from "components/utils";
+import { useQueryParams } from "hooks/useQueryParams";
 import {
   getSecretsLoading,
   getSecretsLoaded,
@@ -26,7 +28,9 @@ import { useAppSelector } from "store/store";
 import SecretContent from "../SecretContent";
 
 export enum Label {
+  ACTION_MENU = "Action menu",
   COPY = "Copy",
+  REMOVE_BUTTON = "Remove secret",
 }
 
 export enum TestId {
@@ -43,6 +47,13 @@ const SecretsTable = () => {
   const secretsLoading = useAppSelector((state) =>
     getSecretsLoading(state, modelUUID),
   );
+  const [, setQuery] = useQueryParams<{
+    panel: string | null;
+    secret: string | null;
+  }>({
+    panel: null,
+    secret: null,
+  });
 
   const tableData = useMemo(() => {
     if (!secrets) {
@@ -97,10 +108,25 @@ const SecretsTable = () => {
         owner,
         created: <RelativeDate datetime={secret["create-time"]} />,
         updated: <RelativeDate datetime={secret["update-time"]} />,
-        actions: "",
+        actions: (
+          <ContextualMenu
+            links={[
+              {
+                children: Label.REMOVE_BUTTON,
+                onClick: () =>
+                  setQuery({ panel: "remove-secret", secret: secret.uri }),
+              },
+            ]}
+            position="right"
+            scrollOverflow
+            toggleAppearance="base"
+            toggleClassName="has-icon u-no-margin--bottom is-small"
+            toggleLabel={<Icon name="menu">{Label.ACTION_MENU}</Icon>}
+          />
+        ),
       };
     });
-  }, [modelUUID, secrets]);
+  }, [modelUUID, secrets, setQuery]);
 
   const columnData: Column[] = useMemo(
     () => [
@@ -136,6 +162,7 @@ const SecretsTable = () => {
       {
         Header: "Actions",
         accessor: "actions",
+        className: "u-align--right",
       },
     ],
     [],

--- a/src/panels/Panels.test.tsx
+++ b/src/panels/Panels.test.tsx
@@ -8,6 +8,7 @@ import { TestId as AuditLogsFilterPanelTestId } from "./AuditLogsFilterPanel/Aud
 import { TestId as CharmsAndActionsPanelTestId } from "./CharmsAndActionsPanel/CharmsAndActionsPanel";
 import { TestId as ConfigPanelTestId } from "./ConfigPanel/ConfigPanel";
 import Panels from "./Panels";
+import { TestId as RemoveSecretPanelTestId } from "./RemoveSecretPanel/RemoveSecretPanel";
 import { TestId as ShareModelTestId } from "./ShareModelPanel/ShareModel";
 
 describe("Panels", () => {
@@ -52,6 +53,15 @@ describe("Panels", () => {
     });
     expect(
       await screen.findByTestId(AddSecretPanelTestId.PANEL),
+    ).toBeInTheDocument();
+  });
+
+  it("can display the remove secret panel", async () => {
+    renderComponent(<Panels />, {
+      url: "/?panel=remove-secret",
+    });
+    expect(
+      await screen.findByTestId(RemoveSecretPanelTestId.PANEL),
     ).toBeInTheDocument();
   });
 });

--- a/src/panels/Panels.tsx
+++ b/src/panels/Panels.tsx
@@ -8,6 +8,7 @@ import ShareModel from "panels/ShareModelPanel/ShareModel";
 import AuditLogsFilterPanel from "./AuditLogsFilterPanel";
 import CharmsAndActionsPanel from "./CharmsAndActionsPanel/CharmsAndActionsPanel";
 import ConfigPanel from "./ConfigPanel/ConfigPanel";
+import RemoveSecretPanel from "./RemoveSecretPanel";
 
 export default function Panels() {
   const [panelQs] = useQueryParams<{ panel: string | null }>({
@@ -28,6 +29,8 @@ export default function Panels() {
         return <AuditLogsFilterPanel />;
       case "add-secret":
         return <AddSecretPanel />;
+      case "remove-secret":
+        return <RemoveSecretPanel />;
       default:
         return null;
     }

--- a/src/panels/RemoveSecretPanel/Fields/Fields.test.tsx
+++ b/src/panels/RemoveSecretPanel/Fields/Fields.test.tsx
@@ -1,0 +1,221 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Formik } from "formik";
+
+import type { RootState } from "store/store";
+import { rootStateFactory } from "testing/factories";
+import {
+  configFactory,
+  generalStateFactory,
+  credentialFactory,
+} from "testing/factories/general";
+import {
+  modelListInfoFactory,
+  secretsStateFactory,
+  listSecretResultFactory,
+  modelSecretsFactory,
+} from "testing/factories/juju/juju";
+import { renderComponent } from "testing/utils";
+import urls from "urls";
+
+import { secretRevisionFactory } from "../../../testing/factories/juju/juju";
+import type { FormFields } from "../types";
+
+import Fields, { Label } from "./Fields";
+
+describe("Fields", () => {
+  let state: RootState;
+  const path = urls.model.index(null);
+  const url = urls.model.index({
+    userName: "eggman@external",
+    modelName: "test-model",
+  });
+
+  beforeEach(() => {
+    state = rootStateFactory.build({
+      general: generalStateFactory.build({
+        credentials: {
+          "wss://example.com/api": credentialFactory.build(),
+        },
+        config: configFactory.build({
+          controllerAPIEndpoint: "wss://example.com/api",
+        }),
+      }),
+      juju: {
+        models: {
+          abc123: modelListInfoFactory.build({
+            wsControllerURL: "wss://example.com/api",
+            uuid: "abc123",
+          }),
+        },
+        secrets: secretsStateFactory.build({
+          abc123: modelSecretsFactory.build({
+            items: [
+              listSecretResultFactory.build({
+                uri: "secret:aabbccdd",
+                label: "secret1",
+                "latest-revision": 2,
+                revisions: [
+                  secretRevisionFactory.build({ revision: 1 }),
+                  secretRevisionFactory.build({ revision: 2 }),
+                ],
+              }),
+            ],
+            loaded: true,
+          }),
+        }),
+      },
+    });
+  });
+
+  it("lists revisions", async () => {
+    renderComponent(
+      <Formik<FormFields>
+        initialValues={{ removeAll: false, revision: "" }}
+        onSubmit={jest.fn()}
+      >
+        <Fields
+          secretURI="secret:aabbccdd"
+          hideConfirm={jest.fn()}
+          handleRemoveSecret={jest.fn()}
+          showConfirm={false}
+        />
+      </Formik>,
+      { state, path, url },
+    );
+    expect(
+      screen.getByRole("option", { name: "2 (latest)" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "1" })).toBeInTheDocument();
+  });
+
+  it("can show a confirmation", async () => {
+    renderComponent(
+      <Formik<FormFields>
+        initialValues={{ removeAll: false, revision: "" }}
+        onSubmit={jest.fn()}
+      >
+        <Fields
+          secretURI="secret:aabbccdd"
+          hideConfirm={jest.fn()}
+          handleRemoveSecret={jest.fn()}
+          showConfirm={true}
+        />
+      </Formik>,
+      { state, path, url },
+    );
+    expect(
+      screen.getByRole("dialog", { name: Label.CONFIRM_TITLE }),
+    ).toBeInTheDocument();
+  });
+
+  it("disables the revision field if the remove all checkbox is checked", async () => {
+    const handleRemoveSecret = jest.fn();
+    renderComponent(
+      <Formik<FormFields>
+        initialValues={{ removeAll: false, revision: "" }}
+        onSubmit={jest.fn()}
+      >
+        <Fields
+          secretURI="secret:aabbccdd"
+          hideConfirm={jest.fn()}
+          handleRemoveSecret={handleRemoveSecret}
+          showConfirm={true}
+        />
+      </Formik>,
+      { state, path, url },
+    );
+    await userEvent.click(
+      screen.getByRole("checkbox", { name: Label.REMOVE_ALL }),
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: Label.CONFIRM_BUTTON }),
+    );
+    expect(
+      screen.getByRole("combobox", { name: Label.REVISION }),
+    ).toBeDisabled();
+  });
+
+  it("can cancel the confirmation", async () => {
+    const hideConfirm = jest.fn();
+    renderComponent(
+      <Formik<FormFields>
+        initialValues={{ removeAll: false, revision: "" }}
+        onSubmit={jest.fn()}
+      >
+        <Fields
+          secretURI="secret:aabbccdd"
+          hideConfirm={hideConfirm}
+          handleRemoveSecret={jest.fn()}
+          showConfirm={true}
+        />
+      </Formik>,
+      { state, path, url },
+    );
+    await userEvent.selectOptions(
+      screen.getByRole("combobox", { name: Label.REVISION }),
+      "2 (latest)",
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: Label.CANCEL_BUTTON }),
+    );
+    expect(hideConfirm).toHaveBeenCalled();
+  });
+
+  it("can confirm a revision and call the callback", async () => {
+    const handleRemoveSecret = jest.fn();
+    renderComponent(
+      <Formik<FormFields>
+        initialValues={{ removeAll: false, revision: "" }}
+        onSubmit={jest.fn()}
+      >
+        <Fields
+          secretURI="secret:aabbccdd"
+          hideConfirm={jest.fn()}
+          handleRemoveSecret={handleRemoveSecret}
+          showConfirm={true}
+        />
+      </Formik>,
+      { state, path, url },
+    );
+    await userEvent.selectOptions(
+      screen.getByRole("combobox", { name: Label.REVISION }),
+      "2 (latest)",
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: Label.CONFIRM_BUTTON }),
+    );
+    expect(handleRemoveSecret).toHaveBeenCalledWith({
+      removeAll: false,
+      revision: "2",
+    });
+  });
+
+  it("can confirm all revisions and call the callback", async () => {
+    const handleRemoveSecret = jest.fn();
+    renderComponent(
+      <Formik<FormFields>
+        initialValues={{ removeAll: false, revision: "" }}
+        onSubmit={jest.fn()}
+      >
+        <Fields
+          secretURI="secret:aabbccdd"
+          hideConfirm={jest.fn()}
+          handleRemoveSecret={handleRemoveSecret}
+          showConfirm={true}
+        />
+      </Formik>,
+      { state, path, url },
+    );
+    await userEvent.click(
+      screen.getByRole("checkbox", { name: Label.REMOVE_ALL }),
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: Label.CONFIRM_BUTTON }),
+    );
+    expect(handleRemoveSecret).toHaveBeenCalledWith({
+      removeAll: true,
+      revision: "",
+    });
+  });
+});

--- a/src/panels/RemoveSecretPanel/Fields/Fields.test.tsx
+++ b/src/panels/RemoveSecretPanel/Fields/Fields.test.tsx
@@ -136,6 +136,37 @@ describe("Fields", () => {
     ).toBeDisabled();
   });
 
+  it("disables the remove all checkbox if there is only one revision", async () => {
+    state.juju.secrets.abc123 = modelSecretsFactory.build({
+      items: [
+        listSecretResultFactory.build({
+          uri: "secret:aabbccdd",
+          "latest-revision": 1,
+          revisions: [secretRevisionFactory.build({ revision: 1 })],
+        }),
+      ],
+      loaded: true,
+    });
+    const handleRemoveSecret = jest.fn();
+    renderComponent(
+      <Formik<FormFields>
+        initialValues={{ removeAll: false, revision: "" }}
+        onSubmit={jest.fn()}
+      >
+        <Fields
+          secretURI="secret:aabbccdd"
+          hideConfirm={jest.fn()}
+          handleRemoveSecret={handleRemoveSecret}
+          showConfirm={true}
+        />
+      </Formik>,
+      { state, path, url },
+    );
+    expect(
+      screen.getByRole("checkbox", { name: Label.REMOVE_ALL }),
+    ).toBeDisabled();
+  });
+
   it("can cancel the confirmation", async () => {
     const hideConfirm = jest.fn();
     renderComponent(

--- a/src/panels/RemoveSecretPanel/Fields/Fields.test.tsx
+++ b/src/panels/RemoveSecretPanel/Fields/Fields.test.tsx
@@ -136,13 +136,13 @@ describe("Fields", () => {
     ).toBeDisabled();
   });
 
-  it("disables the remove all checkbox if there is only one revision", async () => {
+  it("displays a message if there is only one revision", async () => {
     state.juju.secrets.abc123 = modelSecretsFactory.build({
       items: [
         listSecretResultFactory.build({
           uri: "secret:aabbccdd",
-          "latest-revision": 1,
-          revisions: [secretRevisionFactory.build({ revision: 1 })],
+          "latest-revision": 5,
+          revisions: [secretRevisionFactory.build({ revision: 5 })],
         }),
       ],
       loaded: true,
@@ -163,8 +163,16 @@ describe("Fields", () => {
       { state, path, url },
     );
     expect(
-      screen.getByRole("checkbox", { name: Label.REMOVE_ALL }),
-    ).toBeDisabled();
+      screen.queryByRole("checkbox", { name: Label.REMOVE_ALL }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("combobox", { name: Label.REVISION }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /This secret has one revision \(5\) and will be completely removed./,
+      ),
+    ).toBeInTheDocument();
   });
 
   it("can cancel the confirmation", async () => {

--- a/src/panels/RemoveSecretPanel/Fields/Fields.tsx
+++ b/src/panels/RemoveSecretPanel/Fields/Fields.tsx
@@ -47,6 +47,7 @@ const Fields = ({
         label={Label.REMOVE_ALL}
         name="removeAll"
         type="checkbox"
+        disabled={secret?.revisions.length === 1}
       />
       <FormikField
         label={Label.REVISION}

--- a/src/panels/RemoveSecretPanel/Fields/Fields.tsx
+++ b/src/panels/RemoveSecretPanel/Fields/Fields.tsx
@@ -1,0 +1,93 @@
+import { Select, ConfirmationModal } from "@canonical/react-components";
+import { useFormikContext } from "formik";
+import { useSelector } from "react-redux";
+import { useParams } from "react-router-dom";
+import usePortal from "react-useportal";
+
+import FormikField from "components/FormikField/FormikField";
+import type { EntityDetailsRoute } from "components/Routes/Routes";
+import { getSecretByURI, getModelUUIDFromList } from "store/juju/selectors";
+import { useAppSelector } from "store/store";
+
+import type { FormFields } from "../types";
+
+export enum Label {
+  CANCEL_BUTTON = "Cancel",
+  CONFIRM_BUTTON = "Remove",
+  CONFIRM_TITLE = "Remove secret?",
+  REMOVE_ALL = "Remove all revisions",
+  REVISION = "Revision",
+}
+
+type Props = {
+  hideConfirm: () => void;
+  handleRemoveSecret: (values: FormFields) => void;
+  secretURI?: string | null;
+  showConfirm: boolean;
+};
+
+const Fields = ({
+  hideConfirm,
+  handleRemoveSecret,
+  secretURI,
+  showConfirm,
+}: Props): JSX.Element => {
+  const { userName, modelName } = useParams<EntityDetailsRoute>();
+  const modelUUID = useSelector(getModelUUIDFromList(modelName, userName));
+  const { values } = useFormikContext<FormFields>();
+  const secret = useAppSelector((state) =>
+    getSecretByURI(state, modelUUID, secretURI),
+  );
+  const { Portal } = usePortal();
+
+  return (
+    <>
+      <FormikField
+        id={Label.REMOVE_ALL}
+        label={Label.REMOVE_ALL}
+        name="removeAll"
+        type="checkbox"
+      />
+      <FormikField
+        label={Label.REVISION}
+        name="revision"
+        component={Select}
+        disabled={values.removeAll}
+        options={
+          [...(secret?.revisions ?? [])].reverse().map(({ revision }) => ({
+            label: `${revision}${revision === secret?.["latest-revision"] ? " (latest)" : ""}`,
+            value: revision.toString(),
+          })) ?? []
+        }
+      />
+      {showConfirm ? (
+        <Portal>
+          <ConfirmationModal
+            title={Label.CONFIRM_TITLE}
+            cancelButtonLabel={Label.CANCEL_BUTTON}
+            confirmButtonLabel={Label.CONFIRM_BUTTON}
+            confirmButtonAppearance="negative"
+            confirmExtra={
+              <p className="u-text--muted p-text--small u-align--left">
+                This action can't be undone.
+              </p>
+            }
+            onConfirm={(event: React.MouseEvent<HTMLElement, MouseEvent>) => {
+              // Stop propagation of the click event in order for the Panel
+              // to remain open after an error occurs in executeAction().
+              // Remove this manual fix once this issue gets resolved:
+              // https://github.com/canonical/react-components/issues/1032
+              event.nativeEvent.stopImmediatePropagation();
+              handleRemoveSecret(values);
+            }}
+            close={hideConfirm}
+          >
+            <p>Are you sure you would like to remove this secret?</p>
+          </ConfirmationModal>
+        </Portal>
+      ) : null}
+    </>
+  );
+};
+
+export default Fields;

--- a/src/panels/RemoveSecretPanel/Fields/Fields.tsx
+++ b/src/panels/RemoveSecretPanel/Fields/Fields.tsx
@@ -42,25 +42,34 @@ const Fields = ({
 
   return (
     <>
-      <FormikField
-        id={Label.REMOVE_ALL}
-        label={Label.REMOVE_ALL}
-        name="removeAll"
-        type="checkbox"
-        disabled={secret?.revisions.length === 1}
-      />
-      <FormikField
-        label={Label.REVISION}
-        name="revision"
-        component={Select}
-        disabled={values.removeAll}
-        options={
-          [...(secret?.revisions ?? [])].reverse().map(({ revision }) => ({
-            label: `${revision}${revision === secret?.["latest-revision"] ? " (latest)" : ""}`,
-            value: revision.toString(),
-          })) ?? []
-        }
-      />
+      {(secret?.revisions.length ?? 0) > 1 ? (
+        <>
+          <FormikField
+            id={Label.REMOVE_ALL}
+            label={Label.REMOVE_ALL}
+            name="removeAll"
+            type="checkbox"
+            disabled={secret?.revisions.length === 1}
+          />
+          <FormikField
+            label={Label.REVISION}
+            name="revision"
+            component={Select}
+            disabled={values.removeAll}
+            options={
+              [...(secret?.revisions ?? [])].reverse().map(({ revision }) => ({
+                label: `${revision}${revision === secret?.["latest-revision"] ? " (latest)" : ""}`,
+                value: revision.toString(),
+              })) ?? []
+            }
+          />
+        </>
+      ) : (
+        <p>
+          This secret has one revision ({secret?.["latest-revision"]}) and will
+          be completely removed.
+        </p>
+      )}
       {showConfirm ? (
         <Portal>
           <ConfirmationModal

--- a/src/panels/RemoveSecretPanel/Fields/index.ts
+++ b/src/panels/RemoveSecretPanel/Fields/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Fields";

--- a/src/panels/RemoveSecretPanel/RemoveSecretPanel.test.tsx
+++ b/src/panels/RemoveSecretPanel/RemoveSecretPanel.test.tsx
@@ -1,0 +1,203 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import * as apiHooks from "juju/apiHooks";
+import type { RootState } from "store/store";
+import { rootStateFactory } from "testing/factories";
+import {
+  configFactory,
+  generalStateFactory,
+  credentialFactory,
+} from "testing/factories/general";
+import {
+  modelListInfoFactory,
+  secretsStateFactory,
+  listSecretResultFactory,
+  modelSecretsFactory,
+  secretRevisionFactory,
+} from "testing/factories/juju/juju";
+import { renderComponent } from "testing/utils";
+import urls from "urls";
+
+import { Label as FieldsLabel } from "./Fields/Fields";
+import RemoveSecretPanel, { Label } from "./RemoveSecretPanel";
+
+jest.mock("juju/apiHooks", () => {
+  return {
+    useRemoveSecrets: jest.fn().mockReturnValue(jest.fn()),
+    useListSecrets: jest.fn().mockReturnValue(jest.fn()),
+  };
+});
+
+describe("RemoveSecretPanel", () => {
+  let state: RootState;
+  const path = urls.model.index(null);
+  const url = `${urls.model.index({
+    userName: "eggman@external",
+    modelName: "test-model",
+  })}?panel=remove-secret&secret=secret:aabbccdd`;
+
+  beforeEach(() => {
+    state = rootStateFactory.build({
+      general: generalStateFactory.build({
+        credentials: {
+          "wss://example.com/api": credentialFactory.build(),
+        },
+        config: configFactory.build({
+          controllerAPIEndpoint: "wss://example.com/api",
+        }),
+      }),
+      juju: {
+        models: {
+          abc123: modelListInfoFactory.build({
+            wsControllerURL: "wss://example.com/api",
+            uuid: "abc123",
+          }),
+        },
+        secrets: secretsStateFactory.build({
+          abc123: modelSecretsFactory.build({
+            items: [
+              listSecretResultFactory.build({
+                uri: "secret:aabbccdd",
+                label: "secret1",
+                "latest-revision": 2,
+                revisions: [
+                  secretRevisionFactory.build({ revision: 1 }),
+                  secretRevisionFactory.build({ revision: 2 }),
+                ],
+              }),
+            ],
+            loaded: true,
+          }),
+        }),
+      },
+    });
+    jest.spyOn(apiHooks, "useListSecrets").mockImplementation(() => jest.fn());
+  });
+
+  it("shows a confirmation when the form is submitted", async () => {
+    const removeSecrets = jest
+      .fn()
+      .mockImplementation(() => Promise.resolve({ results: [] }));
+    jest
+      .spyOn(apiHooks, "useRemoveSecrets")
+      .mockImplementation(() => removeSecrets);
+    renderComponent(<RemoveSecretPanel />, { state, path, url });
+    await userEvent.click(screen.getByRole("button", { name: Label.SUBMIT }));
+    expect(
+      screen.getByRole("dialog", { name: FieldsLabel.CONFIRM_TITLE }),
+    ).toBeInTheDocument();
+    expect(removeSecrets).not.toHaveBeenCalled();
+  });
+
+  it("can remove a secret", async () => {
+    const removeSecrets = jest
+      .fn()
+      .mockImplementation(() => Promise.resolve({ results: [] }));
+    jest
+      .spyOn(apiHooks, "useRemoveSecrets")
+      .mockImplementation(() => removeSecrets);
+    renderComponent(<RemoveSecretPanel />, { state, path, url });
+    await userEvent.click(screen.getByRole("button", { name: Label.SUBMIT }));
+    await userEvent.click(
+      screen.getByRole("button", { name: FieldsLabel.CONFIRM_BUTTON }),
+    );
+    expect(removeSecrets).toHaveBeenCalledWith([
+      {
+        uri: "secret:aabbccdd",
+        revisions: [2],
+      },
+    ]);
+  });
+
+  it("displays caught errors", async () => {
+    const removeSecrets = jest
+      .fn()
+      .mockImplementation(() => Promise.reject(new Error("Caught error")));
+    jest
+      .spyOn(apiHooks, "useRemoveSecrets")
+      .mockImplementation(() => removeSecrets);
+    renderComponent(<RemoveSecretPanel />, { state, path, url });
+    await userEvent.click(screen.getByRole("button", { name: Label.SUBMIT }));
+    await userEvent.click(
+      screen.getByRole("button", { name: FieldsLabel.CONFIRM_BUTTON }),
+    );
+    expect(
+      document.querySelector(".p-notification--negative"),
+    ).toHaveTextContent("Caught error");
+  });
+
+  it("displays error string results", async () => {
+    const removeSecrets = jest
+      .fn()
+      .mockImplementation(() => Promise.resolve("String error"));
+    jest
+      .spyOn(apiHooks, "useRemoveSecrets")
+      .mockImplementation(() => removeSecrets);
+    renderComponent(<RemoveSecretPanel />, { state, path, url });
+    await userEvent.click(screen.getByRole("button", { name: Label.SUBMIT }));
+    await userEvent.click(
+      screen.getByRole("button", { name: FieldsLabel.CONFIRM_BUTTON }),
+    );
+    expect(
+      document.querySelector(".p-notification--negative"),
+    ).toHaveTextContent("String error");
+  });
+
+  it("displays error object results", async () => {
+    const removeSecrets = jest
+      .fn()
+      .mockImplementation(() =>
+        Promise.resolve({ results: [{ error: { message: "Error result" } }] }),
+      );
+    jest
+      .spyOn(apiHooks, "useRemoveSecrets")
+      .mockImplementation(() => removeSecrets);
+    renderComponent(<RemoveSecretPanel />, { state, path, url });
+    await userEvent.click(screen.getByRole("button", { name: Label.SUBMIT }));
+    await userEvent.click(
+      screen.getByRole("button", { name: FieldsLabel.CONFIRM_BUTTON }),
+    );
+    expect(
+      document.querySelector(".p-notification--negative"),
+    ).toHaveTextContent("Error result");
+  });
+
+  it("closes the panel if successful", async () => {
+    const removeSecrets = jest
+      .fn()
+      .mockImplementation(() => Promise.resolve({ results: [] }));
+    jest
+      .spyOn(apiHooks, "useRemoveSecrets")
+      .mockImplementation(() => removeSecrets);
+    renderComponent(<RemoveSecretPanel />, { state, path, url });
+    expect(window.location.search).toEqual(
+      "?panel=remove-secret&secret=secret:aabbccdd",
+    );
+    await userEvent.click(screen.getByRole("button", { name: Label.SUBMIT }));
+    await userEvent.click(
+      screen.getByRole("button", { name: FieldsLabel.CONFIRM_BUTTON }),
+    );
+    expect(window.location.search).toEqual("");
+  });
+
+  it("refetches the secrets if successful", async () => {
+    const removeSecrets = jest
+      .fn()
+      .mockImplementation(() => Promise.resolve({ results: [] }));
+    jest
+      .spyOn(apiHooks, "useRemoveSecrets")
+      .mockImplementation(() => removeSecrets);
+    const listSecrets = jest.fn();
+    jest
+      .spyOn(apiHooks, "useListSecrets")
+      .mockImplementation(() => listSecrets);
+    renderComponent(<RemoveSecretPanel />, { state, path, url });
+    expect(listSecrets).not.toHaveBeenCalled();
+    await userEvent.click(screen.getByRole("button", { name: Label.SUBMIT }));
+    await userEvent.click(
+      screen.getByRole("button", { name: FieldsLabel.CONFIRM_BUTTON }),
+    );
+    expect(listSecrets).toHaveBeenCalled();
+  });
+});

--- a/src/panels/RemoveSecretPanel/RemoveSecretPanel.tsx
+++ b/src/panels/RemoveSecretPanel/RemoveSecretPanel.tsx
@@ -111,7 +111,7 @@ const RemoveSecretPanel = () => {
         }
         onRemovePanelQueryParams={handleRemovePanelQueryParams}
         ref={scrollArea}
-        title="Add a secret"
+        title="Remove secret"
         width="narrow"
       >
         <>

--- a/src/panels/RemoveSecretPanel/RemoveSecretPanel.tsx
+++ b/src/panels/RemoveSecretPanel/RemoveSecretPanel.tsx
@@ -1,0 +1,150 @@
+import type { ErrorResults } from "@canonical/jujulib/dist/api/facades/secrets/SecretsV2";
+import { ActionButton, Button, Spinner } from "@canonical/react-components";
+import { Form, Formik } from "formik";
+import { useId, useState, useRef, useCallback } from "react";
+import { useSelector } from "react-redux";
+import { useParams } from "react-router-dom";
+
+import Panel from "components/Panel";
+import type { EntityDetailsRoute } from "components/Routes/Routes";
+import { useRemoveSecrets, useListSecrets } from "juju/apiHooks";
+import PanelInlineErrors from "panels/PanelInlineErrors";
+import { usePanelQueryParams } from "panels/hooks";
+import { getSecretByURI, getModelUUIDFromList } from "store/juju/selectors";
+import { useAppSelector } from "store/store";
+
+import Fields from "./Fields";
+import { type FormFields } from "./types";
+
+export enum TestId {
+  PANEL = "remove-secret-panel",
+}
+
+export enum Label {
+  CANCEL = "Cancel",
+  SUBMIT = "Remove secret",
+}
+
+const RemoveSecretPanel = () => {
+  const { userName, modelName } = useParams<EntityDetailsRoute>();
+  const modelUUID = useSelector(getModelUUIDFromList(modelName, userName));
+  const scrollArea = useRef<HTMLDivElement>(null);
+  const formId = useId();
+  const [queryParams, , handleRemovePanelQueryParams] = usePanelQueryParams<{
+    panel: string | null;
+    secret: string | null;
+  }>({
+    panel: null,
+    secret: null,
+  });
+  const secretURI = queryParams.secret;
+  const secret = useAppSelector((state) =>
+    getSecretByURI(state, modelUUID, secretURI),
+  );
+  const [inlineError, setInlineError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+  const removeSecrets = useRemoveSecrets(userName, modelName);
+  const listSecrets = useListSecrets(userName, modelName);
+
+  const handleRemoveSecret = useCallback(
+    (values: FormFields) => {
+      if (!secretURI) {
+        // An error is displayed instead of the form if the secretURI doesn't
+        // exist so it's not possible to get to this point.
+        return;
+      }
+      setSaving(true);
+      setInlineError(null);
+      setShowConfirm(false);
+      removeSecrets([
+        {
+          revisions: values.removeAll ? undefined : [Number(values.revision)],
+          uri: secretURI,
+        },
+      ])
+        .then((response: ErrorResults | string) => {
+          let error;
+          if (typeof response === "string") {
+            error = response;
+          } else if (Array.isArray(response.results)) {
+            error = response.results[0]?.error?.message;
+          }
+          if (error) {
+            setSaving(false);
+            setInlineError(error);
+            return;
+          }
+          listSecrets();
+          handleRemovePanelQueryParams();
+          return;
+        })
+        .catch((error) => {
+          setSaving(false);
+          if (typeof error === "string" || error instanceof Error) {
+            setInlineError(error instanceof Error ? error.message : error);
+          }
+        });
+    },
+    [handleRemovePanelQueryParams, listSecrets, removeSecrets, secretURI],
+  );
+
+  return (
+    <>
+      <Panel
+        data-testid={TestId.PANEL}
+        drawer={
+          <>
+            <Button onClick={handleRemovePanelQueryParams}>
+              {Label.CANCEL}
+            </Button>
+            <ActionButton
+              appearance="positive"
+              disabled={saving}
+              form={formId}
+              loading={saving}
+              type="submit"
+            >
+              {Label.SUBMIT}
+            </ActionButton>
+          </>
+        }
+        onRemovePanelQueryParams={handleRemovePanelQueryParams}
+        ref={scrollArea}
+        title="Add a secret"
+        width="narrow"
+      >
+        <>
+          <PanelInlineErrors
+            inlineErrors={[inlineError]}
+            scrollArea={scrollArea.current}
+          />
+          {secret ? (
+            <Formik<FormFields>
+              initialValues={{
+                removeAll: false,
+                revision: secret["latest-revision"].toString(),
+              }}
+              onSubmit={(values) => {
+                setShowConfirm(true);
+              }}
+            >
+              <Form id={formId}>
+                <Fields
+                  handleRemoveSecret={handleRemoveSecret}
+                  hideConfirm={() => setShowConfirm(false)}
+                  secretURI={secretURI}
+                  showConfirm={showConfirm}
+                />
+              </Form>
+            </Formik>
+          ) : (
+            <Spinner />
+          )}
+        </>
+      </Panel>
+    </>
+  );
+};
+
+export default RemoveSecretPanel;

--- a/src/panels/RemoveSecretPanel/index.ts
+++ b/src/panels/RemoveSecretPanel/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./RemoveSecretPanel";

--- a/src/panels/RemoveSecretPanel/types.ts
+++ b/src/panels/RemoveSecretPanel/types.ts
@@ -1,0 +1,4 @@
+export type FormFields = {
+  removeAll: boolean;
+  revision: string;
+};


### PR DESCRIPTION
## Done

- Add a panel to remove secrets.

## QA

- Get the URI for a secret.
- In a terminal add a few revisions to the secret: `juju update-secret <URI> token=34ae35facd4` (you can run the same command a few times and each time a new revision will get created).
- Open secrets tab.
- Find the row for the secret you added the revisions to.
- Open the actions menu on the right hand side and click "Remove secret".
- In the panel either choose a revision or click the checkbox to remove them all.
- Submit the form and confirm.
- If all revisions were removed the secret should get removed from the list.

## Details

https://warthogs.atlassian.net/browse/WD-8401
