### PR TITLE
WD-8411 - Limit write actions for secrets

### DIFF
--- a/src/hooks/useCanManageSecrets.test.tsx
+++ b/src/hooks/useCanManageSecrets.test.tsx
@@ -1,0 +1,167 @@
+import { renderHook } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+import { Provider } from "react-redux";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import type { RootState } from "store/store";
+import { rootStateFactory } from "testing/factories";
+import {
+  generalStateFactory,
+  configFactory,
+  credentialFactory,
+} from "testing/factories/general";
+import { modelUserInfoFactory } from "testing/factories/juju/ModelManagerV9";
+import {
+  jujuStateFactory,
+  modelDataFactory,
+  modelDataInfoFactory,
+  modelListInfoFactory,
+  modelFeaturesStateFactory,
+  modelFeaturesFactory,
+} from "testing/factories/juju/juju";
+import { modelWatcherModelDataFactory } from "testing/factories/juju/model-watcher";
+
+import useCanManageSecrets from "./useCanManageSecrets";
+
+const mockStore = configureStore();
+
+const generateContainer =
+  (state: RootState, path: string, url: string) =>
+  ({ children }: PropsWithChildren) => {
+    window.history.pushState({}, "", url);
+    const store = mockStore(state);
+    return (
+      <Provider store={store}>
+        <BrowserRouter>
+          <Routes>
+            <Route path={path} element={children} />
+          </Routes>
+        </BrowserRouter>
+      </Provider>
+    );
+  };
+
+describe("useCanManageSecrets", () => {
+  let state: RootState;
+  const url = "/models/eggman@external/test1";
+  const path = "/models/:userName/:modelName";
+
+  beforeEach(() => {
+    state = rootStateFactory.build({
+      general: generalStateFactory.build({
+        config: configFactory.build({
+          controllerAPIEndpoint: "wss://jimm.jujucharms.com/api",
+        }),
+        controllerConnections: {
+          "wss://jimm.jujucharms.com/api": {
+            user: {
+              "display-name": "eggman",
+              identity: "user-eggman@external",
+              "controller-access": "",
+              "model-access": "",
+            },
+          },
+        },
+        credentials: {
+          "wss://jimm.jujucharms.com/api": credentialFactory.build(),
+        },
+      }),
+      juju: jujuStateFactory.build({
+        modelData: {
+          abc123: modelDataFactory.build(),
+        },
+        modelFeatures: modelFeaturesStateFactory.build({
+          abc123: modelFeaturesFactory.build({
+            manageSecrets: true,
+          }),
+        }),
+        models: {
+          abc123: modelListInfoFactory.build({
+            uuid: "abc123",
+            name: "test1",
+            wsControllerURL: "wss://jimm.jujucharms.com/api",
+          }),
+        },
+        modelWatcherData: {
+          abc123: modelWatcherModelDataFactory.build(),
+        },
+      }),
+    });
+  });
+
+  it("allows secrets to be managed when the user has admin access", () => {
+    state.juju.modelData.abc123.info = modelDataInfoFactory.build({
+      uuid: "abc123",
+      name: "test1",
+      "controller-uuid": "controller123",
+      users: [
+        modelUserInfoFactory.build({
+          user: "eggman@external",
+          access: "admin",
+        }),
+      ],
+    });
+    const { result } = renderHook(() => useCanManageSecrets(), {
+      wrapper: generateContainer(state, path, url),
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it("allows secrets to be managed when the user has write access", () => {
+    state.juju.modelData.abc123.info = modelDataInfoFactory.build({
+      uuid: "abc123",
+      name: "test1",
+      "controller-uuid": "controller123",
+      users: [
+        modelUserInfoFactory.build({
+          user: "eggman@external",
+          access: "write",
+        }),
+      ],
+    });
+    const { result } = renderHook(() => useCanManageSecrets(), {
+      wrapper: generateContainer(state, path, url),
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it("doesn't allow secrets to be managed when the user has read access", () => {
+    state.juju.modelData.abc123.info = modelDataInfoFactory.build({
+      uuid: "abc123",
+      name: "test1",
+      "controller-uuid": "controller123",
+      users: [
+        modelUserInfoFactory.build({
+          user: "eggman@external",
+          access: "read",
+        }),
+      ],
+    });
+    const { result } = renderHook(() => useCanManageSecrets(), {
+      wrapper: generateContainer(state, path, url),
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it("doesn't allow secrets to be managed the model doesn't support it", () => {
+    state.juju.modelFeatures.abc123 = modelFeaturesFactory.build({
+      manageSecrets: false,
+    });
+    state.juju.modelData.abc123.info = modelDataInfoFactory.build({
+      uuid: "abc123",
+      name: "test1",
+      "controller-uuid": "controller123",
+      users: [
+        modelUserInfoFactory.build({
+          user: "eggman@external",
+          access: "admin",
+        }),
+      ],
+    });
+    const { result } = renderHook(() => useCanManageSecrets(), {
+      wrapper: generateContainer(state, path, url),
+    });
+    expect(result.current).toBe(false);
+  });
+});

--- a/src/hooks/useCanManageSecrets.ts
+++ b/src/hooks/useCanManageSecrets.ts
@@ -1,0 +1,22 @@
+import { useSelector } from "react-redux";
+import { useParams } from "react-router-dom";
+
+import useCanConfigureModel from "hooks/useCanConfigureModel";
+import {
+  getModelUUIDFromList,
+  getCanManageSecrets,
+} from "store/juju/selectors";
+import { useAppSelector } from "store/store";
+
+const useCanManageSecrets = () => {
+  const routeParams = useParams();
+  const { userName, modelName } = routeParams;
+  const modelUUID = useSelector(getModelUUIDFromList(modelName, userName));
+  const canManageSecrets = useAppSelector((state) =>
+    getCanManageSecrets(state, modelUUID),
+  );
+  const canConfigureModel = useCanConfigureModel();
+  return canManageSecrets && canConfigureModel;
+};
+
+export default useCanManageSecrets;

--- a/src/pages/EntityDetails/Model/Secrets/Secrets.tsx
+++ b/src/pages/EntityDetails/Model/Secrets/Secrets.tsx
@@ -4,6 +4,7 @@ import { useEffect } from "react";
 import { useParams } from "react-router-dom";
 
 import type { EntityDetailsRoute } from "components/Routes/Routes";
+import useCanManageSecrets from "hooks/useCanManageSecrets";
 import { useQueryParams } from "hooks/useQueryParams";
 import { useListSecrets } from "juju/apiHooks";
 import { actions as jujuActions } from "store/juju";
@@ -34,6 +35,7 @@ const Secrets = () => {
   const secretsErrors = useAppSelector((state) =>
     getSecretsErrors(state, modelUUID),
   );
+  const canManageSecrets = useCanManageSecrets();
 
   const [, setQuery] = useQueryParams<{
     panel: string | null;
@@ -63,13 +65,15 @@ const Secrets = () => {
   } else {
     content = (
       <>
-        <Button
-          hasIcon
-          onClick={() => setQuery({ panel: "add-secret" }, { replace: true })}
-        >
-          <Icon name="plus" />
-          <span>{Label.ADD}</span>
-        </Button>
+        {canManageSecrets ? (
+          <Button
+            hasIcon
+            onClick={() => setQuery({ panel: "add-secret" }, { replace: true })}
+          >
+            <Icon name="plus" />
+            <span>{Label.ADD}</span>
+          </Button>
+        ) : null}
         <SecretsTable />
       </>
     );

--- a/src/pages/EntityDetails/Model/Secrets/SecretsTable/SecretsTable.tsx
+++ b/src/pages/EntityDetails/Model/Secrets/SecretsTable/SecretsTable.tsx
@@ -16,6 +16,7 @@ import RelativeDate from "components/RelativeDate";
 import type { EntityDetailsRoute } from "components/Routes/Routes";
 import TruncatedTooltip from "components/TruncatedTooltip";
 import { copyToClipboard } from "components/utils";
+import useCanManageSecrets from "hooks/useCanManageSecrets";
 import { useQueryParams } from "hooks/useQueryParams";
 import {
   getSecretsLoading,
@@ -56,6 +57,7 @@ const SecretsTable = () => {
     panel: null,
     secret: null,
   });
+  const canManageSecrets = useCanManageSecrets();
 
   const tableData = useMemo(() => {
     if (!secrets) {
@@ -111,7 +113,7 @@ const SecretsTable = () => {
         owner,
         created: <RelativeDate datetime={secret["create-time"]} />,
         updated: <RelativeDate datetime={secret["update-time"]} />,
-        actions: (
+        actions: canManageSecrets ? (
           <ContextualMenu
             links={[
               {
@@ -136,13 +138,13 @@ const SecretsTable = () => {
             toggleClassName="has-icon u-no-margin--bottom is-small"
             toggleLabel={<Icon name="menu">{Label.ACTION_MENU}</Icon>}
           />
-        ),
+        ) : null,
       };
     });
-  }, [modelUUID, secrets, setQuery]);
+  }, [canManageSecrets, modelUUID, secrets, setQuery]);
 
-  const columnData: Column[] = useMemo(
-    () => [
+  const columnData: Column[] = useMemo(() => {
+    const headers = [
       {
         Header: "Name",
         accessor: "name",
@@ -176,14 +178,16 @@ const SecretsTable = () => {
         Header: "Updated",
         accessor: "updated",
       },
-      {
+    ];
+    if (canManageSecrets) {
+      headers.push({
         Header: "Actions",
         accessor: "actions",
         className: "u-align--right",
-      },
-    ],
-    [],
-  );
+      });
+    }
+    return headers;
+  }, [canManageSecrets]);
 
   return (
     <>

--- a/src/pages/ModelDetails/ModelDetails.tsx
+++ b/src/pages/ModelDetails/ModelDetails.tsx
@@ -38,9 +38,9 @@ export default function ModelDetails() {
     async function loadFullData() {
       try {
         const response = await startModelWatcher(modelUUID, appState, dispatch);
-        conn = response?.conn ?? null;
-        watcherHandle = response?.watcherHandle ?? null;
-        pingerIntervalId = response?.pingerIntervalId ?? null;
+        conn = response.conn;
+        watcherHandle = response.watcherHandle;
+        pingerIntervalId = response.pingerIntervalId;
         // Fetch additional model data for pre Juju 3.2.
         if (getMajorMinorVersion(conn?.info.serverVersion) < 3.2) {
           const status = await conn?.facades.client?.fullStatus({

--- a/src/panels/Panels.tsx
+++ b/src/panels/Panels.tsx
@@ -1,5 +1,6 @@
 import { AnimatePresence } from "framer-motion";
 
+import useCanManageSecrets from "hooks/useCanManageSecrets";
 import { useQueryParams } from "hooks/useQueryParams";
 import ActionsPanel from "panels/ActionsPanel/ActionsPanel";
 import SecretFormPanel from "panels/SecretFormPanel";
@@ -15,6 +16,7 @@ export default function Panels() {
   const [panelQs] = useQueryParams<{ panel: string | null }>({
     panel: null,
   });
+  const canManageSecrets = useCanManageSecrets();
 
   const generatePanel = () => {
     switch (panelQs.panel) {
@@ -29,13 +31,13 @@ export default function Panels() {
       case "audit-log-filters":
         return <AuditLogsFilterPanel />;
       case "add-secret":
-        return <SecretFormPanel />;
+        return canManageSecrets ? <SecretFormPanel /> : null;
       case "update-secret":
-        return <SecretFormPanel update />;
+        return canManageSecrets ? <SecretFormPanel update /> : null;
       case "grant-secret":
-        return <GrantSecretPanel />;
+        return canManageSecrets ? <GrantSecretPanel /> : null;
       case "remove-secret":
-        return <RemoveSecretPanel />;
+        return canManageSecrets ? <RemoveSecretPanel /> : null;
       default:
         return null;
     }


### PR DESCRIPTION
## Done

- Limit write actions for secrets to users that are have write or admin permission and are using a version of Juju with the Secrets v2 facade.

## QA

- Log in as a model admin (your normal user probably is otherwise log in as the admin user).
- Go to the secrets tab and check that you can open the panels for adding/updating secrets etc.
- Create a new user that has write permissions to a model (you will also need to make them a controller superuser due to this bug: https://bugs.launchpad.net/juju/+bug/2053102):
```
juju add-user writeuser
juju grant writeuser superuser
juju grant writeuser write [model-name]
```
- Log in as that user.
- Go to the secrets tab and check that you can open the panels for adding/updating secrets etc.
- Create a new user that has read permissions for a model:
```
juju add-user readuser
juju grant readuser superuser
juju grant readuser read [model-name]
```
- Log in as that user.
- Go to the secrets tab and check that there is no "Add secret" button and the action column doesn't appear in the table.

## Details

- https://warthogs.atlassian.net/browse/WD-8411
- https://warthogs.atlassian.net/browse/WD-8410
