### PR TITLE
WD-9169 - Handle model store error

### DIFF
--- a/src/juju/api.test.ts
+++ b/src/juju/api.test.ts
@@ -4,7 +4,6 @@ import * as jujuLibVersions from "@canonical/jujulib/dist/api/versions";
 import { waitFor } from "@testing-library/react";
 
 import { actions as jujuActions } from "store/juju";
-import { addControllerCloudRegion } from "store/juju/thunks";
 import type { RootState } from "store/store";
 import { rootStateFactory } from "testing/factories";
 import {
@@ -1040,14 +1039,9 @@ describe("Juju API", () => {
       // We need to return the logged out state on the last call, so check that
       // the number of calls is what we expect:
       expect(getState).toHaveBeenCalledTimes(7);
-      expect(dispatch).toHaveBeenCalledWith(
+      // The `updateModelInfo` should be the last dispatch before exiting.
+      expect(dispatch).toHaveBeenLastCalledWith(
         jujuActions.updateModelInfo({
-          modelInfo: abc123,
-          wsControllerURL: "wss://example.com/api",
-        }),
-      );
-      expect(dispatch).not.toHaveBeenCalledWith(
-        addControllerCloudRegion({
           modelInfo: abc123,
           wsControllerURL: "wss://example.com/api",
         }),

--- a/src/juju/api.ts
+++ b/src/juju/api.ts
@@ -374,6 +374,12 @@ export async function fetchAllModelStatuses(
               getState,
             );
           }
+          if (!isLoggedIn(getState(), wsControllerURL)) {
+            // The user may have logged out while the previous call was in
+            // progress.
+            done();
+            return;
+          }
           const modelInfo = await fetchModelInfo(conn, modelUUID);
           if (modelInfo) {
             dispatch(
@@ -382,6 +388,12 @@ export async function fetchAllModelStatuses(
                 wsControllerURL,
               }),
             );
+          }
+          if (!isLoggedIn(getState(), wsControllerURL)) {
+            // The user may have logged out while the previous call was in
+            // progress.
+            done();
+            return;
           }
           if (modelInfo?.results[0].result?.["is-controller"]) {
             // If this is a controller model then update the

--- a/src/juju/api.ts
+++ b/src/juju/api.ts
@@ -308,6 +308,11 @@ export async function fetchAndStoreModelStatus(
     wsControllerURL,
     getState,
   );
+  if (!isLoggedIn(getState(), wsControllerURL)) {
+    // The user may have logged out while fetching the model status so don't
+    // store anything if they did.
+    return;
+  }
   if (status) {
     dispatch(
       jujuActions.updateModelStatus({ modelUUID, status, wsControllerURL }),

--- a/src/store/middleware/check-auth.ts
+++ b/src/store/middleware/check-auth.ts
@@ -20,7 +20,7 @@ function error(name: string, wsControllerURL?: string | null) {
     name,
     wsControllerURL
       ? `. User not authenticated for the controller: ${wsControllerURL}. ` +
-          "This shouldn't be able to happen!"
+          "Did the user log out before this was dispatched?"
       : ". Either 'wsControllerURL' needs to be added to the dispatched " +
           "action or add the action to the list of actions allowed to be " +
           "performed while logged out.",


### PR DESCRIPTION
## Done

- Handle storing models after logout.

## QA

- Connect to a slow local controller.
- Login and then immediately logout.
- The uncaught error should not appear.

## Details

- https://warthogs.atlassian.net/browse/WD-9169
- https://github.com/canonical/juju-dashboard/issues/1635
