### PR TITLE
feat: clear local storage when closing dashboard

### DIFF
--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -1,9 +1,12 @@
+import { useEffect } from "react";
 import { initialize, pageview } from "react-ga";
 import { BrowserRouter as Router } from "react-router-dom";
 
 import ConnectionError from "components/ConnectionError";
 import ErrorBoundary from "components/ErrorBoundary/ErrorBoundary";
 import { Routes } from "components/Routes/Routes";
+import { CLI_HISTORY_KEY } from "components/WebCLI/WebCLI";
+import { QUERY_HISTORY_KEY } from "pages/AdvancedSearch/SearchForm/SearchForm";
 import { getAnalyticsEnabled, getConfig } from "store/general/selectors";
 import { useAppSelector } from "store/store";
 
@@ -17,6 +20,18 @@ function App() {
     initialize("UA-1018242-68");
     pageview(window.location.href.replace(window.location.origin, ""));
   }
+
+  useEffect(
+    () => () => {
+      const localStorageKeys = [CLI_HISTORY_KEY, QUERY_HISTORY_KEY];
+      localStorageKeys.forEach((key) => {
+        if (window.localStorage.getItem(key) !== null) {
+          window.localStorage.removeItem(key);
+        }
+      });
+    },
+    [],
+  );
 
   return (
     <Router basename={config?.baseAppURL}>

--- a/src/components/WebCLI/WebCLI.tsx
+++ b/src/components/WebCLI/WebCLI.tsx
@@ -42,6 +42,7 @@ type Authentication = {
   macaroons?: Macaroon[];
 };
 
+export const CLI_HISTORY_KEY = "cliHistory";
 export const MAX_HISTORY = 200;
 
 const WebCLI = ({
@@ -60,7 +61,7 @@ const WebCLI = ({
   const sendAnalytics = useAnalytics();
   const storeState = useStore().getState();
   const [cliHistory, setCLIHistory] = useLocalStorage<string[]>(
-    "cliHistory",
+    CLI_HISTORY_KEY,
     [],
   );
 


### PR DESCRIPTION
## Done

- Clear local storage when closing dashboard.

## QA

- Write a command in the `WebCLI`.
- In developer console, there should be `cliHisotry` in local storage.
- Close the dashboard and open it again.
- Check that there is no `cliHistory` in local storage. 
