### PR TITLE
WD-8402 - grant/revoke secrets

### DIFF
--- a/src/juju/apiHooks.test.tsx
+++ b/src/juju/apiHooks.test.tsx
@@ -1312,11 +1312,6 @@ describe("useGrantSecret", () => {
   it("can grant apps", async () => {
     const store = mockStore(state);
     changeURL("/models/eggman@external/group-test/app/etcd");
-    const secrets = [
-      {
-        uri: "secret:aabbccdd",
-      },
-    ];
     const results = { results: [{ result: "secret:def456" }] };
     const grantSecret = jest
       .fn()
@@ -1468,11 +1463,6 @@ describe("useRevokeSecret", () => {
   it("can revoke apps", async () => {
     const store = mockStore(state);
     changeURL("/models/eggman@external/group-test/app/etcd");
-    const secrets = [
-      {
-        uri: "secret:aabbccdd",
-      },
-    ];
     const results = { results: [{ result: "secret:def456" }] };
     const revokeSecret = jest
       .fn()

--- a/src/juju/apiHooks.test.tsx
+++ b/src/juju/apiHooks.test.tsx
@@ -26,6 +26,8 @@ import {
   useGetSecretContent,
   useRemoveSecrets,
   useUpdateSecrets,
+  useGrantSecret,
+  useRevokeSecret,
 } from "./apiHooks";
 
 const mockStore = configureStore<RootState, unknown>([]);
@@ -1280,5 +1282,317 @@ describe("useRemoveSecrets", () => {
     await expect(result.current(secrets)).rejects.toStrictEqual(
       new Error("Uh oh!"),
     );
+  });
+});
+
+describe("useGrantSecret", () => {
+  let state: RootState;
+
+  beforeEach(() => {
+    state = rootStateFactory.build({
+      general: generalStateFactory.build({
+        credentials: {
+          "wss://example.com/api": credentialFactory.build(),
+        },
+        config: configFactory.build({
+          controllerAPIEndpoint: "wss://example.com/api",
+        }),
+      }),
+      juju: {
+        models: {
+          abc123: modelListInfoFactory.build({
+            wsControllerURL: "wss://example.com/api",
+            uuid: "abc123",
+          }),
+        },
+      },
+    });
+  });
+
+  it("can grant apps", async () => {
+    const store = mockStore(state);
+    changeURL("/models/eggman@external/group-test/app/etcd");
+    const secrets = [
+      {
+        uri: "secret:aabbccdd",
+      },
+    ];
+    const results = { results: [{ result: "secret:def456" }] };
+    const grantSecret = jest
+      .fn()
+      .mockImplementation(() => Promise.resolve(results));
+    const loginResponse = {
+      conn: {
+        facades: {
+          secrets: {
+            grantSecret,
+          },
+        },
+      } as unknown as Connection,
+      logout: jest.fn(),
+    };
+    jest
+      .spyOn(jujuLib, "connectAndLogin")
+      .mockImplementation(() => Promise.resolve(loginResponse));
+    const { result } = renderHook(
+      () => useGrantSecret("eggman@external", "test-model"),
+      {
+        wrapper: (props) => (
+          <ComponentProviders
+            {...props}
+            path="/models/:userName/:modelName/app/:appName"
+            store={store}
+          />
+        ),
+      },
+    );
+    await expect(
+      result.current("secret:aabbccdd", ["lxd", "etcd"]),
+    ).resolves.toBe(results);
+    expect(grantSecret).toHaveBeenCalledWith({
+      applications: ["lxd", "etcd"],
+      uri: "secret:aabbccdd",
+    });
+  });
+
+  it("handles no connection", async () => {
+    const store = mockStore(state);
+    changeURL("/models/eggman@external/group-test/app/etcd");
+    const loginResponse = {
+      logout: jest.fn(),
+    };
+    jest
+      .spyOn(jujuLib, "connectAndLogin")
+      .mockImplementation(() => Promise.resolve(loginResponse));
+    const { result } = renderHook(
+      () => useGrantSecret("eggman@external", "test-model"),
+      {
+        wrapper: (props) => (
+          <ComponentProviders
+            {...props}
+            path="/models/:userName/:modelName/app/:appName"
+            store={store}
+          />
+        ),
+      },
+    );
+    await expect(
+      result.current("secret:aabbccdd", ["lxd", "etcd"]),
+    ).rejects.toStrictEqual(new Error("Unable to connect to model"));
+  });
+
+  it("handles connection errors", async () => {
+    const store = mockStore(state);
+    changeURL("/models/eggman@external/group-test/app/etcd");
+    jest
+      .spyOn(jujuLib, "connectAndLogin")
+      .mockImplementation(() => Promise.reject(new Error()));
+    const { result } = renderHook(
+      () => useGrantSecret("eggman@external", "test-model"),
+      {
+        wrapper: (props) => (
+          <ComponentProviders
+            {...props}
+            path="/models/:userName/:modelName/app/:appName"
+            store={store}
+          />
+        ),
+      },
+    );
+    await expect(
+      result.current("secret:aabbccdd", ["lxd", "etcd"]),
+    ).rejects.toBe("Error during promise race.");
+  });
+
+  it("handles errors from granting secrets", async () => {
+    const store = mockStore(state);
+    changeURL("/models/eggman@external/group-test/app/etcd");
+    const grantSecret = jest
+      .fn()
+      .mockImplementation(() => Promise.reject(new Error("Uh oh!")));
+    const loginResponse = {
+      conn: {
+        facades: {
+          secrets: {
+            grantSecret,
+          },
+        },
+      } as unknown as Connection,
+      logout: jest.fn(),
+    };
+    jest
+      .spyOn(jujuLib, "connectAndLogin")
+      .mockImplementation(() => Promise.resolve(loginResponse));
+    const { result } = renderHook(
+      () => useGrantSecret("eggman@external", "test-model"),
+      {
+        wrapper: (props) => (
+          <ComponentProviders
+            {...props}
+            path="/models/:userName/:modelName/app/:appName"
+            store={store}
+          />
+        ),
+      },
+    );
+    await expect(
+      result.current("secret:aabbccdd", ["lxd", "etcd"]),
+    ).rejects.toStrictEqual(new Error("Uh oh!"));
+  });
+});
+
+describe("useRevokeSecret", () => {
+  let state: RootState;
+
+  beforeEach(() => {
+    state = rootStateFactory.build({
+      general: generalStateFactory.build({
+        credentials: {
+          "wss://example.com/api": credentialFactory.build(),
+        },
+        config: configFactory.build({
+          controllerAPIEndpoint: "wss://example.com/api",
+        }),
+      }),
+      juju: {
+        models: {
+          abc123: modelListInfoFactory.build({
+            wsControllerURL: "wss://example.com/api",
+            uuid: "abc123",
+          }),
+        },
+      },
+    });
+  });
+
+  it("can revoke apps", async () => {
+    const store = mockStore(state);
+    changeURL("/models/eggman@external/group-test/app/etcd");
+    const secrets = [
+      {
+        uri: "secret:aabbccdd",
+      },
+    ];
+    const results = { results: [{ result: "secret:def456" }] };
+    const revokeSecret = jest
+      .fn()
+      .mockImplementation(() => Promise.resolve(results));
+    const loginResponse = {
+      conn: {
+        facades: {
+          secrets: {
+            revokeSecret,
+          },
+        },
+      } as unknown as Connection,
+      logout: jest.fn(),
+    };
+    jest
+      .spyOn(jujuLib, "connectAndLogin")
+      .mockImplementation(() => Promise.resolve(loginResponse));
+    const { result } = renderHook(
+      () => useRevokeSecret("eggman@external", "test-model"),
+      {
+        wrapper: (props) => (
+          <ComponentProviders
+            {...props}
+            path="/models/:userName/:modelName/app/:appName"
+            store={store}
+          />
+        ),
+      },
+    );
+    await expect(
+      result.current("secret:aabbccdd", ["lxd", "etcd"]),
+    ).resolves.toBe(results);
+    expect(revokeSecret).toHaveBeenCalledWith({
+      applications: ["lxd", "etcd"],
+      uri: "secret:aabbccdd",
+    });
+  });
+
+  it("handles no connection", async () => {
+    const store = mockStore(state);
+    changeURL("/models/eggman@external/group-test/app/etcd");
+    const loginResponse = {
+      logout: jest.fn(),
+    };
+    jest
+      .spyOn(jujuLib, "connectAndLogin")
+      .mockImplementation(() => Promise.resolve(loginResponse));
+    const { result } = renderHook(
+      () => useRevokeSecret("eggman@external", "test-model"),
+      {
+        wrapper: (props) => (
+          <ComponentProviders
+            {...props}
+            path="/models/:userName/:modelName/app/:appName"
+            store={store}
+          />
+        ),
+      },
+    );
+    await expect(
+      result.current("secret:aabbccdd", ["lxd", "etcd"]),
+    ).rejects.toStrictEqual(new Error("Unable to connect to model"));
+  });
+
+  it("handles connection errors", async () => {
+    const store = mockStore(state);
+    changeURL("/models/eggman@external/group-test/app/etcd");
+    jest
+      .spyOn(jujuLib, "connectAndLogin")
+      .mockImplementation(() => Promise.reject(new Error()));
+    const { result } = renderHook(
+      () => useRevokeSecret("eggman@external", "test-model"),
+      {
+        wrapper: (props) => (
+          <ComponentProviders
+            {...props}
+            path="/models/:userName/:modelName/app/:appName"
+            store={store}
+          />
+        ),
+      },
+    );
+    await expect(
+      result.current("secret:aabbccdd", ["lxd", "etcd"]),
+    ).rejects.toBe("Error during promise race.");
+  });
+
+  it("handles errors from revoking secrets", async () => {
+    const store = mockStore(state);
+    changeURL("/models/eggman@external/group-test/app/etcd");
+    const revokeSecret = jest
+      .fn()
+      .mockImplementation(() => Promise.reject(new Error("Uh oh!")));
+    const loginResponse = {
+      conn: {
+        facades: {
+          secrets: {
+            revokeSecret,
+          },
+        },
+      } as unknown as Connection,
+      logout: jest.fn(),
+    };
+    jest
+      .spyOn(jujuLib, "connectAndLogin")
+      .mockImplementation(() => Promise.resolve(loginResponse));
+    const { result } = renderHook(
+      () => useRevokeSecret("eggman@external", "test-model"),
+      {
+        wrapper: (props) => (
+          <ComponentProviders
+            {...props}
+            path="/models/:userName/:modelName/app/:appName"
+            store={store}
+          />
+        ),
+      },
+    );
+    await expect(
+      result.current("secret:aabbccdd", ["lxd", "etcd"]),
+    ).rejects.toStrictEqual(new Error("Uh oh!"));
   });
 });

--- a/src/juju/apiHooks.ts
+++ b/src/juju/apiHooks.ts
@@ -6,6 +6,7 @@ import type {
   ErrorResults,
   DeleteSecretArg,
   UpdateUserSecretArgs,
+  GrantRevokeUserSecretArg,
 } from "@canonical/jujulib/dist/api/facades/secrets/SecretsV2";
 import { useEffect, useCallback } from "react";
 import { useSelector } from "react-redux";
@@ -295,6 +296,84 @@ export const useRemoveSecrets = (userName?: string, modelName?: string) => {
               // Cast to `DeleteSecretArg` as the API requires either label or
               // URI, but the type declares both as required.
               ?.removeSecrets({ args: secrets as DeleteSecretArg[] })
+              .then((response) => {
+                resolve(response);
+                return;
+              })
+              .catch((error) => reject(error));
+          },
+        );
+      });
+    },
+    [modelConnectionCallback],
+  );
+};
+
+export const useGrantSecret = (userName?: string, modelName?: string) => {
+  const modelUUID = useSelector(getModelUUIDFromList(modelName, userName));
+  const modelConnectionCallback = useModelConnectionCallback(modelUUID);
+  return useCallback(
+    (secretURI: string, applications: string[]) => {
+      return new Promise<ErrorResults | string>((resolve, reject) => {
+        modelConnectionCallback(
+          (
+            connection?: ConnectionWithFacades | null,
+            error?: string | null,
+          ) => {
+            if (error) {
+              reject(error);
+              return;
+            }
+            if (!connection) {
+              reject(new Error("Unable to connect to model"));
+              return;
+            }
+            connection.facades.secrets
+              // Cast to `GrantRevokeUserSecretArg` as the API requires either label or
+              // URI, but the type declares both as required.
+              ?.grantSecret({
+                uri: secretURI,
+                applications,
+              } as GrantRevokeUserSecretArg)
+              .then((response) => {
+                resolve(response);
+                return;
+              })
+              .catch((error) => reject(error));
+          },
+        );
+      });
+    },
+    [modelConnectionCallback],
+  );
+};
+
+export const useRevokeSecret = (userName?: string, modelName?: string) => {
+  const modelUUID = useSelector(getModelUUIDFromList(modelName, userName));
+  const modelConnectionCallback = useModelConnectionCallback(modelUUID);
+  return useCallback(
+    (secretURI: string, applications: string[]) => {
+      return new Promise<ErrorResults | string>((resolve, reject) => {
+        modelConnectionCallback(
+          (
+            connection?: ConnectionWithFacades | null,
+            error?: string | null,
+          ) => {
+            if (error) {
+              reject(error);
+              return;
+            }
+            if (!connection) {
+              reject(new Error("Unable to connect to model"));
+              return;
+            }
+            connection.facades.secrets
+              // Cast to `GrantRevokeUserSecretArg` as the API requires either label or
+              // URI, but the type declares both as required.
+              ?.revokeSecret({
+                uri: secretURI,
+                applications,
+              } as GrantRevokeUserSecretArg)
               .then((response) => {
                 resolve(response);
                 return;

--- a/src/pages/EntityDetails/Model/Secrets/SecretsTable/SecretsTable.test.tsx
+++ b/src/pages/EntityDetails/Model/Secrets/SecretsTable/SecretsTable.test.tsx
@@ -191,4 +191,24 @@ describe("SecretsTable", () => {
       "?panel=update-secret&secret=secret%3Aaabbccdd",
     );
   });
+
+  it("can display the grant secret panel", async () => {
+    state.juju.secrets = secretsStateFactory.build({
+      abc123: modelSecretsFactory.build({
+        items: [listSecretResultFactory.build({ uri: "secret:aabbccdd" })],
+        loaded: true,
+      }),
+    });
+    renderComponent(<SecretsTable />, { state, path, url });
+    expect(window.location.search).toEqual("");
+    await userEvent.click(
+      screen.getByRole("button", { name: Label.ACTION_MENU }),
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: Label.GRANT_BUTTON }),
+    );
+    expect(window.location.search).toEqual(
+      "?panel=grant-secret&secret=secret%3Aaabbccdd",
+    );
+  });
 });

--- a/src/pages/EntityDetails/Model/Secrets/SecretsTable/SecretsTable.tsx
+++ b/src/pages/EntityDetails/Model/Secrets/SecretsTable/SecretsTable.tsx
@@ -30,6 +30,7 @@ import SecretContent from "../SecretContent";
 export enum Label {
   ACTION_MENU = "Action menu",
   COPY = "Copy",
+  GRANT_BUTTON = "Grant",
   REMOVE_BUTTON = "Remove",
   UPDATE_BUTTON = "Update",
 }
@@ -106,6 +107,7 @@ const SecretsTable = () => {
         ),
         revision: secret["latest-revision"],
         description: secret.description,
+        granted: secret.access?.length ?? 0,
         owner,
         created: <RelativeDate datetime={secret["create-time"]} />,
         updated: <RelativeDate datetime={secret["update-time"]} />,
@@ -116,6 +118,11 @@ const SecretsTable = () => {
                 children: Label.UPDATE_BUTTON,
                 onClick: () =>
                   setQuery({ panel: "update-secret", secret: secret.uri }),
+              },
+              {
+                children: Label.GRANT_BUTTON,
+                onClick: () =>
+                  setQuery({ panel: "grant-secret", secret: secret.uri }),
               },
               {
                 children: Label.REMOVE_BUTTON,
@@ -156,6 +163,10 @@ const SecretsTable = () => {
       {
         Header: "Owner",
         accessor: "owner",
+      },
+      {
+        Header: "Granted to #",
+        accessor: "granted",
       },
       {
         Header: "Created",

--- a/src/panels/GrantSecretPanel/GrantSecretPanel.test.tsx
+++ b/src/panels/GrantSecretPanel/GrantSecretPanel.test.tsx
@@ -1,0 +1,221 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import * as apiHooks from "juju/apiHooks";
+import type { RootState } from "store/store";
+import { rootStateFactory } from "testing/factories";
+import {
+  configFactory,
+  generalStateFactory,
+  credentialFactory,
+} from "testing/factories/general";
+import {
+  modelListInfoFactory,
+  secretsStateFactory,
+  listSecretResultFactory,
+  modelSecretsFactory,
+} from "testing/factories/juju/juju";
+import { secretAccessInfoFactory } from "testing/factories/juju/juju";
+import {
+  applicationInfoFactory,
+  modelWatcherModelDataFactory,
+} from "testing/factories/juju/model-watcher";
+import { renderComponent } from "testing/utils";
+import urls from "urls";
+
+import GrantSecretPanel, { Label } from "./GrantSecretPanel";
+
+jest.mock("juju/apiHooks", () => {
+  return {
+    useGrantSecret: jest.fn().mockReturnValue(jest.fn()),
+    useListSecrets: jest.fn().mockReturnValue(jest.fn()),
+    useRevokeSecret: jest.fn().mockReturnValue(jest.fn()),
+  };
+});
+
+describe("GrantSecretPanel", () => {
+  let state: RootState;
+  const path = urls.model.index(null);
+  const url = `${urls.model.index({
+    userName: "eggman@external",
+    modelName: "test-model",
+  })}?panel=grant-secret&secret=secret:aabbccdd`;
+
+  beforeEach(() => {
+    state = rootStateFactory.build({
+      general: generalStateFactory.build({
+        credentials: {
+          "wss://example.com/api": credentialFactory.build(),
+        },
+        config: configFactory.build({
+          controllerAPIEndpoint: "wss://example.com/api",
+        }),
+      }),
+      juju: {
+        models: {
+          abc123: modelListInfoFactory.build({
+            wsControllerURL: "wss://example.com/api",
+            uuid: "abc123",
+          }),
+        },
+        modelWatcherData: {
+          abc123: modelWatcherModelDataFactory.build({
+            applications: {
+              lxd: applicationInfoFactory.build(),
+              etcd: applicationInfoFactory.build(),
+            },
+          }),
+        },
+        secrets: secretsStateFactory.build({
+          abc123: modelSecretsFactory.build({
+            items: [
+              listSecretResultFactory.build({
+                uri: "secret:aabbccdd",
+              }),
+            ],
+            loaded: true,
+          }),
+        }),
+      },
+    });
+    jest.spyOn(apiHooks, "useListSecrets").mockImplementation(() => jest.fn());
+  });
+
+  it("displays a spinner while loading", async () => {
+    state.juju.secrets = {};
+    renderComponent(<GrantSecretPanel />, { state, path, url });
+    expect(screen.getByRole("alert", { name: "Loading" })).toBeVisible();
+  });
+
+  it("displays checkboxes for applications", async () => {
+    renderComponent(<GrantSecretPanel />, { state, path, url });
+    expect(screen.getByRole("checkbox", { name: "etcd" })).toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: "lxd" })).toBeInTheDocument();
+  });
+
+  it("ticks applications that have already been granted", async () => {
+    state.juju.secrets.abc123.items = [
+      listSecretResultFactory.build({
+        uri: "secret:aabbccdd",
+        access: [
+          secretAccessInfoFactory.build({ "target-tag": "application-etcd" }),
+        ],
+      }),
+    ];
+    renderComponent(<GrantSecretPanel />, { state, path, url });
+    expect(screen.getByRole("checkbox", { name: "etcd" })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "lxd" })).not.toBeChecked();
+  });
+
+  it("can grant and revoke apps", async () => {
+    state.juju.secrets.abc123.items = [
+      listSecretResultFactory.build({
+        uri: "secret:aabbccdd",
+        access: [
+          secretAccessInfoFactory.build({ "target-tag": "application-etcd" }),
+        ],
+      }),
+    ];
+    const grantSecret = jest
+      .fn()
+      .mockImplementation(() => Promise.resolve({ results: [] }));
+    jest
+      .spyOn(apiHooks, "useGrantSecret")
+      .mockImplementation(() => grantSecret);
+    const revokeSecret = jest
+      .fn()
+      .mockImplementation(() => Promise.resolve({ results: [] }));
+    jest
+      .spyOn(apiHooks, "useRevokeSecret")
+      .mockImplementation(() => revokeSecret);
+    renderComponent(<GrantSecretPanel />, { state, path, url });
+    await userEvent.click(screen.getByRole("checkbox", { name: "etcd" }));
+    await userEvent.click(screen.getByRole("checkbox", { name: "lxd" }));
+    await userEvent.click(screen.getByRole("button", { name: Label.SUBMIT }));
+    expect(grantSecret).toHaveBeenCalledWith("secret:aabbccdd", ["lxd"]);
+    expect(revokeSecret).toHaveBeenCalledWith("secret:aabbccdd", ["etcd"]);
+  });
+
+  it("displays caught errors", async () => {
+    const grantSecret = jest
+      .fn()
+      .mockImplementation(() => Promise.reject(new Error("Caught error")));
+    jest
+      .spyOn(apiHooks, "useGrantSecret")
+      .mockImplementation(() => grantSecret);
+    renderComponent(<GrantSecretPanel />, { state, path, url });
+    await userEvent.click(screen.getByRole("checkbox", { name: "etcd" }));
+    await userEvent.click(screen.getByRole("button", { name: Label.SUBMIT }));
+    await waitFor(() => {
+      expect(
+        document.querySelector(".p-notification--negative"),
+      ).toHaveTextContent("Caught error");
+    });
+  });
+
+  it("displays error string results", async () => {
+    const grantSecret = jest
+      .fn()
+      .mockImplementation(() => Promise.resolve("String error"));
+    jest
+      .spyOn(apiHooks, "useGrantSecret")
+      .mockImplementation(() => grantSecret);
+    renderComponent(<GrantSecretPanel />, { state, path, url });
+    await userEvent.click(screen.getByRole("checkbox", { name: "etcd" }));
+    await userEvent.click(screen.getByRole("button", { name: Label.SUBMIT }));
+    expect(
+      document.querySelector(".p-notification--negative"),
+    ).toHaveTextContent("String error");
+  });
+
+  it("displays error object results", async () => {
+    const grantSecret = jest
+      .fn()
+      .mockImplementation(() =>
+        Promise.resolve({ results: [{ error: { message: "Error result" } }] }),
+      );
+    jest
+      .spyOn(apiHooks, "useGrantSecret")
+      .mockImplementation(() => grantSecret);
+    renderComponent(<GrantSecretPanel />, { state, path, url });
+    await userEvent.click(screen.getByRole("checkbox", { name: "etcd" }));
+    await userEvent.click(screen.getByRole("button", { name: Label.SUBMIT }));
+    expect(
+      document.querySelector(".p-notification--negative"),
+    ).toHaveTextContent("Error result");
+  });
+
+  it("closes the panel if successful", async () => {
+    const grantSecret = jest
+      .fn()
+      .mockImplementation(() => Promise.resolve({ results: [] }));
+    jest
+      .spyOn(apiHooks, "useGrantSecret")
+      .mockImplementation(() => grantSecret);
+    renderComponent(<GrantSecretPanel />, { state, path, url });
+    expect(window.location.search).toEqual(
+      "?panel=grant-secret&secret=secret:aabbccdd",
+    );
+    await userEvent.click(screen.getByRole("checkbox", { name: "etcd" }));
+    await userEvent.click(screen.getByRole("button", { name: Label.SUBMIT }));
+    expect(window.location.search).toEqual("");
+  });
+
+  it("refetches the secrets if successful", async () => {
+    const grantSecret = jest
+      .fn()
+      .mockImplementation(() => Promise.resolve({ results: [] }));
+    jest
+      .spyOn(apiHooks, "useGrantSecret")
+      .mockImplementation(() => grantSecret);
+    const listSecrets = jest.fn();
+    jest
+      .spyOn(apiHooks, "useListSecrets")
+      .mockImplementation(() => listSecrets);
+    renderComponent(<GrantSecretPanel />, { state, path, url });
+    expect(listSecrets).not.toHaveBeenCalled();
+    await userEvent.click(screen.getByRole("checkbox", { name: "etcd" }));
+    await userEvent.click(screen.getByRole("button", { name: Label.SUBMIT }));
+    expect(listSecrets).toHaveBeenCalled();
+  });
+});

--- a/src/panels/GrantSecretPanel/GrantSecretPanel.test.tsx
+++ b/src/panels/GrantSecretPanel/GrantSecretPanel.test.tsx
@@ -87,6 +87,16 @@ describe("GrantSecretPanel", () => {
     expect(screen.getByRole("alert", { name: "Loading" })).toBeVisible();
   });
 
+  it("displays a message if there are no applications", async () => {
+    state.juju.modelWatcherData = {
+      abc123: modelWatcherModelDataFactory.build({
+        applications: {},
+      }),
+    };
+    renderComponent(<GrantSecretPanel />, { state, path, url });
+    expect(screen.getByText(Label.NO_APPS)).toBeInTheDocument();
+  });
+
   it("displays checkboxes for applications", async () => {
     renderComponent(<GrantSecretPanel />, { state, path, url });
     expect(screen.getByRole("checkbox", { name: "etcd" })).toBeInTheDocument();

--- a/src/panels/GrantSecretPanel/GrantSecretPanel.tsx
+++ b/src/panels/GrantSecretPanel/GrantSecretPanel.tsx
@@ -150,16 +150,32 @@ const GrantSecretPanel = () => {
                     </p>
                     <div id={groupId}>Applications</div>
                     <div role="group" aria-labelledby={groupId}>
-                      {modelApps.map((app) => (
-                        <FormikField
-                          id={app}
-                          key={app}
-                          label={app}
-                          name="applications"
-                          type="checkbox"
-                          value={app}
-                        />
-                      ))}
+                      {modelApps.map((app) => {
+                        const isOwner =
+                          app ===
+                          secret["owner-tag"].replace(/^application-/, "");
+                        return isOwner ? (
+                          // The owner field is not managed by Formik, it is for
+                          // display purposes only.
+                          <FormikField
+                            checked
+                            disabled
+                            key={app}
+                            label={`${app} (secret owner)`}
+                            name="owner"
+                            type="checkbox"
+                          />
+                        ) : (
+                          <FormikField
+                            id={app}
+                            key={app}
+                            label={app}
+                            name="applications"
+                            type="checkbox"
+                            value={app}
+                          />
+                        );
+                      })}
                     </div>
                   </>
                 ) : (

--- a/src/panels/GrantSecretPanel/GrantSecretPanel.tsx
+++ b/src/panels/GrantSecretPanel/GrantSecretPanel.tsx
@@ -102,16 +102,12 @@ const GrantSecretPanel = () => {
             inlineErrors={[inlineError]}
             scrollArea={scrollArea.current}
           />
-          {secret ? (
+          {secretURI && secret ? (
             <Formik<FormFields>
               initialValues={{
                 applications: currentApplications,
               }}
               onSubmit={async (values) => {
-                if (!secretURI) {
-                  // The form isn't shown if the secretURI doesn't exist so it's not possible to get to this point.
-                  return;
-                }
                 setSaving(true);
                 setInlineError(null);
                 const grantApps = values.applications.filter(

--- a/src/panels/GrantSecretPanel/GrantSecretPanel.tsx
+++ b/src/panels/GrantSecretPanel/GrantSecretPanel.tsx
@@ -1,0 +1,174 @@
+import type { ErrorResults } from "@canonical/jujulib/dist/api/facades/secrets/SecretsV2";
+import { ActionButton, Button, Spinner } from "@canonical/react-components";
+import { Form, Formik } from "formik";
+import { useId, useState, useRef } from "react";
+import { useSelector } from "react-redux";
+import { useParams } from "react-router-dom";
+
+import FormikField from "components/FormikField";
+import Panel from "components/Panel";
+import type { EntityDetailsRoute } from "components/Routes/Routes";
+import { useListSecrets, useGrantSecret, useRevokeSecret } from "juju/apiHooks";
+import PanelInlineErrors from "panels/PanelInlineErrors";
+import { usePanelQueryParams } from "panels/hooks";
+import {
+  getSecretByURI,
+  getModelUUIDFromList,
+  getModelApplications,
+} from "store/juju/selectors";
+import { useAppSelector } from "store/store";
+
+export enum TestId {
+  PANEL = "grant-secret-panel",
+}
+
+export enum Label {
+  CANCEL = "Cancel",
+  SUBMIT = "Grant",
+}
+
+export type FormFields = {
+  applications: string[];
+};
+
+const handleErrors = (response: string | ErrorResults) => {
+  if (typeof response === "string") {
+    throw new Error(response);
+  } else if (Array.isArray(response.results)) {
+    const error = response.results.find(({ error }) => !!error);
+    if (error?.error?.message) {
+      throw new Error(error.error?.message);
+    }
+  }
+};
+
+const GrantSecretPanel = () => {
+  const { userName, modelName } = useParams<EntityDetailsRoute>();
+  const modelUUID = useSelector(getModelUUIDFromList(modelName, userName));
+  const applications = useSelector(getModelApplications(modelUUID));
+  const scrollArea = useRef<HTMLDivElement>(null);
+  const formId = useId();
+  const groupId = useId();
+  const [queryParams, , handleRemovePanelQueryParams] = usePanelQueryParams<{
+    panel: string | null;
+    secret: string | null;
+  }>({
+    panel: null,
+    secret: null,
+  });
+  const secretURI = queryParams.secret;
+  const secret = useAppSelector((state) =>
+    getSecretByURI(state, modelUUID, secretURI),
+  );
+  const [inlineError, setInlineError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const grantSecret = useGrantSecret(userName, modelName);
+  const revokeSecret = useRevokeSecret(userName, modelName);
+  const listSecrets = useListSecrets(userName, modelName);
+  const currentApplications =
+    secret?.access?.map((access) =>
+      access["target-tag"].replace(/^application-/, ""),
+    ) ?? [];
+
+  return (
+    <>
+      <Panel
+        data-testid={TestId.PANEL}
+        drawer={
+          <>
+            <Button onClick={handleRemovePanelQueryParams}>
+              {Label.CANCEL}
+            </Button>
+            <ActionButton
+              appearance="positive"
+              disabled={saving}
+              form={formId}
+              loading={saving}
+              type="submit"
+            >
+              {Label.SUBMIT}
+            </ActionButton>
+          </>
+        }
+        onRemovePanelQueryParams={handleRemovePanelQueryParams}
+        ref={scrollArea}
+        title="Grant access"
+        width="narrow"
+      >
+        <>
+          <PanelInlineErrors
+            inlineErrors={[inlineError]}
+            scrollArea={scrollArea.current}
+          />
+          <p>
+            Grant applications access to view the value of this secret.
+            Deselected applications will have their access revoked.
+          </p>
+          {secret ? (
+            <Formik<FormFields>
+              initialValues={{
+                applications: currentApplications,
+              }}
+              onSubmit={async (values) => {
+                if (!secretURI) {
+                  // The form isn't shown if the secretURI doesn't exist so it's not possible to get to this point.
+                  return;
+                }
+                setSaving(true);
+                setInlineError(null);
+                const grantApps = values.applications.filter(
+                  (app) => !currentApplications.includes(app),
+                );
+                const revokeApps = currentApplications.filter(
+                  (app) => !values.applications.includes(app),
+                );
+                try {
+                  if (grantApps.length) {
+                    const response = await grantSecret(
+                      secretURI,
+                      values.applications,
+                    );
+                    handleErrors(response);
+                  }
+                  if (revokeApps.length) {
+                    const response = await revokeSecret(secretURI, revokeApps);
+                    handleErrors(response);
+                  }
+                  listSecrets();
+                  handleRemovePanelQueryParams();
+                } catch (error) {
+                  setSaving(false);
+                  if (typeof error === "string" || error instanceof Error) {
+                    setInlineError(
+                      error instanceof Error ? error.message : error,
+                    );
+                  }
+                }
+              }}
+            >
+              <Form id={formId}>
+                <div id={groupId}>Applications</div>
+                <div role="group" aria-labelledby={groupId}>
+                  {Object.keys(applications ?? {}).map((app) => (
+                    <FormikField
+                      id={app}
+                      key={app}
+                      label={app}
+                      name="applications"
+                      type="checkbox"
+                      value={app}
+                    />
+                  ))}
+                </div>
+              </Form>
+            </Formik>
+          ) : (
+            <Spinner aria-label="Loading" />
+          )}
+        </>
+      </Panel>
+    </>
+  );
+};
+
+export default GrantSecretPanel;

--- a/src/panels/GrantSecretPanel/GrantSecretPanel.tsx
+++ b/src/panels/GrantSecretPanel/GrantSecretPanel.tsx
@@ -25,6 +25,7 @@ export enum TestId {
 export enum Label {
   CANCEL = "Cancel",
   SUBMIT = "Grant",
+  NO_APPS = "There are no applications in this model.",
 }
 
 export type FormFields = {
@@ -69,6 +70,7 @@ const GrantSecretPanel = () => {
     secret?.access?.map((access) =>
       access["target-tag"].replace(/^application-/, ""),
     ) ?? [];
+  const modelApps = Object.keys(applications ?? {});
 
   return (
     <>
@@ -81,7 +83,7 @@ const GrantSecretPanel = () => {
             </Button>
             <ActionButton
               appearance="positive"
-              disabled={saving}
+              disabled={saving || modelApps.length === 0}
               form={formId}
               loading={saving}
               type="submit"
@@ -100,10 +102,6 @@ const GrantSecretPanel = () => {
             inlineErrors={[inlineError]}
             scrollArea={scrollArea.current}
           />
-          <p>
-            Grant applications access to view the value of this secret.
-            Deselected applications will have their access revoked.
-          </p>
           {secret ? (
             <Formik<FormFields>
               initialValues={{
@@ -147,19 +145,30 @@ const GrantSecretPanel = () => {
               }}
             >
               <Form id={formId}>
-                <div id={groupId}>Applications</div>
-                <div role="group" aria-labelledby={groupId}>
-                  {Object.keys(applications ?? {}).map((app) => (
-                    <FormikField
-                      id={app}
-                      key={app}
-                      label={app}
-                      name="applications"
-                      type="checkbox"
-                      value={app}
-                    />
-                  ))}
-                </div>
+                {modelApps.length > 0 ? (
+                  <>
+                    <p>
+                      Grant applications access to view the value of this
+                      secret. Deselected applications will have their access
+                      revoked.
+                    </p>
+                    <div id={groupId}>Applications</div>
+                    <div role="group" aria-labelledby={groupId}>
+                      {modelApps.map((app) => (
+                        <FormikField
+                          id={app}
+                          key={app}
+                          label={app}
+                          name="applications"
+                          type="checkbox"
+                          value={app}
+                        />
+                      ))}
+                    </div>
+                  </>
+                ) : (
+                  <p>{Label.NO_APPS}</p>
+                )}
               </Form>
             </Formik>
           ) : (

--- a/src/panels/GrantSecretPanel/index.ts
+++ b/src/panels/GrantSecretPanel/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./GrantSecretPanel";

--- a/src/panels/Panels.test.tsx
+++ b/src/panels/Panels.test.tsx
@@ -6,6 +6,7 @@ import { TestId as ActionsPanelTestId } from "./ActionsPanel/ActionsPanel";
 import { TestId as AuditLogsFilterPanelTestId } from "./AuditLogsFilterPanel/AuditLogsFilterPanel";
 import { TestId as CharmsAndActionsPanelTestId } from "./CharmsAndActionsPanel/CharmsAndActionsPanel";
 import { TestId as ConfigPanelTestId } from "./ConfigPanel/ConfigPanel";
+import { TestId as GrantSecretPanelTestId } from "./GrantSecretPanel/GrantSecretPanel";
 import Panels from "./Panels";
 import { TestId as RemoveSecretPanelTestId } from "./RemoveSecretPanel/RemoveSecretPanel";
 import { TestId as SecretFormPanelTestId } from "./SecretFormPanel/SecretFormPanel";
@@ -71,6 +72,15 @@ describe("Panels", () => {
     });
     expect(
       await screen.findByTestId(RemoveSecretPanelTestId.PANEL),
+    ).toBeInTheDocument();
+  });
+
+  it("can display the grant secret panel", async () => {
+    renderComponent(<Panels />, {
+      url: "/?panel=grant-secret",
+    });
+    expect(
+      await screen.findByTestId(GrantSecretPanelTestId.PANEL),
     ).toBeInTheDocument();
   });
 });

--- a/src/panels/Panels.tsx
+++ b/src/panels/Panels.tsx
@@ -8,6 +8,7 @@ import ShareModel from "panels/ShareModelPanel/ShareModel";
 import AuditLogsFilterPanel from "./AuditLogsFilterPanel";
 import CharmsAndActionsPanel from "./CharmsAndActionsPanel/CharmsAndActionsPanel";
 import ConfigPanel from "./ConfigPanel/ConfigPanel";
+import GrantSecretPanel from "./GrantSecretPanel";
 import RemoveSecretPanel from "./RemoveSecretPanel";
 
 export default function Panels() {
@@ -31,6 +32,8 @@ export default function Panels() {
         return <SecretFormPanel />;
       case "update-secret":
         return <SecretFormPanel update />;
+      case "grant-secret":
+        return <GrantSecretPanel />;
       case "remove-secret":
         return <RemoveSecretPanel />;
       default:

--- a/src/testing/factories/juju/juju.ts
+++ b/src/testing/factories/juju/juju.ts
@@ -7,6 +7,7 @@ import type {
 } from "@canonical/jujulib/dist/api/facades/client/ClientV6";
 import type { ModelInfo } from "@canonical/jujulib/dist/api/facades/model-manager/ModelManagerV9";
 import type {
+  AccessInfo,
   ListSecretResult,
   SecretRevision,
 } from "@canonical/jujulib/dist/api/facades/secrets/SecretsV2";
@@ -172,6 +173,12 @@ export const modelDataFactory = Factory.define<ModelData>(() => ({
 
 export const secretRevisionFactory = Factory.define<SecretRevision>(() => ({
   revision: 1,
+}));
+
+export const secretAccessInfoFactory = Factory.define<AccessInfo>(() => ({
+  role: "view",
+  "scope-tag": "model-abc123",
+  "target-tag": "application-lxd",
 }));
 
 export const listSecretResultFactory = Factory.define<ListSecretResult>(() => ({


### PR DESCRIPTION
## Done

- Add a panel for granting/revoking secrets.

## QA

- Go to the secrets tab for a model with more than one application.
- Open the action menu for a secret.
- Click "Grant"
- Choose an application and save.
- The panel should close and the number of granted counts should update.
- Open the grant panel again and deselect the selected app and select another and save.
- Reopen the panel and the checkboxes should reflect the changes you just made.

## Details

https://warthogs.atlassian.net/browse/WD-8403
https://warthogs.atlassian.net/browse/WD-8402
