### PR TITLE
WD-8829 - feat: display errors in Charms and Actions Panel

### DIFF
--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -76,7 +76,9 @@ describe("renderApp", () => {
     }
     jest.useRealTimers();
     await waitFor(() => {
-      expect(screen.getByText(new RegExp(Label.NO_CONFIG))).toBeInTheDocument();
+      expect(
+        screen.getByText(Label.NO_CONFIG, { exact: false }),
+      ).toBeInTheDocument();
     });
   });
 

--- a/src/pages/ModelsIndex/ModelsIndex.test.tsx
+++ b/src/pages/ModelsIndex/ModelsIndex.test.tsx
@@ -177,7 +177,7 @@ describe("Models Index page", () => {
   it("should display the error notification", async () => {
     state.juju.modelsError = "Oops!";
     renderComponent(<ModelsIndex />, { state });
-    expect(screen.getByText(new RegExp(/Oops!/))).toBeInTheDocument();
+    expect(screen.getByText(/Oops!/)).toBeInTheDocument();
   });
 
   it("should refresh the window when pressing the button in error notification", async () => {

--- a/src/panels/ActionsPanel/ActionsPanel.test.tsx
+++ b/src/panels/ActionsPanel/ActionsPanel.test.tsx
@@ -333,7 +333,7 @@ describe("ActionsPanel", () => {
     );
     await waitFor(() =>
       expect(
-        screen.getByText(new RegExp(Label.GET_ACTIONS_ERROR)),
+        screen.getByText(Label.GET_ACTIONS_ERROR, { exact: false }),
       ).toBeInTheDocument(),
     );
     await userEvent.click(
@@ -377,7 +377,7 @@ describe("ActionsPanel", () => {
     );
     await waitFor(() =>
       expect(
-        screen.getByText(new RegExp(Label.EXECUTE_ACTION_ERROR)),
+        screen.getByText(Label.EXECUTE_ACTION_ERROR, { exact: false }),
       ).toBeInTheDocument(),
     );
   });

--- a/src/panels/CharmsAndActionsPanel/CharmsAndActionsPanel.test.tsx
+++ b/src/panels/CharmsAndActionsPanel/CharmsAndActionsPanel.test.tsx
@@ -174,12 +174,8 @@ describe("CharmsAndActionsPanel", () => {
       CharmsPanelLabel.PANEL_TITLE,
     );
     const getCharmsURLErrorNotification = screen.getByText(
-      new RegExp(
-        CharmsAndActionsPanelLabel.GET_URL_ERROR.replace(
-          /[.*+?^${}()|[\]\\]/g,
-          "\\$&",
-        ),
-      ),
+      CharmsAndActionsPanelLabel.GET_URL_ERROR,
+      { exact: false },
     );
     expect(getCharmsURLErrorNotification).toBeInTheDocument();
     expect(getCharmsURLErrorNotification.childElementCount).toBe(1);

--- a/src/panels/CharmsAndActionsPanel/CharmsAndActionsPanel.tsx
+++ b/src/panels/CharmsAndActionsPanel/CharmsAndActionsPanel.tsx
@@ -1,9 +1,11 @@
-import { useEffect, useState } from "react";
+import { Button } from "@canonical/react-components";
+import { useCallback, useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router-dom";
 
 import type { EntityDetailsRoute } from "components/Routes/Routes";
 import { isSet } from "components/utils";
+import useInlineErrors from "hooks/useInlineErrors";
 import { getCharmsURLFromApplications } from "juju/api";
 import CharmActionsPanel from "panels/ActionsPanel/CharmActionsPanel";
 import CharmsPanel from "panels/CharmsPanel/CharmsPanel";
@@ -15,11 +17,15 @@ import {
 import { useAppStore } from "store/store";
 
 export enum Label {
-  GET_URL_ERROR = "Error while trying to get charms url from applications",
+  GET_URL_ERROR = "Unable to get data for selected application(s).",
 }
 
 export enum TestId {
   PANEL = "charms-and-actions-panel",
+}
+
+enum InlineErrors {
+  GET_URL = "get-url",
 }
 
 type CharmsAndActionsQueryParams = {
@@ -39,20 +45,29 @@ const CharmsAndActionsPanel = () => {
   const dispatch = useDispatch();
   const { userName, modelName } = useParams<EntityDetailsRoute>();
   const modelUUID = useSelector(getModelUUIDFromList(modelName, userName));
+  const [inlineErrors, setInlineErrors, hasInlineError] = useInlineErrors({
+    [InlineErrors.GET_URL]: (error) => (
+      <>
+        {error} Try{" "}
+        <Button
+          appearance="link"
+          onClick={() => {
+            getCharmsURL();
+          }}
+        >
+          refetching
+        </Button>{" "}
+        the charm application(s) data.
+      </>
+    ),
+  });
 
   // charmURL is initially undefined (isSet(charmURL) is false) and we
   // set its value once we get the information about the charms. Until
   // then, the Panel will be in a loading state.
   const isPanelLoading = !isSet(charmURL);
 
-  useEffect(() => {
-    // getCharmsURLFromApplications should be resolved only once after
-    // selectedApplications and modelUUID are initialized. Once it is
-    // resolved, the Panel is loaded and we will get an early return
-    // at each subsequent call of useEffect.
-    if (!selectedApplications || !modelUUID || !isPanelLoading) {
-      return;
-    }
+  const getCharmsURL = useCallback(() => {
     getCharmsURLFromApplications(
       selectedApplications,
       modelUUID,
@@ -62,10 +77,32 @@ const CharmsAndActionsPanel = () => {
       .then((charmsURL) => {
         const isCharmURLUnique = charmsURL.length === 1;
         setCharmURL(isCharmURLUnique ? charmsURL[0] : null);
+        setInlineErrors(InlineErrors.GET_URL, null);
         return;
       })
-      .catch((error) => console.error(Label.GET_URL_ERROR, error));
-  }, [appState, dispatch, isPanelLoading, modelUUID, selectedApplications]);
+      .catch((error) => {
+        setInlineErrors(InlineErrors.GET_URL, Label.GET_URL_ERROR);
+        console.error(Label.GET_URL_ERROR, error);
+      });
+  }, [appState, dispatch, modelUUID, selectedApplications, setInlineErrors]);
+
+  useEffect(() => {
+    // getCharmsURLFromApplications should be resolved only once after
+    // selectedApplications and modelUUID are initialized. Once it is
+    // resolved, the Panel is loaded and we will get an early return
+    // at each subsequent call of useEffect.
+    if (!selectedApplications || !modelUUID || !isPanelLoading) {
+      setInlineErrors(InlineErrors.GET_URL, null);
+      return;
+    }
+    getCharmsURL();
+  }, [
+    getCharmsURL,
+    isPanelLoading,
+    modelUUID,
+    selectedApplications,
+    setInlineErrors,
+  ]);
 
   return (
     <>
@@ -76,9 +113,10 @@ const CharmsAndActionsPanel = () => {
         />
       ) : (
         <CharmsPanel
+          inlineErrors={inlineErrors}
           onCharmURLChange={setCharmURL}
           onRemovePanelQueryParams={handleRemovePanelQueryParams}
-          isLoading={isPanelLoading}
+          isLoading={isPanelLoading && !hasInlineError()}
         />
       )}
     </>

--- a/src/panels/CharmsAndActionsPanel/CharmsAndActionsPanel.tsx
+++ b/src/panels/CharmsAndActionsPanel/CharmsAndActionsPanel.tsx
@@ -41,7 +41,7 @@ const CharmsAndActionsPanel = () => {
     usePanelQueryParams<CharmsAndActionsQueryParams>(defaultQueryParams);
 
   const selectedApplications = useSelector(getSelectedApplications());
-  const appState = useAppStore().getState();
+  const getState = useAppStore().getState;
   const dispatch = useDispatch();
   const { userName, modelName } = useParams<EntityDetailsRoute>();
   const modelUUID = useSelector(getModelUUIDFromList(modelName, userName));
@@ -71,7 +71,7 @@ const CharmsAndActionsPanel = () => {
     getCharmsURLFromApplications(
       selectedApplications,
       modelUUID,
-      appState,
+      getState(),
       dispatch,
     )
       .then((charmsURL) => {
@@ -84,7 +84,7 @@ const CharmsAndActionsPanel = () => {
         setInlineErrors(InlineErrors.GET_URL, Label.GET_URL_ERROR);
         console.error(Label.GET_URL_ERROR, error);
       });
-  }, [appState, dispatch, modelUUID, selectedApplications, setInlineErrors]);
+  }, [dispatch, getState, modelUUID, selectedApplications, setInlineErrors]);
 
   useEffect(() => {
     // getCharmsURLFromApplications should be resolved only once after

--- a/src/panels/CharmsPanel/CharmsPanel.test.tsx
+++ b/src/panels/CharmsPanel/CharmsPanel.test.tsx
@@ -193,4 +193,18 @@ describe("CharmsPanel", () => {
       }),
     ).toBeVisible();
   });
+
+  it("should show errors", () => {
+    state.juju.charms = [];
+    renderComponent(
+      <CharmsPanel
+        onCharmURLChange={jest.fn()}
+        onRemovePanelQueryParams={jest.fn()}
+        isLoading={false}
+        inlineErrors={["Oops, there is an error!"]}
+      />,
+      { path, url, state },
+    );
+    expect(screen.getByText("Oops, there is an error!")).toBeInTheDocument();
+  });
 });

--- a/src/panels/CharmsPanel/CharmsPanel.test.tsx
+++ b/src/panels/CharmsPanel/CharmsPanel.test.tsx
@@ -62,6 +62,7 @@ describe("CharmsPanel", () => {
         onCharmURLChange={jest.fn()}
         onRemovePanelQueryParams={jest.fn()}
         isLoading={false}
+        inlineErrors={[]}
       />,
       {
         path,
@@ -78,6 +79,7 @@ describe("CharmsPanel", () => {
         onCharmURLChange={jest.fn()}
         onRemovePanelQueryParams={jest.fn()}
         isLoading={false}
+        inlineErrors={[]}
       />,
       {
         path,
@@ -94,6 +96,7 @@ describe("CharmsPanel", () => {
         onCharmURLChange={jest.fn()}
         onRemovePanelQueryParams={jest.fn()}
         isLoading={false}
+        inlineErrors={[]}
       />,
       {
         path,
@@ -112,6 +115,7 @@ describe("CharmsPanel", () => {
         onCharmURLChange={mockHandleCharmURLChange}
         onRemovePanelQueryParams={jest.fn()}
         isLoading={false}
+        inlineErrors={[]}
       />,
       { path, url, state },
     );
@@ -128,6 +132,7 @@ describe("CharmsPanel", () => {
         onCharmURLChange={jest.fn()}
         onRemovePanelQueryParams={jest.fn()}
         isLoading={false}
+        inlineErrors={[]}
       />,
       { path, url, state },
     );
@@ -148,6 +153,7 @@ describe("CharmsPanel", () => {
         onCharmURLChange={jest.fn()}
         onRemovePanelQueryParams={jest.fn()}
         isLoading={false}
+        inlineErrors={[]}
       />,
       { path, url, state },
     );
@@ -170,6 +176,7 @@ describe("CharmsPanel", () => {
         onCharmURLChange={jest.fn()}
         onRemovePanelQueryParams={jest.fn()}
         isLoading={false}
+        inlineErrors={[]}
       />,
       { path, url, state },
     );

--- a/src/panels/CharmsPanel/CharmsPanel.tsx
+++ b/src/panels/CharmsPanel/CharmsPanel.tsx
@@ -1,8 +1,9 @@
 import { Button, RadioInput, Tooltip } from "@canonical/react-components";
-import { useState, type FormEventHandler } from "react";
+import { useState, type FormEventHandler, type ReactNode } from "react";
 
 import Panel from "components/Panel";
 import { TestId } from "panels/CharmsAndActionsPanel/CharmsAndActionsPanel";
+import PanelInlineErrors from "panels/PanelInlineErrors";
 import { getCharms } from "store/juju/selectors";
 import { useAppSelector } from "store/store";
 
@@ -17,12 +18,14 @@ type Props = {
   onCharmURLChange: (charmURL: string | null) => void;
   onRemovePanelQueryParams: () => void;
   isLoading: boolean;
+  inlineErrors: ReactNode[];
 };
 
 export default function CharmsPanel({
   onCharmURLChange,
   isLoading,
   onRemovePanelQueryParams,
+  inlineErrors,
 }: Props): JSX.Element {
   const [selectedCharm, setSelectedCharm] = useState<string | null>(null);
   const charms = useAppSelector(getCharms());
@@ -48,6 +51,7 @@ export default function CharmsPanel({
       onRemovePanelQueryParams={onRemovePanelQueryParams}
       loading={isLoading}
     >
+      <PanelInlineErrors inlineErrors={inlineErrors} />
       <form onSubmit={handleSubmit}>
         {charms.map((charm) => {
           const hasActionData =

--- a/src/panels/ConfigPanel/ConfigPanel.test.tsx
+++ b/src/panels/ConfigPanel/ConfigPanel.test.tsx
@@ -403,9 +403,9 @@ describe("ConfigPanel", () => {
         new Error("Error while calling getApplicationConfig"),
       );
     });
-    const configErrorNotification = screen.getByText(
-      new RegExp(Label.GET_CONFIG_ERROR),
-    );
+    const configErrorNotification = screen.getByText(Label.GET_CONFIG_ERROR, {
+      exact: false,
+    });
     expect(configErrorNotification).toBeInTheDocument();
     expect(configErrorNotification.childElementCount).toBe(1);
     const refetchButton = configErrorNotification.children[0];
@@ -470,7 +470,7 @@ describe("ConfigPanel", () => {
       ),
     );
     expect(
-      screen.getByText(new RegExp(Label.SUBMIT_TO_JUJU_ERROR)),
+      screen.getByText(Label.SUBMIT_TO_JUJU_ERROR, { exact: false }),
     ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Done

- Display get charm application(s) error (triggered in `CharmsAndActionsPanel`) in `CharmsPanel`.

## Details

- https://warthogs.atlassian.net/browse/WD-8829

## Screenshots

![Screenshot from 2024-02-12 17-42-51](https://github.com/canonical/juju-dashboard/assets/108150922/1491ddce-d1fd-4793-8df8-90826d3df566)

