### PR TITLE
WD-8972 - Disable app-owned secret actions

### DIFF
--- a/src/pages/EntityDetails/Model/Secrets/SecretsTable/SecretsTable.test.tsx
+++ b/src/pages/EntityDetails/Model/Secrets/SecretsTable/SecretsTable.test.tsx
@@ -234,6 +234,29 @@ describe("SecretsTable", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("does not display the action menu if secrets are owned by apps", async () => {
+    state.juju.secrets = secretsStateFactory.build({
+      abc123: modelSecretsFactory.build({
+        items: [
+          listSecretResultFactory.build({
+            uri: "secret:aabbccdd",
+            "owner-tag": "application-etcd",
+          }),
+        ],
+        loaded: true,
+      }),
+    });
+    renderComponent(<SecretsTable />, { state, path, url });
+    expect(
+      screen.queryByRole("button", { name: Label.ACTION_MENU }),
+    ).not.toBeInTheDocument();
+    expect(
+      document.querySelector(
+        "tr:last-child td:last-child .p-icon--information",
+      ),
+    ).toBeInTheDocument();
+  });
+
   it("can display the remove secret panel", async () => {
     state.juju.secrets = secretsStateFactory.build({
       abc123: modelSecretsFactory.build({

--- a/src/panels/ConfigPanel/ConfigPanel.tsx
+++ b/src/panels/ConfigPanel/ConfigPanel.tsx
@@ -33,6 +33,7 @@ import boxImage from "static/images/no-config-params.svg";
 import { actions as jujuActions } from "store/juju";
 import { getModelSecrets, getModelByUUID } from "store/juju/selectors";
 import { useAppStore, useAppSelector, useAppDispatch } from "store/store";
+import { secretIsAppOwned } from "utils";
 
 import BooleanConfig from "./BooleanConfig";
 import type { SetNewValue, SetSelectedConfig } from "./ConfigField";
@@ -105,9 +106,9 @@ const getRequiredGrants = (
   return secrets
     ? secretURIs?.filter((secretURI) => {
         const secret = secrets.find(
-          ({ uri, "owner-tag": ownerTag }) =>
+          (secretItem) =>
             // Can't grant application owned secrets so ignore them.
-            uri === secretURI && !ownerTag.startsWith("application-"),
+            secretItem.uri === secretURI && !secretIsAppOwned(secretItem),
         );
         const access = secret?.access?.find(
           (accessInfo) => accessInfo["target-tag"] === `application-${appName}`,

--- a/src/panels/ConfigPanel/SecretsPicker/SecretsPicker.test.tsx
+++ b/src/panels/ConfigPanel/SecretsPicker/SecretsPicker.test.tsx
@@ -165,6 +165,38 @@ describe("SecretsPicker", () => {
     ).toBeInTheDocument();
   });
 
+  it("does not include app-owned secrets in the list", async () => {
+    state.juju.secrets = secretsStateFactory.build({
+      abc123: modelSecretsFactory.build({
+        items: [
+          listSecretResultFactory.build({
+            label: "secret1",
+            uri: "secret:aabbccdd",
+          }),
+          listSecretResultFactory.build({
+            uri: "secret:eeffgghh",
+            "owner-tag": "application-etcd",
+          }),
+        ],
+        loaded: true,
+      }),
+    });
+    renderComponent(<SecretsPicker setValue={jest.fn()} />, {
+      state,
+      url,
+      path,
+    });
+    await userEvent.click(
+      screen.getByRole("button", { name: Label.CHOOSE_SECRET }),
+    );
+    expect(
+      screen.getByRole("button", { name: "secret1 (aabbccdd)" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "eeffgghh" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("can set the secret value", async () => {
     const setValue = jest.fn();
     renderComponent(<SecretsPicker setValue={setValue} />, {

--- a/src/panels/ConfigPanel/SecretsPicker/SecretsPicker.tsx
+++ b/src/panels/ConfigPanel/SecretsPicker/SecretsPicker.tsx
@@ -32,6 +32,7 @@ import {
   getSecretsLoaded,
 } from "store/juju/selectors";
 import { useAppDispatch, useAppSelector } from "store/store";
+import { secretIsAppOwned } from "utils";
 
 export enum Label {
   BUTTON_ADD = "Add a secret...",
@@ -95,13 +96,17 @@ export default function SecretsPicker({ setValue }: Props): JSX.Element {
   } else if (!canManageSecrets && !secrets?.length) {
     dropdownContent = Label.NONE;
   } else {
-    const secretLinks: MenuLink<ButtonProps> | undefined =
-      secrets?.map<ButtonProps>((secret) => {
-        return {
+    const secretLinks: MenuLink<ButtonProps> | undefined = secrets?.reduce<
+      ButtonProps[]
+    >((links, secret) => {
+      if (!secretIsAppOwned(secret)) {
+        links.push({
           children: <SecretLabel secret={secret} />,
           onClick: () => setValue(secret.uri),
-        };
-      });
+        });
+      }
+      return links;
+    }, []);
     if (canManageSecrets) {
       const addButton: MenuLink<ButtonProps> = {
         children: Label.BUTTON_ADD,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,3 +2,4 @@ export { argPath } from "./argPath";
 export { default as breakLines } from "./breakLines";
 export { default as getMajorMinorVersion } from "./getMajorMinorVersion";
 export { default as getUserName } from "./getUserName";
+export { default as secretIsAppOwned } from "./secretIsAppOwned";

--- a/src/utils/secretIsAppOwned.test.ts
+++ b/src/utils/secretIsAppOwned.test.ts
@@ -1,0 +1,16 @@
+import { listSecretResultFactory } from "testing/factories/juju/juju";
+import { secretIsAppOwned } from "utils";
+
+describe("secretIsAppOwned", () => {
+  it("should handle app owned secrets", () => {
+    const secret = listSecretResultFactory.build({
+      "owner-tag": "application-etcd",
+    });
+    expect(secretIsAppOwned(secret)).toBe(true);
+  });
+
+  it("should handle model owned secrets", () => {
+    const secret = listSecretResultFactory.build({ "owner-tag": "model-test" });
+    expect(secretIsAppOwned(secret)).toBe(false);
+  });
+});

--- a/src/utils/secretIsAppOwned.ts
+++ b/src/utils/secretIsAppOwned.ts
@@ -1,0 +1,6 @@
+import type { ListSecretResult } from "@canonical/jujulib/dist/api/facades/secrets/SecretsV2";
+
+const secretIsAppOwned = (secret: ListSecretResult) =>
+  secret["owner-tag"].startsWith("application-");
+
+export default secretIsAppOwned;


### PR DESCRIPTION
## Done

- Disable write actions for app-owned secrets.

## QA

- Go to the secrets tab.
- Check that app-owned secrets don't display an actions menu.
- Go to the config panel for a charm.
- Open the secrets picker.
- Check that no app-owned secrets are in the list.

## Details

- https://warthogs.atlassian.net/browse/WD-8972
