### PR TITLE
WD-9981 - refactor: remove click propagation

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@canonical/jujulib": "6.0.0",
     "@canonical/macaroon-bakery": "1.3.2",
-    "@canonical/react-components": "0.51.0",
+    "@canonical/react-components": "0.51.1",
     "@reduxjs/toolkit": "2.0.1",
     "@sentry/browser": "7.93.0",
     "ansi-to-html": "0.7.2",

--- a/src/panels/ActionsPanel/ActionsPanel.tsx
+++ b/src/panels/ActionsPanel/ActionsPanel.tsx
@@ -259,12 +259,7 @@ export default function ActionsPanel(): JSX.Element {
               cancelButtonLabel={Label.CANCEL_BUTTON}
               confirmButtonLabel={Label.CONFIRM_BUTTON}
               confirmButtonAppearance="positive"
-              onConfirm={(event: React.MouseEvent<HTMLElement, MouseEvent>) => {
-                // Stop propagation of the click event in order for the Panel
-                // to remain open after an error occurs in executeAction().
-                // Remove this manual fix once this issue gets resolved:
-                // https://github.com/canonical/react-components/issues/1032
-                event.nativeEvent.stopImmediatePropagation();
+              onConfirm={() => {
                 setConfirmType(null);
                 setIsExecutingAction(true);
                 executeAction()

--- a/src/panels/ActionsPanel/CharmActionsPanel.tsx
+++ b/src/panels/ActionsPanel/CharmActionsPanel.tsx
@@ -159,8 +159,7 @@ export default function CharmActionsPanel({
               cancelButtonLabel={Label.CANCEL_BUTTON}
               confirmButtonLabel={Label.CONFIRM_BUTTON}
               confirmButtonAppearance="positive"
-              onConfirm={(event) => {
-                event.stopPropagation();
+              onConfirm={() => {
                 setConfirmType(null);
                 executeAction();
                 onRemovePanelQueryParams();

--- a/src/panels/RemoveSecretPanel/Fields/Fields.tsx
+++ b/src/panels/RemoveSecretPanel/Fields/Fields.tsx
@@ -75,12 +75,7 @@ const Fields = ({
                 This action can't be undone.
               </p>
             }
-            onConfirm={(event: React.MouseEvent<HTMLElement, MouseEvent>) => {
-              // Stop propagation of the click event in order for the Panel
-              // to remain open after an error occurs in executeAction().
-              // Remove this manual fix once this issue gets resolved:
-              // https://github.com/canonical/react-components/issues/1032
-              event.nativeEvent.stopImmediatePropagation();
+            onConfirm={() => {
               handleRemoveSecret(values);
             }}
             close={hideConfirm}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1818,9 +1818,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@canonical/react-components@npm:0.51.0":
-  version: 0.51.0
-  resolution: "@canonical/react-components@npm:0.51.0"
+"@canonical/react-components@npm:0.51.1":
+  version: 0.51.1
+  resolution: "@canonical/react-components@npm:0.51.1"
   dependencies:
     "@types/jest": "npm:29.5.11"
     "@types/node": "npm:20.8.5"
@@ -1840,7 +1840,7 @@ __metadata:
     react: ^17.0.2 || ^18.0.0
     react-dom: ^17.0.2 || ^18.0.0
     vanilla-framework: ^3.15.1 || ^4.0.0
-  checksum: f1db7593e44d1e8fb517a7056ad3e5954ba1c2185094779f759169411346a83ea49cc11c86fdc38914f745b6d88a6ba5554650c0b6626fc79d9ee8884f5e198c
+  checksum: b81206c17e4edfd24ff70d26ac64553d464e05617b5ba5dff6fa741a3c6310266fbfa0e7bce62153ae2b25bf28a814e430177b3ca167a777b6a2229977776097
   languageName: node
   linkType: hard
 
@@ -11294,7 +11294,7 @@ __metadata:
     "@babel/plugin-proposal-private-property-in-object": "npm:7.21.11"
     "@canonical/jujulib": "npm:6.0.0"
     "@canonical/macaroon-bakery": "npm:1.3.2"
-    "@canonical/react-components": "npm:0.51.0"
+    "@canonical/react-components": "npm:0.51.1"
     "@reduxjs/toolkit": "npm:2.0.1"
     "@sentry/browser": "npm:7.93.0"
     "@testing-library/jest-dom": "npm:6.2.0"


### PR DESCRIPTION
## Done

- Refactored after the fix to stop click event propagation in `Modal` and `ConfirmationModal` in `react-components`.

## Details

- https://warthogs.atlassian.net/browse/WD-9981
