### PR TITLE
WD-8929 - owner in access count

### DIFF
--- a/src/pages/EntityDetails/Model/Secrets/SecretsTable/SecretsTable.test.tsx
+++ b/src/pages/EntityDetails/Model/Secrets/SecretsTable/SecretsTable.test.tsx
@@ -20,6 +20,7 @@ import {
   modelFeaturesFactory,
   modelDataFactory,
   modelDataInfoFactory,
+  secretAccessInfoFactory,
 } from "testing/factories/juju/juju";
 import { modelWatcherModelDataFactory } from "testing/factories/juju/model-watcher";
 import { renderComponent } from "testing/utils";
@@ -131,6 +132,32 @@ describe("SecretsTable", () => {
     expect(
       screen.getByRole("cell", { name: "Show content secret2" }),
     ).toBeInTheDocument();
+  });
+
+  it("displays the number of apps with access to the secret", async () => {
+    state.juju.secrets = secretsStateFactory.build({
+      abc123: modelSecretsFactory.build({
+        items: [
+          listSecretResultFactory.build({
+            access: [
+              secretAccessInfoFactory.build(),
+              secretAccessInfoFactory.build(),
+            ],
+            label: "secret1",
+          }),
+          listSecretResultFactory.build({
+            access: [],
+            label: "secret2",
+            "owner-tag": "application-etcd",
+          }),
+        ],
+        loaded: true,
+      }),
+    });
+    renderComponent(<SecretsTable />, { state, path, url });
+    const grantedTo = screen.getAllByTestId(TestId.GRANTED_TO);
+    expect(grantedTo[0]).toHaveTextContent("2");
+    expect(grantedTo[1]).toHaveTextContent("1");
   });
 
   it("should remove the prefix from the id", async () => {

--- a/src/pages/EntityDetails/Model/Secrets/SecretsTable/SecretsTable.tsx
+++ b/src/pages/EntityDetails/Model/Secrets/SecretsTable/SecretsTable.tsx
@@ -38,6 +38,7 @@ export enum Label {
 
 export enum TestId {
   SECRETS_TABLE = "secrets-table",
+  GRANTED_TO = "granted-to",
 }
 
 const SecretsTable = () => {
@@ -76,6 +77,12 @@ const SecretsTable = () => {
           </AppLink>
         );
       }
+      let granted = secret.access?.length ?? 0;
+      if (secret["owner-tag"]?.startsWith("application-")) {
+        // If the secret is owned by an application then include it in the
+        // count of apps with access to the secret.
+        granted += 1;
+      }
       return {
         name: (
           <>
@@ -109,7 +116,7 @@ const SecretsTable = () => {
         ),
         revision: secret["latest-revision"],
         description: secret.description,
-        granted: secret.access?.length ?? 0,
+        granted: <span data-testid={TestId.GRANTED_TO}>{granted}</span>,
         owner,
         created: <RelativeDate datetime={secret["create-time"]} />,
         updated: <RelativeDate datetime={secret["update-time"]} />,


### PR DESCRIPTION
## Done

- Include the secret owner in the access count

## QA

- Go to the secrets tab.
- Check that secrets that are owned by an application include the owner in the count of applications that have been granted access.

## Details

https://warthogs.atlassian.net/browse/WD-8929
