### PR TITLE
WD-8405 - Config panel secret picker

### DIFF
--- a/src/panels/ConfigPanel/SecretsPicker/SecretsPicker.tsx
+++ b/src/panels/ConfigPanel/SecretsPicker/SecretsPicker.tsx
@@ -1,0 +1,106 @@
+import type { ContextualMenuProps } from "@canonical/react-components";
+import {
+  ContextualMenu,
+  Icon,
+  Spinner,
+  Tooltip,
+} from "@canonical/react-components";
+import type { ReactNode } from "react";
+import { useEffect } from "react";
+import { useParams } from "react-router-dom";
+
+import type { EntityDetailsRoute } from "components/Routes/Routes";
+import { useListSecrets } from "juju/apiHooks";
+import { actions as jujuActions } from "store/juju";
+import {
+  getModelByUUID,
+  getModelUUIDFromList,
+  getSecretsErrors,
+  getSecretsLoading,
+  getModelSecrets,
+} from "store/juju/selectors";
+import { useAppDispatch, useAppSelector } from "store/store";
+
+export enum Label {
+  CHOOSE_SECRET = "Choose a secret",
+  LOADING = "Loading",
+}
+
+type Props = {
+  setValue: (secret: string) => void;
+};
+
+export default function SecretsPicker({ setValue }: Props): JSX.Element {
+  const { userName, modelName } = useParams<EntityDetailsRoute>();
+  const dispatch = useAppDispatch();
+  const modelUUID = useAppSelector(getModelUUIDFromList(modelName, userName));
+  const wsControllerURL = useAppSelector((state) =>
+    getModelByUUID(state, modelUUID),
+  )?.wsControllerURL;
+  const secretsErrors = useAppSelector((state) =>
+    getSecretsErrors(state, modelUUID),
+  );
+  const listSecrets = useListSecrets(userName, modelName);
+  const secretsLoading = useAppSelector((state) =>
+    getSecretsLoading(state, modelUUID),
+  );
+  const secrets = useAppSelector((state) => getModelSecrets(state, modelUUID));
+
+  useEffect(() => {
+    listSecrets();
+    return () => {
+      if (!modelUUID || !wsControllerURL) {
+        return;
+      }
+      dispatch(jujuActions.clearSecrets({ modelUUID, wsControllerURL }));
+    };
+  }, [dispatch, listSecrets, modelUUID, wsControllerURL]);
+
+  let links: ContextualMenuProps<unknown>["links"] = null;
+  let dropdownContent: ReactNode = null;
+  if (secretsLoading) {
+    dropdownContent = (
+      <div className="u-align--center">
+        <Spinner aria-label={Label.LOADING} />
+      </div>
+    );
+  } else if (secretsErrors) {
+    dropdownContent = secretsErrors;
+  } else {
+    links = secrets?.map((secret) => {
+      const id = secret.uri.replace(/^secret:/, "");
+      return {
+        children: (
+          <>
+            {secret.label ? (
+              <>
+                {secret.label} <span className="u-text--muted">({id})</span>
+              </>
+            ) : (
+              id
+            )}
+          </>
+        ),
+        onClick: () => setValue(secret.uri),
+      };
+    });
+  }
+
+  return (
+    <ContextualMenu
+      dropdownClassName="p-contextual-menu__dropdown--over-panel prevent-panel-close"
+      links={links ?? []}
+      position="right"
+      scrollOverflow
+      toggleAppearance="base"
+      toggleClassName="has-icon u-no-margin--bottom is-small config-input__pick-secret"
+      toggleLabel={
+        <Tooltip message={Label.CHOOSE_SECRET}>
+          <Icon name="security">{Label.CHOOSE_SECRET}</Icon>
+        </Tooltip>
+      }
+    >
+      {dropdownContent}
+    </ContextualMenu>
+  );
+}

--- a/src/panels/ConfigPanel/SecretsPicker/index.ts
+++ b/src/panels/ConfigPanel/SecretsPicker/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SecretsPicker";

--- a/src/panels/ConfigPanel/TextAreaConfig.tsx
+++ b/src/panels/ConfigPanel/TextAreaConfig.tsx
@@ -2,6 +2,7 @@ import { useRef } from "react";
 
 import type { ConfigProps } from "./ConfigField";
 import ConfigField from "./ConfigField";
+import SecretsPicker from "./SecretsPicker";
 
 export default function TextAreaConfig({
   config,
@@ -18,14 +19,19 @@ export default function TextAreaConfig({
       setSelectedConfig={setSelectedConfig}
       setNewValue={setNewValue}
       input={(value) => (
-        <textarea
-          ref={inputRef}
-          value={value ?? ""}
-          onFocus={() => setSelectedConfig(config)}
-          onChange={(e) => {
-            setNewValue(config.name, e.target.value);
-          }}
-        ></textarea>
+        <div className="u-flex">
+          <textarea
+            ref={inputRef}
+            value={value ?? ""}
+            onFocus={() => setSelectedConfig(config)}
+            onChange={(e) => {
+              setNewValue(config.name, e.target.value);
+            }}
+          ></textarea>
+          <SecretsPicker
+            setValue={(secret) => setNewValue(config.name, secret)}
+          />
+        </div>
       )}
     />
   );

--- a/src/panels/ConfigPanel/_config-panel.scss
+++ b/src/panels/ConfigPanel/_config-panel.scss
@@ -185,4 +185,9 @@
     min-height: 2.3rem;
     resize: vertical;
   }
+
+}
+
+button.config-input__pick-secret {
+  margin-left: $sph--small;
 }

--- a/src/scss/_utils.scss
+++ b/src/scss/_utils.scss
@@ -1,3 +1,5 @@
+@import "./functions/z-index";
+
 // Capitalise every world of a string
 .u-capitalise {
   text-transform: capitalize;
@@ -82,4 +84,8 @@
 
 .u-full-width {
   width: 100%;
+}
+
+.p-contextual-menu__dropdown.p-contextual-menu__dropdown--over-panel {
+    z-index: z("zelda");
 }

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -44,6 +44,7 @@ $color-navigation-background: $color-brand;
 @include vf-p-icon-video-play;
 @include vf-p-icon-lock-locked;
 @include vf-p-icon-restart;
+@include vf-p-icon-security;
 @include vf-p-icon-topic;
 
 // Overrides for Vanilla. This needs to be after the Vanilla includes.


### PR DESCRIPTION
## Done

- Add a secret picker to the config panel.

## QA

- Go to a model and click on an application.
- Click the Configure button to open the config panel.
- Next to the string inputs you should see a little shield icon.
- Click the shield icon and pick a secret.
- The text input should get the full secret URI.
Note: at the moment the list is empty if there are no secrets in the model, but this will get updated to have an "Add secret..." button.

## Details

- https://warthogs.atlassian.net/browse/WD-8405

## Screenshots

<img width="412" alt="Screenshot 2024-02-15 at 4 44 07 pm" src="https://github.com/canonical/juju-dashboard/assets/361637/25818d31-e283-439c-bc4a-cbd54bcec199">

