### PR TITLE
WD-11707 - feat: OIDC ws login

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -483,7 +483,16 @@ You can now configure your local dashboard by setting the endpoint in
 controllerAPIEndpoint: "wss://[container.ip]:17070/api",
 ```
 
-You may also need to configure your dashboard to work with a local controller:
+When deployed by a charm the controller relation will provide the value for
+`identityProviderURL`. The actual value isn't used by the dashboard at this
+time, but rather the existence of the value informs the dashboard that Candid is
+available, so in `config.local.js` you just need to set the URL to any truthy value:
+
+```shell
+identityProviderURL: "/candid",
+```
+
+You also need to configure your dashboard to work with a local controller:
 
 ```shell
 isJuju: true,

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     ]
   },
   "dependencies": {
-    "@canonical/jujulib": "6.0.0",
+    "@canonical/jujulib": "7.0.0",
     "@canonical/macaroon-bakery": "1.3.2",
     "@canonical/react-components": "0.52.0",
     "@reduxjs/toolkit": "2.2.4",

--- a/src/juju/jimm/JIMMV3.ts
+++ b/src/juju/jimm/JIMMV3.ts
@@ -74,7 +74,7 @@ class JIMMV3 {
       const req = {
         type: "JIMM",
         request: "DisableControllerUUIDMasking",
-        version: 3,
+        version: this.version,
         params: {},
       };
       this._transport.write(req, resolve, reject);
@@ -86,7 +86,7 @@ class JIMMV3 {
       const req = {
         type: "JIMM",
         request: "FindAuditEvents",
-        version: 3,
+        version: this.version,
         params: params,
       };
       this._transport.write(req, resolve, reject);
@@ -98,7 +98,7 @@ class JIMMV3 {
       const req = {
         type: "JIMM",
         request: "ListControllers",
-        version: 3,
+        version: this.version,
         params: {},
       };
       this._transport.write(req, resolve, reject);

--- a/src/juju/jimm/JIMMV4.test.ts
+++ b/src/juju/jimm/JIMMV4.test.ts
@@ -51,4 +51,49 @@ describe("JIMMV4", () => {
       expect.any(Function),
     );
   });
+
+  it("disableControllerUUIDMasking", async () => {
+    const jimm = new JIMMV4(transport, connectionInfo);
+    void jimm.disableControllerUUIDMasking();
+    expect(transport.write).toHaveBeenCalledWith(
+      {
+        type: "JIMM",
+        request: "DisableControllerUUIDMasking",
+        version: 4,
+        params: {},
+      },
+      expect.any(Function),
+      expect.any(Function),
+    );
+  });
+
+  it("findAuditEvents", async () => {
+    const jimm = new JIMMV4(transport, connectionInfo);
+    void jimm.findAuditEvents({ "user-tag": "user-eggman@external" });
+    expect(transport.write).toHaveBeenCalledWith(
+      {
+        type: "JIMM",
+        request: "FindAuditEvents",
+        version: 4,
+        params: { "user-tag": "user-eggman@external" },
+      },
+      expect.any(Function),
+      expect.any(Function),
+    );
+  });
+
+  it("listControllers", async () => {
+    const jimm = new JIMMV4(transport, connectionInfo);
+    void jimm.listControllers();
+    expect(transport.write).toHaveBeenCalledWith(
+      {
+        type: "JIMM",
+        request: "ListControllers",
+        version: 4,
+        params: {},
+      },
+      expect.any(Function),
+      expect.any(Function),
+    );
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -625,15 +625,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@canonical/jujulib@npm:6.0.0":
-  version: 6.0.0
-  resolution: "@canonical/jujulib@npm:6.0.0"
+"@canonical/jujulib@npm:7.0.0":
+  version: 7.0.0
+  resolution: "@canonical/jujulib@npm:7.0.0"
   dependencies:
     "@canonical/macaroon-bakery": "npm:1.3.2"
     btoa: "npm:1.2.1"
     websocket: "npm:1.0.34"
     xhr2: "npm:0.2.1"
-  checksum: 10c0/3d25504d136fc5e103e3547b252b7ac51ce1df4b9d9afac3b1c2df7233fad1903e2b46b82e6d2a02d730d6ef4f195e82f5581140aacc06dc287450951e9f129a
+  checksum: 10c0/1ddfb5338ea6b4446ce3dd64b39a1d53bd5a736035f2478193879510c623f76faa225e6971b759ad5c9dc7e1412dc5f74aea0b16ef2a03869d1a48a4198c644d
   languageName: node
   linkType: hard
 
@@ -7513,7 +7513,7 @@ __metadata:
   resolution: "juju-dashboard@workspace:."
   dependencies:
     "@babel/plugin-proposal-private-property-in-object": "npm:7.21.11"
-    "@canonical/jujulib": "npm:6.0.0"
+    "@canonical/jujulib": "npm:7.0.0"
     "@canonical/macaroon-bakery": "npm:1.3.2"
     "@canonical/react-components": "npm:0.52.0"
     "@reduxjs/toolkit": "npm:2.2.4"


### PR DESCRIPTION
Note: this will fail CI until https://github.com/juju/js-libjuju/pull/127 is released which needs to be QAed along with this PR.

## Done

- Log in to controllers and models using OIDC.

## QA

- Inside the Multipass running the dashboard and JIMM with OIDC, checkout out this branch: https://github.com/juju/js-libjuju/pull/127.
- `yarn install` and `yarn build` inside the jujulib dir.
- Go to the dashboard dir and `yarn link` to the jujulib dir you just checked out.
- Start the dashboard and visit it in your browser.
- Log in (if you're not already logged in) and the dashboard should load and display your models and controllers.
- Now configure your dashboard to point to a local controller using local (username/password) users (or check this branch out somewhere that has access to a local controller - you'll need to link to the jujulib branch again) and check you're able to log in and view models/controllers.
- Finally, configure your dashboard to point to a local controller (or again check this and the jujulib branches out somewhere that has access to a local controller) using [Candid](https://github.com/canonical/juju-dashboard/blob/main/HACKING.md#juju-controller-with-candid) and check you're able to log in and view models/controllers.

## Details

https://warthogs.atlassian.net/browse/WD-11707
