### PR TITLE
WD-8855 - feat: display model-poller errors

### DIFF
--- a/src/components/ConnectionError/ConnectionError.test.tsx
+++ b/src/components/ConnectionError/ConnectionError.test.tsx
@@ -45,10 +45,13 @@ describe("ConnectionError", () => {
     const state = rootStateFactory.withGeneralConfig().build({
       juju: { auditEvents: { errors: "Oops!" } },
     });
-    const {
-      result: { rerender },
-    } = renderComponent(<ConnectionError />, { state });
-    rerender(<Toaster />);
+    renderComponent(
+      <>
+        <Toaster />
+        <ConnectionError />
+      </>,
+      { state },
+    );
     const auditLogsErrorNotification = screen.getByText(/Oops!/);
     expect(auditLogsErrorNotification.childElementCount).toBe(1);
     const refreshButton = auditLogsErrorNotification.children[0];

--- a/src/components/ConnectionError/ConnectionError.test.tsx
+++ b/src/components/ConnectionError/ConnectionError.test.tsx
@@ -1,5 +1,6 @@
-import { screen } from "@testing-library/react";
+import { act, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import reactHotToast, { Toaster } from "react-hot-toast";
 
 import { rootStateFactory } from "testing/factories/root";
 import { renderComponent } from "testing/utils";
@@ -20,6 +21,7 @@ describe("ConnectionError", () => {
     Object.defineProperty(window, "location", {
       value: location,
     });
+    act(() => reactHotToast.remove());
   });
 
   it("displays connection errors", () => {
@@ -36,6 +38,22 @@ describe("ConnectionError", () => {
       .build({ general: { connectionError: "Can't connect" } });
     renderComponent(<ConnectionError />, { state });
     await userEvent.click(screen.getByRole("button", { name: "refreshing" }));
+    expect(window.location.reload).toHaveBeenCalled();
+  });
+
+  it("displays Audit Logs errors", async () => {
+    const state = rootStateFactory.withGeneralConfig().build({
+      juju: { auditEvents: { errors: "Oops!" } },
+    });
+    const {
+      result: { rerender },
+    } = renderComponent(<ConnectionError />, { state });
+    rerender(<Toaster />);
+    const auditLogsErrorNotification = screen.getByText(/Oops!/);
+    expect(auditLogsErrorNotification.childElementCount).toBe(1);
+    const refreshButton = auditLogsErrorNotification.children[0];
+    expect(refreshButton).toHaveTextContent("refresh");
+    await userEvent.click(refreshButton);
     expect(window.location.reload).toHaveBeenCalled();
   });
 });

--- a/src/components/ConnectionError/ConnectionError.tsx
+++ b/src/components/ConnectionError/ConnectionError.tsx
@@ -1,11 +1,28 @@
 import { Button, Notification, Strip } from "@canonical/react-components";
 import type { PropsWithChildren } from "react";
+import reactHotToast from "react-hot-toast";
 
+import ToastCard from "components/ToastCard/ToastCard";
 import { getConnectionError } from "store/general/selectors";
+import { getAuditEventsErrors } from "store/juju/selectors";
 import { useAppSelector } from "store/store";
 
 const ConnectionError = ({ children }: PropsWithChildren) => {
   const error = useAppSelector(getConnectionError);
+  const auditLogsErrors = useAppSelector(getAuditEventsErrors);
+
+  if (auditLogsErrors) {
+    reactHotToast.custom((t) => (
+      <ToastCard type="negative" toastInstance={t}>
+        {auditLogsErrors} Try{" "}
+        <Button appearance="link" onClick={() => window.location.reload()}>
+          refreshing
+        </Button>{" "}
+        the page.
+      </ToastCard>
+    ));
+  }
+
   if (error) {
     return (
       <Strip>

--- a/src/components/ConnectionError/ConnectionError.tsx
+++ b/src/components/ConnectionError/ConnectionError.tsx
@@ -1,5 +1,5 @@
 import { Button, Notification, Strip } from "@canonical/react-components";
-import type { PropsWithChildren } from "react";
+import { useEffect, type PropsWithChildren } from "react";
 import reactHotToast from "react-hot-toast";
 
 import ToastCard from "components/ToastCard/ToastCard";
@@ -11,27 +11,31 @@ const ConnectionError = ({ children }: PropsWithChildren) => {
   const error = useAppSelector(getConnectionError);
   const auditLogsErrors = useAppSelector(getAuditEventsErrors);
 
-  if (auditLogsErrors) {
-    reactHotToast.custom((t) => (
-      <ToastCard type="negative" toastInstance={t}>
-        {auditLogsErrors} Try{" "}
-        <Button appearance="link" onClick={() => window.location.reload()}>
-          refreshing
-        </Button>{" "}
-        the page.
-      </ToastCard>
-    ));
-  }
+  const generateErrorContent = (error: string) => (
+    <>
+      {error} Try{" "}
+      <Button appearance="link" onClick={() => window.location.reload()}>
+        refreshing
+      </Button>{" "}
+      the page.
+    </>
+  );
+
+  useEffect(() => {
+    if (auditLogsErrors) {
+      reactHotToast.custom((t) => (
+        <ToastCard type="negative" toastInstance={t}>
+          {generateErrorContent(auditLogsErrors)}
+        </ToastCard>
+      ));
+    }
+  }, [auditLogsErrors]);
 
   if (error) {
     return (
       <Strip>
         <Notification severity="negative" title="Error">
-          {error} Try{" "}
-          <Button appearance="link" onClick={() => window.location.reload()}>
-            refreshing
-          </Button>{" "}
-          the page.
+          {generateErrorContent(error)}
         </Notification>
       </Strip>
     );

--- a/src/store/juju/actions.test.ts
+++ b/src/store/juju/actions.test.ts
@@ -162,6 +162,13 @@ describe("actions", () => {
     });
   });
 
+  it("updateAuditEventsErrors", () => {
+    expect(actions.updateAuditEventsErrors("Oops!")).toStrictEqual({
+      type: "juju/updateAuditEventsErrors",
+      payload: "Oops!",
+    });
+  });
+
   it("fetchCrossModelQuery", () => {
     expect(
       actions.fetchCrossModelQuery({

--- a/src/store/juju/reducers.test.ts
+++ b/src/store/juju/reducers.test.ts
@@ -332,6 +332,18 @@ describe("reducers", () => {
     });
   });
 
+  it("updateAuditEventsErrors", () => {
+    const state = jujuStateFactory.build();
+    expect(
+      reducer(state, actions.updateAuditEventsErrors("Oops!")),
+    ).toStrictEqual({
+      ...state,
+      auditEvents: auditEventsStateFactory.build({
+        errors: "Oops!",
+      }),
+    });
+  });
+
   it("clearControllerData", () => {
     const state = jujuStateFactory.build({
       controllers: {

--- a/src/store/juju/selectors.ts
+++ b/src/store/juju/selectors.ts
@@ -58,6 +58,14 @@ export const getAuditEvents = createSelector(
 );
 
 /**
+  Fetches the audit event errors from state.
+*/
+export const getAuditEventsErrors = createSelector(
+  [getAuditEventsState],
+  (auditEvents) => auditEvents.errors,
+);
+
+/**
   Fetches the audit events loaded state.
 */
 export const getAuditEventsLoaded = createSelector(

--- a/src/store/juju/slice.ts
+++ b/src/store/juju/slice.ts
@@ -75,6 +75,7 @@ const slice = createSlice({
   initialState: {
     auditEvents: {
       items: null,
+      errors: null,
       loaded: false,
       loading: false,
       limit: DEFAULT_AUDIT_EVENTS_LIMIT,
@@ -213,16 +214,24 @@ const slice = createSlice({
     },
     updateAuditEvents: (state, { payload }: PayloadAction<AuditEvent[]>) => {
       state.auditEvents.items = payload;
+      state.auditEvents.errors = null;
       state.auditEvents.loaded = true;
       state.auditEvents.loading = false;
     },
     clearAuditEvents: (state) => {
       state.auditEvents.items = null;
+      state.auditEvents.errors = null;
       state.auditEvents.loaded = false;
       state.auditEvents.loading = false;
     },
     updateAuditEventsLimit: (state, { payload }: PayloadAction<number>) => {
       state.auditEvents.limit = payload;
+    },
+    updateAuditEventsErrors: (
+      state,
+      { payload }: PayloadAction<string | null>,
+    ) => {
+      state.auditEvents.errors = payload;
     },
     fetchCrossModelQuery: (
       state,

--- a/src/store/juju/types.ts
+++ b/src/store/juju/types.ts
@@ -62,10 +62,7 @@ export type ModelsList = {
   [uuid: string]: ModelListInfo;
 };
 
-export type AuditEventsState = Omit<
-  GenericItemsState<AuditEvent, void>,
-  "errors"
-> & {
+export type AuditEventsState = GenericItemsState<AuditEvent, string | null> & {
   limit: number;
 };
 

--- a/src/store/middleware/check-auth.ts
+++ b/src/store/middleware/check-auth.ts
@@ -75,6 +75,7 @@ export const checkAuthMiddleware: Middleware<
       jujuActions.processAllWatcherDeltas.type,
       jujuActions.updateAuditEvents.type,
       jujuActions.updateAuditEventsLimit.type,
+      jujuActions.updateAuditEventsErrors.type,
       jujuActions.updateControllerList.type,
       jujuActions.clearControllerData.type,
       jujuActions.clearModelData.type,

--- a/src/store/middleware/model-poller.ts
+++ b/src/store/middleware/model-poller.ts
@@ -33,6 +33,10 @@ export enum ModelsError {
   LIST_OR_UPDATE_MODELS = "Unable to list or update models.",
 }
 
+export enum AuditLogsError {
+  CHECK_PERMISSIONS = "Unable to check Audit Logs user permissions.",
+}
+
 const checkJIMMRelation = async (
   conn: ConnectionWithFacades,
   identity: string,
@@ -149,9 +153,14 @@ export const modelPollerMiddleware: Middleware<
                 JIMMRelation.ADMINISTRATOR,
               );
             }
+            reduxStore.dispatch(jujuActions.updateAuditEventsErrors(null));
           } catch (error) {
-            // TODO: this should be displayed to the user somehow.
-            console.error("Unable to check user permissions", error);
+            reduxStore.dispatch(
+              jujuActions.updateAuditEventsErrors(
+                AuditLogsError.CHECK_PERMISSIONS,
+              ),
+            );
+            console.error(AuditLogsError.CHECK_PERMISSIONS, error);
           }
         }
         reduxStore.dispatch(

--- a/src/store/middleware/model-poller.ts
+++ b/src/store/middleware/model-poller.ts
@@ -34,7 +34,7 @@ export enum ModelsError {
 }
 
 export enum AuditLogsError {
-  CHECK_PERMISSIONS = "Unable to check Audit Logs user permissions.",
+  CHECK_PERMISSIONS = "Unable to check Audit Logs user permission.",
 }
 
 const checkJIMMRelation = async (

--- a/src/store/middleware/model-poller.ts
+++ b/src/store/middleware/model-poller.ts
@@ -21,9 +21,13 @@ import { actions as jujuActions } from "store/juju";
 import type { RootState, Store } from "store/store";
 import { isSpecificAction } from "types";
 
+export enum AuditLogsError {
+  CHECK_PERMISSIONS = "Unable to check Audit Logs user permission.",
+}
+
 export enum LoginError {
-  LOG = "Unable to log into controller",
-  NO_INFO = "Unable to retrieve controller details",
+  LOG = "Unable to log into controller.",
+  NO_INFO = "Unable to retrieve controller details.",
 }
 
 export enum ModelsError {
@@ -31,10 +35,6 @@ export enum ModelsError {
   LOAD_SOME_MODELS = "Unable to load some models.",
   LOAD_LATEST_MODELS = "Unable to load latest model data.",
   LIST_OR_UPDATE_MODELS = "Unable to list or update models.",
-}
-
-export enum AuditLogsError {
-  CHECK_PERMISSIONS = "Unable to check Audit Logs user permission.",
 }
 
 const checkJIMMRelation = async (

--- a/src/testing/factories/juju/juju.ts
+++ b/src/testing/factories/juju/juju.ts
@@ -186,6 +186,7 @@ export const listSecretResultFactory = Factory.define<ListSecretResult>(() => ({
 
 export const auditEventsStateFactory = Factory.define<AuditEventsState>(() => ({
   items: null,
+  errors: null,
   loaded: false,
   loading: false,
   limit: DEFAULT_AUDIT_EVENTS_LIMIT,


### PR DESCRIPTION
## Done

- Displayed the Audit Logs user permission check error.

## QA

- Run either demo or staging of JIMM.
- Throw an error on line 155 in `store/middleware/model-poller.ts`.
- A toast identical to the one in the attached screenshot should appear.

## Details

- https://warthogs.atlassian.net/browse/WD-8855

## Screenshots

![Screenshot from 2024-02-13 16-38-42](https://github.com/canonical/juju-dashboard/assets/108150922/668a3441-9935-4815-9e5a-3268503cf50d)


