### PR TITLE
WD-8398 - View secret contents

### DIFF
--- a/src/components/FormikField/index.ts
+++ b/src/components/FormikField/index.ts
@@ -1,0 +1,1 @@
+export { default, type Props as FormikFieldProps } from "./FormikField";

--- a/src/components/secrets/RevisionField/RevisionField.test.tsx
+++ b/src/components/secrets/RevisionField/RevisionField.test.tsx
@@ -1,0 +1,88 @@
+import { screen } from "@testing-library/react";
+import { Formik } from "formik";
+
+import type { RootState } from "store/store";
+import { rootStateFactory } from "testing/factories";
+import {
+  configFactory,
+  generalStateFactory,
+  credentialFactory,
+} from "testing/factories/general";
+import {
+  modelListInfoFactory,
+  secretsStateFactory,
+  listSecretResultFactory,
+  modelSecretsFactory,
+  secretRevisionFactory,
+} from "testing/factories/juju/juju";
+import { renderComponent } from "testing/utils";
+import urls from "urls";
+
+import RevisionField from "./RevisionField";
+
+jest.mock("components/utils", () => ({
+  ...jest.requireActual("components/utils"),
+  copyToClipboard: jest.fn(),
+}));
+
+describe("RevisionField", () => {
+  let state: RootState;
+  const path = urls.model.index(null);
+  const url = urls.model.index({
+    userName: "eggman@external",
+    modelName: "test-model",
+  });
+
+  beforeEach(() => {
+    state = rootStateFactory.build({
+      general: generalStateFactory.build({
+        credentials: {
+          "wss://example.com/api": credentialFactory.build(),
+        },
+        config: configFactory.build({
+          controllerAPIEndpoint: "wss://example.com/api",
+        }),
+      }),
+      juju: {
+        models: {
+          abc123: modelListInfoFactory.build({
+            wsControllerURL: "wss://example.com/api",
+            uuid: "abc123",
+          }),
+        },
+        secrets: secretsStateFactory.build({
+          abc123: modelSecretsFactory.build({
+            items: [
+              listSecretResultFactory.build({
+                uri: "secret:aabbccdd",
+                label: "secret1",
+                "latest-revision": 2,
+                revisions: [
+                  secretRevisionFactory.build({ revision: 1 }),
+                  secretRevisionFactory.build({ revision: 2 }),
+                ],
+              }),
+            ],
+            loaded: true,
+          }),
+        }),
+      },
+    });
+  });
+
+  it("lists revisions", async () => {
+    renderComponent(
+      <Formik<{ revision: string }>
+        initialValues={{ revision: "" }}
+        onSubmit={jest.fn()}
+      >
+        <RevisionField secretURI="secret:aabbccdd" modelUUID="abc123" />
+      </Formik>,
+      { state, path, url },
+    );
+    expect(
+      screen.getByRole("option", { name: "2 (latest)" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "1" })).toBeInTheDocument();
+  });
+});

--- a/src/components/secrets/RevisionField/RevisionField.tsx
+++ b/src/components/secrets/RevisionField/RevisionField.tsx
@@ -1,0 +1,41 @@
+import type { PropsWithSpread, SelectProps } from "@canonical/react-components";
+import { Select } from "@canonical/react-components";
+
+import type { FormikFieldProps } from "components/FormikField";
+import FormikField from "components/FormikField";
+import { getSecretByURI } from "store/juju/selectors";
+import { useAppSelector } from "store/store";
+
+export enum Label {
+  REVISION = "Revision",
+}
+
+type Props = PropsWithSpread<
+  {
+    modelUUID: string;
+    secretURI: string;
+  },
+  Partial<FormikFieldProps> & Partial<SelectProps>
+>;
+
+const RevisionField = ({ modelUUID, secretURI, ...props }: Props) => {
+  const secret = useAppSelector((state) =>
+    getSecretByURI(state, modelUUID, secretURI),
+  );
+  return (
+    <FormikField
+      label={Label.REVISION}
+      name="revision"
+      component={Select}
+      options={
+        [...(secret?.revisions ?? [])].reverse().map(({ revision }) => ({
+          label: `${revision}${revision === secret?.["latest-revision"] ? " (latest)" : ""}`,
+          value: revision.toString(),
+        })) ?? []
+      }
+      {...props}
+    />
+  );
+};
+
+export default RevisionField;

--- a/src/components/secrets/RevisionField/index.ts
+++ b/src/components/secrets/RevisionField/index.ts
@@ -1,0 +1,1 @@
+export { default, Label as RevisionFieldLabel } from "./RevisionField";

