### PR TITLE
Improve timeout promise

### DIFF
--- a/src/juju/api.test.ts
+++ b/src/juju/api.test.ts
@@ -279,12 +279,14 @@ describe("Juju API", () => {
         false,
       );
       jest.advanceTimersByTime(LOGIN_TIMEOUT);
-      await expect(response).rejects.toMatchObject(new Error("timeout"));
+      await expect(response).rejects.toMatchObject(
+        new Error(Label.LOGIN_TIMEOUT_ERROR),
+      );
     });
 
     it("should handle exceptions when logging in", async () => {
       jest.spyOn(jujuLib, "connectAndLogin").mockImplementation(async () => {
-        return await new Promise((resolve, reject) => {
+        return await new Promise((_resolve, reject) => {
           reject(new Error("Uh oh!"));
         });
       });
@@ -297,9 +299,7 @@ describe("Juju API", () => {
         generateConnectionOptions(false),
         false,
       );
-      await expect(response).rejects.toMatchObject(
-        new Error("Error during promise race.", new Error("Uh oh!")),
-      );
+      await expect(response).rejects.toMatchObject(new Error("Uh oh!"));
     });
   });
 
@@ -371,11 +371,13 @@ describe("Juju API", () => {
         () => state,
       );
       jest.advanceTimersByTime(LOGIN_TIMEOUT);
-      await expect(response).rejects.toStrictEqual(new Error("timeout"));
+      await expect(response).rejects.toStrictEqual(
+        new Error(Label.LOGIN_TIMEOUT_ERROR),
+      );
       expect(console.error).toHaveBeenCalledWith(
         "Error connecting to model:",
         "abc123",
-        new Error("timeout"),
+        new Error(Label.LOGIN_TIMEOUT_ERROR),
       );
       console.error = consoleError;
     });

--- a/src/juju/apiHooks.test.tsx
+++ b/src/juju/apiHooks.test.tsx
@@ -17,7 +17,7 @@ import {
 } from "testing/factories/juju/juju";
 import { ComponentProviders, changeURL } from "testing/utils";
 
-import { LOGIN_TIMEOUT } from "./api";
+import { LOGIN_TIMEOUT, Label as APILabel } from "./api";
 import {
   useListSecrets,
   useCreateSecrets,
@@ -123,7 +123,7 @@ describe("useModelConnectionCallback", () => {
     changeURL("/models/eggman@external/group-test/app/etcd");
     jest
       .spyOn(jujuLib, "connectAndLogin")
-      .mockImplementation(() => Promise.reject(new Error()));
+      .mockImplementation(() => Promise.reject(new Error("Uh oh!")));
     const callback = jest.fn();
     const { result } = renderHook(() => useModelConnectionCallback("abc123"), {
       wrapper: (props) => (
@@ -137,7 +137,7 @@ describe("useModelConnectionCallback", () => {
     result.current(callback);
     await waitFor(() => {
       expect(callback).toHaveBeenCalledWith({
-        error: "Error during promise race.",
+        error: "Uh oh!",
       });
     });
   });
@@ -163,7 +163,9 @@ describe("useModelConnectionCallback", () => {
     result.current(callback);
     jest.advanceTimersByTime(LOGIN_TIMEOUT);
     await waitFor(() => {
-      expect(callback).toHaveBeenCalledWith({ error: "timeout" });
+      expect(callback).toHaveBeenCalledWith({
+        error: APILabel.LOGIN_TIMEOUT_ERROR,
+      });
     });
   });
 


### PR DESCRIPTION
## Done

- Reject on timeout instead of returning special string.

## QA

- Go to the model list and check that the models appear.
- Open api.ts and change `LOGIN_TIMEOUT` to a very low number.
- Reload the model list and check that the console has timeout errors.
