### PR TITLE
WD-8858 - fix: fix notifications overlapping top navigation bar

### DIFF
--- a/src/scss/_vanilla-overrides.scss
+++ b/src/scss/_vanilla-overrides.scss
@@ -29,9 +29,9 @@
   }
 }
 
-// Fix for bug: https://github.com/canonical/vanilla-framework/issues/4907.
+// Fix for bug: https://github.com/canonical/vanilla-framework/issues/4990.
 .p-panel__header.is-sticky {
-  background-color: $color-x-light;
+  z-index: z("gamma");
 }
 
 // Make the skip link visible over the side nav

--- a/src/scss/_vanilla-overrides.scss
+++ b/src/scss/_vanilla-overrides.scss
@@ -31,7 +31,7 @@
 
 // Fix for bug: https://github.com/canonical/vanilla-framework/issues/4990.
 .p-panel__header.is-sticky {
-  z-index: z("gamma");
+  z-index: z("zeta");
 }
 
 // Make the skip link visible over the side nav


### PR DESCRIPTION
## Done

- Fix notifications overlapping top navigation bar.

## Details

- This PR fixes this bug: https://github.com/canonical/vanilla-framework/issues/4990
- https://warthogs.atlassian.net/browse/WD-8858

## Screenshots

Before:
![Screenshot from 2024-02-13 11-03-48](https://github.com/canonical/juju-dashboard/assets/108150922/b57d6bcd-c973-46bc-ab83-c6a4f97f9922)

After:
![Screenshot from 2024-02-13 11-03-59](https://github.com/canonical/juju-dashboard/assets/108150922/874e6569-1a2e-4611-b87f-b9dda100c4fb)

