### PR TITLE
WD-8971 - Display secret name

### DIFF
--- a/src/pages/EntityDetails/Model/Secrets/SecretContent/SecretContent.tsx
+++ b/src/pages/EntityDetails/Model/Secrets/SecretContent/SecretContent.tsx
@@ -13,6 +13,7 @@ import usePortal from "react-useportal";
 
 import type { EntityDetailsRoute } from "components/Routes/Routes";
 import RevisionField from "components/secrets/RevisionField";
+import SecretLabel from "components/secrets/SecretLabel";
 import { useGetSecretContent } from "juju/apiHooks";
 import { actions as jujuActions } from "store/juju";
 import {
@@ -100,17 +101,25 @@ const SecretContent = ({ secretURI }: Props) => {
                   getSecretContent(secretURI, Number(values.revision));
                 }}
               >
-                <Form className="p-form--inline">
-                  <RevisionField secretURI={secretURI} modelUUID={modelUUID} />
-                  <ActionButton
-                    appearance="positive"
-                    disabled={contentLoading}
-                    loading={contentLoading}
-                    type="submit"
-                  >
-                    {Label.SUBMIT}
-                  </ActionButton>
-                </Form>
+                <>
+                  <h5>
+                    Secret: <SecretLabel secret={secret} />
+                  </h5>
+                  <Form className="p-form--inline">
+                    <RevisionField
+                      secretURI={secretURI}
+                      modelUUID={modelUUID}
+                    />
+                    <ActionButton
+                      appearance="positive"
+                      disabled={contentLoading}
+                      loading={contentLoading}
+                      type="submit"
+                    >
+                      {Label.SUBMIT}
+                    </ActionButton>
+                  </Form>
+                </>
               </Formik>
             ) : null}
             {contentLoaded && !contentLoading ? (

--- a/src/panels/GrantSecretPanel/GrantSecretPanel.tsx
+++ b/src/panels/GrantSecretPanel/GrantSecretPanel.tsx
@@ -8,6 +8,7 @@ import { useParams } from "react-router-dom";
 import FormikField from "components/FormikField";
 import Panel from "components/Panel";
 import type { EntityDetailsRoute } from "components/Routes/Routes";
+import SecretLabel from "components/secrets/SecretLabel";
 import { useListSecrets, useGrantSecret, useRevokeSecret } from "juju/apiHooks";
 import PanelInlineErrors from "panels/PanelInlineErrors";
 import { usePanelQueryParams } from "panels/hooks";
@@ -143,6 +144,9 @@ const GrantSecretPanel = () => {
               <Form id={formId}>
                 {modelApps.length > 0 ? (
                   <>
+                    <h5>
+                      Secret: <SecretLabel secret={secret} />
+                    </h5>
                     <p>
                       Grant applications access to view the value of this
                       secret. Deselected applications will have their access

--- a/src/panels/RemoveSecretPanel/RemoveSecretPanel.tsx
+++ b/src/panels/RemoveSecretPanel/RemoveSecretPanel.tsx
@@ -7,6 +7,7 @@ import { useParams } from "react-router-dom";
 
 import Panel from "components/Panel";
 import type { EntityDetailsRoute } from "components/Routes/Routes";
+import SecretLabel from "components/secrets/SecretLabel";
 import { useRemoveSecrets, useListSecrets } from "juju/apiHooks";
 import PanelInlineErrors from "panels/PanelInlineErrors";
 import { usePanelQueryParams } from "panels/hooks";
@@ -130,6 +131,9 @@ const RemoveSecretPanel = () => {
               }}
             >
               <Form id={formId}>
+                <h5>
+                  Secret: <SecretLabel secret={secret} />
+                </h5>
                 <Fields
                   handleRemoveSecret={handleRemoveSecret}
                   hideConfirm={() => setShowConfirm(false)}


### PR DESCRIPTION
## Done

- Display secret name/URI in panels.

## QA

- Go to the secrets tab.
- Open the grant panel and check that the secret name/URI is displayed near top.
- Open the remove panel and check that the secret name/URI is displayed near top.
- Click the eye icon to view the secret content and check that the secret name/URI is displayed near top.

## Details

- https://warthogs.atlassian.net/browse/WD-8971
