### PR TITLE
WD-11704 - feat: add development proxy to JIMM

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+VITE_JIMM_API_URL=http://jimm.localhost:17070/

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ public/config.local.js
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+.env.local
+.env.*.local

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,6 +35,11 @@ export default defineConfig(({ mode }) => {
     server: {
       host: "0.0.0.0",
       port: Number(env.PORT),
+      proxy: {
+        "/auth": {
+          target: env.VITE_JIMM_API_URL ?? "/",
+        },
+      },
     },
     test: {
       coverage: {


### PR DESCRIPTION
## Done

- Add a proxy to the JIMM API for OIDC login.

## QA

- Set up JIMM following the instructions in this PR: https://github.com/canonical/juju-dashboard/pull/1764.
- Visit `http://jimm.localhost:8036/auth/whoami`.
- Check that you see the logged in user details or forbidden message if you're not logged in (or you might even get `Internal Server Error - failed to retrieve session` if you've never logged in before ).

## Details

https://warthogs.atlassian.net/browse/WD-11704