--- a/src/pages/EntityDetails/Model/Secrets/SecretContent/SecretContent.test.tsx
+++ b/src/pages/EntityDetails/Model/Secrets/SecretContent/SecretContent.test.tsx
@@ -85,12 +85,13 @@ describe("SecretContent", () => {
 
   it("initially hides the modal", async () => {
     const store = mockStore(state);
-    renderComponent(
-      <SecretContent label="A secret" secretURI="secret:aabbccdd" />,
-      { store, path, url },
-    );
+    renderComponent(<SecretContent secretURI="secret:aabbccdd" />, {
+      store,
+      path,
+      url,
+    });
     expect(
-      screen.getByRole("button", { name: "Show content A secret" }),
+      screen.getByRole("button", { name: Label.SHOW }),
     ).toBeInTheDocument();
     expect(
       screen.queryByRole("dialog", { name: Label.MODAL_TITLE }),
@@ -99,13 +100,12 @@ describe("SecretContent", () => {
 
   it("can open the modal", async () => {
     const store = mockStore(state);
-    renderComponent(
-      <SecretContent label="A secret" secretURI="secret:aabbccdd" />,
-      { store, path, url },
-    );
-    await userEvent.click(
-      screen.getByRole("button", { name: "Show content A secret" }),
-    );
+    renderComponent(<SecretContent secretURI="secret:aabbccdd" />, {
+      store,
+      path,
+      url,
+    });
+    await userEvent.click(screen.getByRole("button", { name: Label.SHOW }));
     expect(
       screen.getByRole("dialog", { name: Label.MODAL_TITLE }),
     ).toBeInTheDocument();
@@ -113,17 +113,16 @@ describe("SecretContent", () => {
 
   it("cleans up secrets when closing the modal", async () => {
     const store = mockStore(state);
-    renderComponent(
-      <SecretContent label="A secret" secretURI="secret:aabbccdd" />,
-      { store, path, url },
-    );
+    renderComponent(<SecretContent secretURI="secret:aabbccdd" />, {
+      store,
+      path,
+      url,
+    });
     const clearAction = jujuActions.clearSecretsContent({
       modelUUID: "abc123",
       wsControllerURL: "wss://example.com/api",
     });
-    await userEvent.click(
-      screen.getByRole("button", { name: "Show content A secret" }),
-    );
+    await userEvent.click(screen.getByRole("button", { name: Label.SHOW }));
     await userEvent.click(
       screen.getByRole("button", { name: "Close active modal" }),
     );
@@ -141,13 +140,12 @@ describe("SecretContent", () => {
     jest
       .spyOn(apiHooks, "useGetSecretContent")
       .mockImplementation(() => getSecretContent);
-    renderComponent(
-      <SecretContent label="A secret" secretURI="secret:aabbccdd" />,
-      { state, path, url },
-    );
-    await userEvent.click(
-      screen.getByRole("button", { name: "Show content A secret" }),
-    );
+    renderComponent(<SecretContent secretURI="secret:aabbccdd" />, {
+      state,
+      path,
+      url,
+    });
+    await userEvent.click(screen.getByRole("button", { name: Label.SHOW }));
     await userEvent.selectOptions(
       screen.getByRole("combobox", { name: RevisionFieldLabel.REVISION }),
       "3 (latest)",
@@ -160,13 +158,12 @@ describe("SecretContent", () => {
     state.juju.secrets.abc123.content = modelSecretsContentFactory.build({
       loading: true,
     });
-    renderComponent(
-      <SecretContent label="A secret" secretURI="secret:aabbccdd" />,
-      { state, path, url },
-    );
-    await userEvent.click(
-      screen.getByRole("button", { name: "Show content A secret" }),
-    );
+    renderComponent(<SecretContent secretURI="secret:aabbccdd" />, {
+      state,
+      path,
+      url,
+    });
+    await userEvent.click(screen.getByRole("button", { name: Label.SHOW }));
     expect(
       screen.getByLabelText(ActionButtonLabel.WAITING),
     ).toBeInTheDocument();
@@ -177,13 +174,12 @@ describe("SecretContent", () => {
       loaded: true,
       content: { "a key": "a value" },
     });
-    renderComponent(
-      <SecretContent label="A secret" secretURI="secret:aabbccdd" />,
-      { state, path, url },
-    );
-    await userEvent.click(
-      screen.getByRole("button", { name: "Show content A secret" }),
-    );
+    renderComponent(<SecretContent secretURI="secret:aabbccdd" />, {
+      state,
+      path,
+      url,
+    });
+    await userEvent.click(screen.getByRole("button", { name: Label.SHOW }));
     expect(screen.getByRole("heading", { name: "a key" })).toBeInTheDocument();
     expect(screen.getByText("a value")).toBeInTheDocument();
   });
@@ -193,13 +189,12 @@ describe("SecretContent", () => {
       loaded: true,
       errors: "Uh oh!",
     });
-    renderComponent(
-      <SecretContent label="A secret" secretURI="secret:aabbccdd" />,
-      { state, path, url },
-    );
-    await userEvent.click(
-      screen.getByRole("button", { name: "Show content A secret" }),
-    );
+    renderComponent(<SecretContent secretURI="secret:aabbccdd" />, {
+      state,
+      path,
+      url,
+    });
+    await userEvent.click(screen.getByRole("button", { name: Label.SHOW }));
     expect(screen.getByText("Uh oh!")).toBeInTheDocument();
   });
 });

--- a/src/pages/EntityDetails/Model/Secrets/SecretContent/SecretContent.test.tsx
+++ b/src/pages/EntityDetails/Model/Secrets/SecretContent/SecretContent.test.tsx
@@ -1,0 +1,205 @@
+import { Label as ActionButtonLabel } from "@canonical/react-components/dist/components/ActionButton/ActionButton";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import configureStore from "redux-mock-store";
+
+import { RevisionFieldLabel } from "components/secrets/RevisionField";
+import * as apiHooks from "juju/apiHooks";
+import { actions as jujuActions } from "store/juju";
+import type { RootState } from "store/store";
+import { rootStateFactory } from "testing/factories";
+import {
+  configFactory,
+  generalStateFactory,
+  credentialFactory,
+} from "testing/factories/general";
+import {
+  modelListInfoFactory,
+  secretsStateFactory,
+  listSecretResultFactory,
+  modelSecretsFactory,
+  secretRevisionFactory,
+} from "testing/factories/juju/juju";
+import { modelSecretsContentFactory } from "testing/factories/juju/juju";
+import { renderComponent } from "testing/utils";
+import urls from "urls";
+
+import SecretContent, { Label } from "./SecretContent";
+
+const mockStore = configureStore<RootState, unknown>([]);
+
+jest.mock("juju/apiHooks", () => {
+  return {
+    useGetSecretContent: jest.fn().mockReturnValue(jest.fn()),
+  };
+});
+
+describe("SecretContent", () => {
+  let state: RootState;
+  const path = urls.model.index(null);
+  const url = urls.model.index({
+    userName: "eggman@external",
+    modelName: "test-model",
+  });
+
+  beforeEach(() => {
+    jest
+      .spyOn(apiHooks, "useGetSecretContent")
+      .mockImplementation(() => jest.fn());
+    state = rootStateFactory.build({
+      general: generalStateFactory.build({
+        credentials: {
+          "wss://example.com/api": credentialFactory.build(),
+        },
+        config: configFactory.build({
+          controllerAPIEndpoint: "wss://example.com/api",
+        }),
+      }),
+      juju: {
+        models: {
+          abc123: modelListInfoFactory.build({
+            wsControllerURL: "wss://example.com/api",
+            uuid: "abc123",
+          }),
+        },
+        secrets: secretsStateFactory.build({
+          abc123: modelSecretsFactory.build({
+            items: [
+              listSecretResultFactory.build({
+                uri: "secret:aabbccdd",
+                label: "secret1",
+                "latest-revision": 3,
+                revisions: [
+                  secretRevisionFactory.build({ revision: 1 }),
+                  secretRevisionFactory.build({ revision: 2 }),
+                  secretRevisionFactory.build({ revision: 3 }),
+                ],
+              }),
+            ],
+            loaded: true,
+          }),
+        }),
+      },
+    });
+  });
+
+  it("initially hides the modal", async () => {
+    const store = mockStore(state);
+    renderComponent(
+      <SecretContent label="A secret" secretURI="secret:aabbccdd" />,
+      { store, path, url },
+    );
+    expect(
+      screen.getByRole("button", { name: "Show content A secret" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("dialog", { name: Label.MODAL_TITLE }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("can open the modal", async () => {
+    const store = mockStore(state);
+    renderComponent(
+      <SecretContent label="A secret" secretURI="secret:aabbccdd" />,
+      { store, path, url },
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Show content A secret" }),
+    );
+    expect(
+      screen.getByRole("dialog", { name: Label.MODAL_TITLE }),
+    ).toBeInTheDocument();
+  });
+
+  it("cleans up secrets when closing the modal", async () => {
+    const store = mockStore(state);
+    renderComponent(
+      <SecretContent label="A secret" secretURI="secret:aabbccdd" />,
+      { store, path, url },
+    );
+    const clearAction = jujuActions.clearSecretsContent({
+      modelUUID: "abc123",
+      wsControllerURL: "wss://example.com/api",
+    });
+    await userEvent.click(
+      screen.getByRole("button", { name: "Show content A secret" }),
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Close active modal" }),
+    );
+    await waitFor(() => {
+      expect(
+        store
+          .getActions()
+          .find((dispatch) => dispatch.type === clearAction.type),
+      ).toMatchObject(clearAction);
+    });
+  });
+
+  it("can fetch the content for the chosen revision", async () => {
+    const getSecretContent = jest.fn();
+    jest
+      .spyOn(apiHooks, "useGetSecretContent")
+      .mockImplementation(() => getSecretContent);
+    renderComponent(
+      <SecretContent label="A secret" secretURI="secret:aabbccdd" />,
+      { state, path, url },
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Show content A secret" }),
+    );
+    await userEvent.selectOptions(
+      screen.getByRole("combobox", { name: RevisionFieldLabel.REVISION }),
+      "3 (latest)",
+    );
+    await userEvent.click(screen.getByRole("button", { name: Label.SUBMIT }));
+    expect(getSecretContent).toHaveBeenCalledWith("secret:aabbccdd", 3);
+  });
+
+  it("displays the loading state", async () => {
+    state.juju.secrets.abc123.content = modelSecretsContentFactory.build({
+      loading: true,
+    });
+    renderComponent(
+      <SecretContent label="A secret" secretURI="secret:aabbccdd" />,
+      { state, path, url },
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Show content A secret" }),
+    );
+    expect(
+      screen.getByLabelText(ActionButtonLabel.WAITING),
+    ).toBeInTheDocument();
+  });
+
+  it("can display content", async () => {
+    state.juju.secrets.abc123.content = modelSecretsContentFactory.build({
+      loaded: true,
+      content: { "a key": "a value" },
+    });
+    renderComponent(
+      <SecretContent label="A secret" secretURI="secret:aabbccdd" />,
+      { state, path, url },
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Show content A secret" }),
+    );
+    expect(screen.getByRole("heading", { name: "a key" })).toBeInTheDocument();
+    expect(screen.getByText("a value")).toBeInTheDocument();
+  });
+
+  it("can display content errors", async () => {
+    state.juju.secrets.abc123.content = modelSecretsContentFactory.build({
+      loaded: true,
+      errors: "Uh oh!",
+    });
+    renderComponent(
+      <SecretContent label="A secret" secretURI="secret:aabbccdd" />,
+      { state, path, url },
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Show content A secret" }),
+    );
+    expect(screen.getByText("Uh oh!")).toBeInTheDocument();
+  });
+});

--- a/src/pages/EntityDetails/Model/Secrets/SecretContent/SecretContent.tsx
+++ b/src/pages/EntityDetails/Model/Secrets/SecretContent/SecretContent.tsx
@@ -33,11 +33,10 @@ export enum Label {
 }
 
 type Props = {
-  label?: string;
   secretURI: string;
 };
 
-const SecretContent = ({ label, secretURI }: Props) => {
+const SecretContent = ({ secretURI }: Props) => {
   const { userName, modelName } = useParams<EntityDetailsRoute>();
   const dispatch = useAppDispatch();
   const modelUUID = useAppSelector(getModelUUIDFromList(modelName, userName));
@@ -73,7 +72,6 @@ const SecretContent = ({ label, secretURI }: Props) => {
           hasIcon
         >
           <Icon name="show">{Label.SHOW}</Icon>
-          {label ? <span>{label}</span> : null}
         </Button>
       </Tooltip>
       {isOpen && (

--- a/src/pages/EntityDetails/Model/Secrets/SecretContent/SecretContent.tsx
+++ b/src/pages/EntityDetails/Model/Secrets/SecretContent/SecretContent.tsx
@@ -1,0 +1,143 @@
+import {
+  Button,
+  CodeSnippet,
+  Icon,
+  Modal,
+  Tooltip,
+  ActionButton,
+  Notification,
+} from "@canonical/react-components";
+import { Form, Formik } from "formik";
+import { useParams } from "react-router-dom";
+import usePortal from "react-useportal";
+
+import type { EntityDetailsRoute } from "components/Routes/Routes";
+import RevisionField from "components/secrets/RevisionField";
+import { useGetSecretContent } from "juju/apiHooks";
+import { actions as jujuActions } from "store/juju";
+import {
+  getSecretByURI,
+  getSecretsContent,
+  getSecretsContentErrors,
+  getSecretsContentLoaded,
+  getSecretsContentLoading,
+  getModelUUIDFromList,
+  getModelByUUID,
+} from "store/juju/selectors";
+import { useAppSelector, useAppDispatch } from "store/store";
+
+export enum Label {
+  MODAL_TITLE = "Secret values",
+  SHOW = "Show content",
+  SUBMIT = "View",
+}
+
+type Props = {
+  label?: string;
+  secretURI: string;
+};
+
+const SecretContent = ({ label, secretURI }: Props) => {
+  const { userName, modelName } = useParams<EntityDetailsRoute>();
+  const dispatch = useAppDispatch();
+  const modelUUID = useAppSelector(getModelUUIDFromList(modelName, userName));
+  const wsControllerURL = useAppSelector((state) =>
+    getModelByUUID(state, modelUUID),
+  )?.wsControllerURL;
+  const secret = useAppSelector((state) =>
+    getSecretByURI(state, modelUUID, secretURI),
+  );
+  const content = useAppSelector((state) =>
+    getSecretsContent(state, modelUUID),
+  );
+  const contentError = useAppSelector((state) =>
+    getSecretsContentErrors(state, modelUUID),
+  );
+  const contentLoaded = useAppSelector((state) =>
+    getSecretsContentLoaded(state, modelUUID),
+  );
+  const contentLoading = useAppSelector((state) =>
+    getSecretsContentLoading(state, modelUUID),
+  );
+  const { openPortal, closePortal, isOpen, Portal } = usePortal();
+  const getSecretContent = useGetSecretContent(userName, modelName);
+
+  return (
+    <>
+      <Tooltip message="View secret values">
+        <Button
+          appearance="base"
+          className="is-small"
+          onClick={openPortal}
+          type="button"
+          hasIcon
+        >
+          <Icon name="show">{Label.SHOW}</Icon>
+          {label ? <span>{label}</span> : null}
+        </Button>
+      </Tooltip>
+      {isOpen && (
+        <Portal>
+          <Modal
+            className="info-panel__modal"
+            close={() => {
+              closePortal();
+              if (wsControllerURL) {
+                dispatch(
+                  jujuActions.clearSecretsContent({
+                    modelUUID,
+                    wsControllerURL,
+                  }),
+                );
+              }
+            }}
+            title={Label.MODAL_TITLE}
+          >
+            {secret ? (
+              <Formik<{ revision: string }>
+                initialValues={{
+                  revision: secret["latest-revision"].toString(),
+                }}
+                onSubmit={(values) => {
+                  getSecretContent(secretURI, Number(values.revision));
+                }}
+              >
+                <Form className="p-form--inline">
+                  <RevisionField secretURI={secretURI} modelUUID={modelUUID} />
+                  <ActionButton
+                    appearance="positive"
+                    disabled={contentLoading}
+                    loading={contentLoading}
+                    type="submit"
+                  >
+                    {Label.SUBMIT}
+                  </ActionButton>
+                </Form>
+              </Formik>
+            ) : null}
+            {contentLoaded && !contentLoading ? (
+              <>
+                <hr />
+                {contentError ? (
+                  <Notification severity="negative" title="Error:">
+                    {contentError}
+                  </Notification>
+                ) : null}
+                <CodeSnippet
+                  blocks={Object.entries(content ?? {})?.map(
+                    ([key, value]) => ({
+                      title: key,
+                      code: value,
+                    }),
+                  )}
+                />
+              </>
+            ) : null}
+          </Modal>
+        </Portal>
+      )}
+    </>
+  );
+};
+
+export default SecretContent;

--- a/src/pages/EntityDetails/Model/Secrets/SecretContent/index.ts
+++ b/src/pages/EntityDetails/Model/Secrets/SecretContent/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SecretContent";

--- a/src/pages/EntityDetails/Model/Secrets/Secrets.test.tsx
+++ b/src/pages/EntityDetails/Model/Secrets/Secrets.test.tsx
@@ -26,6 +26,7 @@ const mockStore = configureStore<RootState, unknown>([]);
 
 jest.mock("juju/apiHooks", () => {
   return {
+    useGetSecretContent: jest.fn().mockReturnValue(jest.fn()),
     useListSecrets: jest.fn().mockReturnValue(jest.fn()),
   };
 });

--- a/src/pages/EntityDetails/Model/Secrets/SecretsTable/SecretsTable.test.tsx
+++ b/src/pages/EntityDetails/Model/Secrets/SecretsTable/SecretsTable.test.tsx
@@ -86,8 +86,12 @@ describe("SecretsTable", () => {
 
   it("should display secrets", async () => {
     renderComponent(<SecretsTable />, { state, path, url });
-    expect(screen.getByRole("cell", { name: "secret1" })).toBeInTheDocument();
-    expect(screen.getByRole("cell", { name: "secret2" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("cell", { name: "Show content secret1" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("cell", { name: "Show content secret2" }),
+    ).toBeInTheDocument();
   });
 
   it("should remove the prefix from the id", async () => {

--- a/src/pages/EntityDetails/Model/Secrets/SecretsTable/SecretsTable.tsx
+++ b/src/pages/EntityDetails/Model/Secrets/SecretsTable/SecretsTable.tsx
@@ -23,6 +23,8 @@ import {
 } from "store/juju/selectors";
 import { useAppSelector } from "store/store";
 
+import SecretContent from "../SecretContent";
+
 export enum Label {
   COPY = "Copy",
 }
@@ -60,7 +62,7 @@ const SecretsTable = () => {
         );
       }
       return {
-        name: secret.label,
+        name: <SecretContent label={secret.label} secretURI={secret.uri} />,
         id: (
           <div className="u-flex u-flex--gap-small">
             <TruncatedTooltip
@@ -86,7 +88,7 @@ const SecretsTable = () => {
             </div>
           </div>
         ),
-        revision: secret.revisions[0]?.revision,
+        revision: secret["latest-revision"],
         description: secret.description,
         owner,
         created: <RelativeDate datetime={secret["create-time"]} />,

--- a/src/pages/EntityDetails/Model/Secrets/SecretsTable/SecretsTable.tsx
+++ b/src/pages/EntityDetails/Model/Secrets/SecretsTable/SecretsTable.tsx
@@ -62,7 +62,11 @@ const SecretsTable = () => {
         );
       }
       return {
-        name: <SecretContent label={secret.label} secretURI={secret.uri} />,
+        name: (
+          <>
+            <SecretContent secretURI={secret.uri} /> {secret.label}
+          </>
+        ),
         id: (
           <div className="u-flex u-flex--gap-small">
             <TruncatedTooltip

--- a/src/store/juju/actions.test.ts
+++ b/src/store/juju/actions.test.ts
@@ -340,4 +340,69 @@ describe("actions", () => {
       },
     });
   });
+
+  it("secretsContentLoading", () => {
+    expect(
+      actions.secretsContentLoading({
+        modelUUID: "abc123",
+        wsControllerURL: "wss://test.example.com",
+      }),
+    ).toStrictEqual({
+      type: "juju/secretsContentLoading",
+      payload: {
+        modelUUID: "abc123",
+        wsControllerURL: "wss://test.example.com",
+      },
+    });
+  });
+
+  it("updateSecretsContent", () => {
+    const content = { key: "val" };
+    expect(
+      actions.updateSecretsContent({
+        modelUUID: "abc123",
+        content,
+        wsControllerURL: "wss://test.example.com",
+      }),
+    ).toStrictEqual({
+      type: "juju/updateSecretsContent",
+      payload: {
+        modelUUID: "abc123",
+        content,
+        wsControllerURL: "wss://test.example.com",
+      },
+    });
+  });
+
+  it("setSecretsContentErrors", () => {
+    expect(
+      actions.setSecretsContentErrors({
+        errors: "Uh oh!",
+        modelUUID: "abc123",
+        wsControllerURL: "wss://test.example.com",
+      }),
+    ).toStrictEqual({
+      type: "juju/setSecretsContentErrors",
+      payload: {
+        errors: "Uh oh!",
+        modelUUID: "abc123",
+        wsControllerURL: "wss://test.example.com",
+      },
+    });
+  });
+
+  it("clearSecretsContent", () => {
+    expect(
+      actions.clearSecretsContent({
+        modelUUID: "abc123",
+        wsControllerURL: "wss://test.example.com",
+      }),
+    ).toStrictEqual({
+      type: "juju/clearSecretsContent",
+      payload: {
+        modelUUID: "abc123",
+        wsControllerURL: "wss://test.example.com",
+      },
+    });
+  });
 });

--- a/src/store/juju/reducers.test.ts
+++ b/src/store/juju/reducers.test.ts
@@ -17,6 +17,7 @@ import {
   listSecretResultFactory,
   modelSecretsFactory,
   modelFeaturesStateFactory,
+  modelSecretsContentFactory,
 } from "testing/factories/juju/juju";
 import {
   modelWatcherModelDataFactory,
@@ -695,6 +696,301 @@ describe("reducers", () => {
     ).toStrictEqual({
       ...state,
       secrets: secretsStateFactory.build(),
+    });
+  });
+
+  it("secretsContentLoading", () => {
+    const state = jujuStateFactory.build({
+      secrets: secretsStateFactory.build({
+        abc123: modelSecretsFactory.build({
+          content: modelSecretsContentFactory.build({ loading: false }),
+        }),
+      }),
+    });
+    expect(
+      reducer(
+        state,
+        actions.secretsContentLoading({
+          modelUUID: "abc123",
+          wsControllerURL: "wss://test.example.com",
+        }),
+      ),
+    ).toStrictEqual({
+      ...state,
+      secrets: secretsStateFactory.build({
+        abc123: modelSecretsFactory.build({
+          content: modelSecretsContentFactory.build({ loading: true }),
+        }),
+      }),
+    });
+  });
+
+  it("secretsContentLoading handles no existing model", () => {
+    const state = jujuStateFactory.build({
+      secrets: secretsStateFactory.build(),
+    });
+    expect(
+      reducer(
+        state,
+        actions.secretsContentLoading({
+          modelUUID: "abc123",
+          wsControllerURL: "wss://test.example.com",
+        }),
+      ),
+    ).toStrictEqual({
+      ...state,
+      secrets: secretsStateFactory.build({
+        abc123: modelSecretsFactory.build({
+          content: modelSecretsContentFactory.build({ loading: true }),
+        }),
+      }),
+    });
+  });
+
+  it("secretsContentLoading handles no existing content state", () => {
+    const state = jujuStateFactory.build({
+      secrets: secretsStateFactory.build({
+        abc123: modelSecretsFactory.build({ content: undefined }),
+      }),
+    });
+    expect(
+      reducer(
+        state,
+        actions.secretsContentLoading({
+          modelUUID: "abc123",
+          wsControllerURL: "wss://test.example.com",
+        }),
+      ),
+    ).toStrictEqual({
+      ...state,
+      secrets: secretsStateFactory.build({
+        abc123: modelSecretsFactory.build({
+          content: modelSecretsContentFactory.build({ loading: true }),
+        }),
+      }),
+    });
+  });
+
+  it("setSecretsContentErrors", () => {
+    const state = jujuStateFactory.build({
+      secrets: secretsStateFactory.build({
+        abc123: modelSecretsFactory.build({
+          content: modelSecretsContentFactory.build({
+            content: { key: "val" },
+            errors: null,
+            loaded: false,
+            loading: true,
+          }),
+        }),
+      }),
+    });
+    expect(
+      reducer(
+        state,
+        actions.setSecretsContentErrors({
+          errors: "Uh oh!",
+          modelUUID: "abc123",
+          wsControllerURL: "wss://test.example.com",
+        }),
+      ),
+    ).toStrictEqual({
+      ...state,
+      secrets: secretsStateFactory.build({
+        abc123: modelSecretsFactory.build({
+          content: modelSecretsContentFactory.build({
+            content: null,
+            errors: "Uh oh!",
+            loaded: true,
+            loading: false,
+          }),
+        }),
+      }),
+    });
+  });
+
+  it("setSecretsContentErrors handles no existing model", () => {
+    const state = jujuStateFactory.build({
+      secrets: secretsStateFactory.build(),
+    });
+    expect(
+      reducer(
+        state,
+        actions.setSecretsContentErrors({
+          errors: "Uh oh!",
+          modelUUID: "abc123",
+          wsControllerURL: "wss://test.example.com",
+        }),
+      ),
+    ).toStrictEqual({
+      ...state,
+      secrets: secretsStateFactory.build({
+        abc123: modelSecretsFactory.build({
+          content: modelSecretsContentFactory.build({
+            content: null,
+            errors: "Uh oh!",
+            loaded: true,
+            loading: false,
+          }),
+        }),
+      }),
+    });
+  });
+
+  it("setSecretsContentErrors handles no existing content state", () => {
+    const state = jujuStateFactory.build({
+      secrets: secretsStateFactory.build({
+        abc123: modelSecretsFactory.build({ content: undefined }),
+      }),
+    });
+    expect(
+      reducer(
+        state,
+        actions.setSecretsContentErrors({
+          errors: "Uh oh!",
+          modelUUID: "abc123",
+          wsControllerURL: "wss://test.example.com",
+        }),
+      ),
+    ).toStrictEqual({
+      ...state,
+      secrets: secretsStateFactory.build({
+        abc123: modelSecretsFactory.build({
+          content: modelSecretsContentFactory.build({
+            content: null,
+            errors: "Uh oh!",
+            loaded: true,
+            loading: false,
+          }),
+        }),
+      }),
+    });
+  });
+
+  it("clearSecretsContent", () => {
+    const content = { key: "val" };
+    const state = jujuStateFactory.build({
+      secrets: secretsStateFactory.build({
+        abc123: modelSecretsFactory.build({
+          content: modelSecretsContentFactory.build({
+            content,
+            errors: "Uh oh!",
+            loaded: true,
+            loading: true,
+          }),
+        }),
+      }),
+    });
+    expect(
+      reducer(
+        state,
+        actions.clearSecretsContent({
+          modelUUID: "abc123",
+          wsControllerURL: "wss://test.example.com",
+        }),
+      ),
+    ).toStrictEqual({
+      ...state,
+      secrets: secretsStateFactory.build({
+        abc123: modelSecretsFactory.build(),
+      }),
+    });
+  });
+
+  it("updateSecretsContent", () => {
+    const state = jujuStateFactory.build({
+      secrets: secretsStateFactory.build({
+        abc123: modelSecretsFactory.build({
+          content: modelSecretsContentFactory.build({
+            content: { oldkey: "oldval" },
+            errors: null,
+            loaded: false,
+            loading: true,
+          }),
+        }),
+      }),
+    });
+    const content = { newkey: "newval" };
+    expect(
+      reducer(
+        state,
+        actions.updateSecretsContent({
+          content,
+          modelUUID: "abc123",
+          wsControllerURL: "wss://test.example.com",
+        }),
+      ),
+    ).toStrictEqual({
+      ...state,
+      secrets: secretsStateFactory.build({
+        abc123: modelSecretsFactory.build({
+          content: modelSecretsContentFactory.build({
+            content,
+            errors: null,
+            loaded: true,
+            loading: false,
+          }),
+        }),
+      }),
+    });
+  });
+
+  it("updateSecretsContent handles no existing model", () => {
+    const state = jujuStateFactory.build({
+      secrets: secretsStateFactory.build(),
+    });
+    const content = { key: "val" };
+    expect(
+      reducer(
+        state,
+        actions.updateSecretsContent({
+          content,
+          modelUUID: "abc123",
+          wsControllerURL: "wss://test.example.com",
+        }),
+      ),
+    ).toStrictEqual({
+      ...state,
+      secrets: secretsStateFactory.build({
+        abc123: modelSecretsFactory.build({
+          content: modelSecretsContentFactory.build({
+            content,
+            errors: null,
+            loaded: true,
+            loading: false,
+          }),
+        }),
+      }),
+    });
+  });
+
+  it("updateSecretsContent handles no existing content state", () => {
+    const state = jujuStateFactory.build({
+      secrets: secretsStateFactory.build({
+        abc123: modelSecretsFactory.build({ content: undefined }),
+      }),
+    });
+    const content = { key: "val" };
+    expect(
+      reducer(
+        state,
+        actions.updateSecretsContent({
+          content,
+          modelUUID: "abc123",
+          wsControllerURL: "wss://test.example.com",
+        }),
+      ),
+    ).toStrictEqual({
+      ...state,
+      secrets: secretsStateFactory.build({
+        abc123: modelSecretsFactory.build({
+          content: modelSecretsContentFactory.build({
+            content,
+            errors: null,
+            loaded: true,
+            loading: false,
+          }),
+        }),
+      }),
     });
   });
 });

--- a/src/store/juju/selectors.test.ts
+++ b/src/store/juju/selectors.test.ts
@@ -37,6 +37,8 @@ import {
   workloadStatusFactory,
 } from "testing/factories/juju/model-watcher";
 
+import { modelSecretsContentFactory } from "../../testing/factories/juju/juju";
+
 import {
   getActiveUser,
   getActiveUsers,
@@ -103,6 +105,12 @@ import {
   getCanListSecrets,
   getModelFeatures,
   getCanManageSecrets,
+  getSecretByURI,
+  getSecretsContentState,
+  getSecretsContent,
+  getSecretsContentErrors,
+  getSecretsContentLoaded,
+  getSecretsContentLoading,
 } from "./selectors";
 
 describe("selectors", () => {
@@ -307,7 +315,7 @@ describe("selectors", () => {
     ).toStrictEqual(secrets);
   });
 
-  it("getSecretsResults", () => {
+  it("getModelSecrets", () => {
     const items = [listSecretResultFactory.build()];
     expect(
       getModelSecrets(
@@ -321,6 +329,34 @@ describe("selectors", () => {
         "abc123",
       ),
     ).toStrictEqual(items);
+  });
+
+  it("getSecretByURI", () => {
+    const items = [
+      listSecretResultFactory.build({ uri: "secret:aabbccdd" }),
+      listSecretResultFactory.build({ uri: "secret:eeffgghh" }),
+    ];
+    expect(
+      getSecretByURI(
+        rootStateFactory.build({
+          juju: jujuStateFactory.build({
+            secrets: secretsStateFactory.build({
+              abc123: modelSecretsFactory.build({ items }),
+              def456: modelSecretsFactory.build({
+                items: [
+                  listSecretResultFactory.build({
+                    uri: "secret:aabbccdd",
+                    label: "other-model",
+                  }),
+                ],
+              }),
+            }),
+          }),
+        }),
+        "abc123",
+        "secret:aabbccdd",
+      ),
+    ).toStrictEqual(items[0]);
   });
 
   it("getSecretsErrors", () => {
@@ -366,6 +402,106 @@ describe("selectors", () => {
             secrets: secretsStateFactory.build({
               abc123: modelSecretsFactory.build({
                 loading: true,
+              }),
+            }),
+          }),
+        }),
+        "abc123",
+      ),
+    ).toStrictEqual(true);
+  });
+
+  it("getSecretsContentState", () => {
+    const content = modelSecretsContentFactory.build({
+      loaded: true,
+    });
+    expect(
+      getSecretsContentState(
+        rootStateFactory.build({
+          juju: jujuStateFactory.build({
+            secrets: secretsStateFactory.build({
+              abc123: modelSecretsFactory.build({
+                content,
+              }),
+            }),
+          }),
+        }),
+        "abc123",
+      ),
+    ).toStrictEqual(content);
+  });
+
+  it("getSecretsContent", () => {
+    const content = {
+      key: "val",
+    };
+    expect(
+      getSecretsContent(
+        rootStateFactory.build({
+          juju: jujuStateFactory.build({
+            secrets: secretsStateFactory.build({
+              abc123: modelSecretsFactory.build({
+                content: modelSecretsContentFactory.build({
+                  content,
+                }),
+              }),
+            }),
+          }),
+        }),
+        "abc123",
+      ),
+    ).toStrictEqual(content);
+  });
+
+  it("getSecretsContentErrors", () => {
+    const errors = "Uh oh!";
+    expect(
+      getSecretsContentErrors(
+        rootStateFactory.build({
+          juju: jujuStateFactory.build({
+            secrets: secretsStateFactory.build({
+              abc123: modelSecretsFactory.build({
+                content: modelSecretsContentFactory.build({
+                  errors,
+                }),
+              }),
+            }),
+          }),
+        }),
+        "abc123",
+      ),
+    ).toStrictEqual(errors);
+  });
+
+  it("getSecretsContentLoading", () => {
+    expect(
+      getSecretsContentLoading(
+        rootStateFactory.build({
+          juju: jujuStateFactory.build({
+            secrets: secretsStateFactory.build({
+              abc123: modelSecretsFactory.build({
+                content: modelSecretsContentFactory.build({
+                  loading: true,
+                }),
+              }),
+            }),
+          }),
+        }),
+        "abc123",
+      ),
+    ).toStrictEqual(true);
+  });
+
+  it("getSecretsContentLoaded", () => {
+    expect(
+      getSecretsContentLoaded(
+        rootStateFactory.build({
+          juju: jujuStateFactory.build({
+            secrets: secretsStateFactory.build({
+              abc123: modelSecretsFactory.build({
+                content: modelSecretsContentFactory.build({
+                  loaded: true,
+                }),
               }),
             }),
           }),

--- a/src/store/juju/selectors.ts
+++ b/src/store/juju/selectors.ts
@@ -196,6 +196,40 @@ export const getSecretsLoading = createSelector(
   (secrets) => secrets?.loading,
 );
 
+export const getSecretByURI = createSelector(
+  [
+    getModelSecrets,
+    (_state, _modelUUID: string, secretURI?: string | null) => secretURI,
+  ],
+  (secrets, secretURI) =>
+    secretURI ? secrets?.find(({ uri }) => uri === secretURI) : null,
+);
+
+export const getSecretsContentState = createSelector(
+  [getModelSecretsState],
+  (secrets) => secrets?.content,
+);
+
+export const getSecretsContent = createSelector(
+  [getSecretsContentState],
+  (content) => content?.content,
+);
+
+export const getSecretsContentErrors = createSelector(
+  [getSecretsContentState],
+  (content) => content?.errors,
+);
+
+export const getSecretsContentLoaded = createSelector(
+  [getSecretsContentState],
+  (content) => content?.loaded,
+);
+
+export const getSecretsContentLoading = createSelector(
+  [getSecretsContentState],
+  (content) => content?.loading,
+);
+
 export const getModelFeaturesState = createSelector(
   [slice],
   (sliceState) => sliceState.modelFeatures,

--- a/src/store/juju/types.ts
+++ b/src/store/juju/types.ts
@@ -1,6 +1,9 @@
 import type { Charm } from "@canonical/jujulib/dist/api/facades/charms/CharmsV6";
 import type { ModelInfo } from "@canonical/jujulib/dist/api/facades/model-manager/ModelManagerV9";
-import type { ListSecretResult } from "@canonical/jujulib/dist/api/facades/secrets/SecretsV2";
+import type {
+  ListSecretResult,
+  SecretValueResult,
+} from "@canonical/jujulib/dist/api/facades/secrets/SecretsV2";
 
 import type { ControllerInfo } from "juju/jimm/JIMMV3";
 import type { AuditEvent } from "juju/jimm/JIMMV3";
@@ -73,7 +76,7 @@ export type CrossModelQueryState = GenericState<
 };
 
 export type SecretsContent = GenericState<string> & {
-  content: string | null;
+  content?: SecretValueResult["data"] | null;
 };
 
 export type ModelSecrets = GenericItemsState<ListSecretResult, string> & {

--- a/src/testing/factories/juju/juju.ts
+++ b/src/testing/factories/juju/juju.ts
@@ -6,7 +6,10 @@ import type {
   UnitStatus,
 } from "@canonical/jujulib/dist/api/facades/client/ClientV6";
 import type { ModelInfo } from "@canonical/jujulib/dist/api/facades/model-manager/ModelManagerV9";
-import type { ListSecretResult } from "@canonical/jujulib/dist/api/facades/secrets/SecretsV2";
+import type {
+  ListSecretResult,
+  SecretRevision,
+} from "@canonical/jujulib/dist/api/facades/secrets/SecretsV2";
 import { Factory } from "fishery";
 
 import { DEFAULT_AUDIT_EVENTS_LIMIT } from "store/juju/slice";
@@ -23,6 +26,7 @@ import type {
   ModelSecrets,
   SecretsState,
 } from "store/juju/types";
+import type { SecretsContent } from "store/juju/types";
 
 import { modelStatusInfoFactory, detailedStatusFactory } from "./ClientV6";
 import { modelSLAInfoFactory } from "./ModelManagerV9";
@@ -166,6 +170,10 @@ export const modelDataFactory = Factory.define<ModelData>(() => ({
   "remote-applications": {},
 }));
 
+export const secretRevisionFactory = Factory.define<SecretRevision>(() => ({
+  revision: 1,
+}));
+
 export const listSecretResultFactory = Factory.define<ListSecretResult>(() => ({
   "create-time": "2024-01-05T05:10:17Z",
   "latest-revision": 1,
@@ -186,6 +194,15 @@ export const auditEventsStateFactory = Factory.define<AuditEventsState>(() => ({
 export const crossModelQueryStateFactory = Factory.define<CrossModelQueryState>(
   () => ({
     results: null,
+    errors: null,
+    loaded: false,
+    loading: false,
+  }),
+);
+
+export const modelSecretsContentFactory = Factory.define<SecretsContent>(
+  () => ({
+    content: null,
     errors: null,
     loaded: false,
     loading: false,


### PR DESCRIPTION
## Done

- Fetch and display secret contents in a modal.

## QA

- Go to the secrets tab.
- Click the eye next to a secret.
- Choose a revision and click "View"
- The secret contents should be displayed.

## Details

https://warthogs.atlassian.net/browse/WD-8398