### PR TITLE
fix: dotrun workflow task

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -128,7 +128,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install dotrun
-        uses: canonical/install-dotrun@main
+        run: sudo pip3 install dotrun requests==2.31.0 # requests version is pinned to avoid breaking changes, can be removed once issue is resolved: https://github.com/docker/docker-py/issues/3256
       - name: Install dependencies
         run: |
           sudo chmod -R 777 .


### PR DESCRIPTION
## Done

- Updated the dotrun action to use the python version and prevent it always failing

## QA

- The dotrun job should work for this PR
