### PR TITLE
WD-8828 - feat: Display errors in Action Logs

### DIFF
--- a/src/pages/EntityDetails/Model/Logs/ActionLogs/ActionLogs.test.tsx
+++ b/src/pages/EntityDetails/Model/Logs/ActionLogs/ActionLogs.test.tsx
@@ -374,7 +374,10 @@ describe("Action Logs", () => {
     renderComponent(<ActionLogs />, { path, url, state });
     expect(queryOperationsListSpy).toHaveBeenCalledTimes(1);
     await waitFor(() => {
-      expect(console.error).toHaveBeenCalled();
+      expect(console.error).toHaveBeenCalledWith(
+        Label.FETCH_ERROR,
+        new Error("Error while querying operations list."),
+      );
     });
     const fetchErrorNotification = screen.getByText(
       new RegExp(Label.FETCH_ERROR),


### PR DESCRIPTION
## Done

- Display fetch action logs error in Action Logs.

## Details

- https://warthogs.atlassian.net/browse/WD-8828

## Screenshots

![Screenshot from 2024-02-12 15-30-24](https://github.com/canonical/juju-dashboard/assets/108150922/e8ddde74-b11b-4dac-a300-87448323e82b)

