### PR TITLE
WD-12178 - fix: handle 500 errors for the whoami endpoint

### DIFF
--- a/src/store/middleware/model-poller.test.ts
+++ b/src/store/middleware/model-poller.test.ts
@@ -24,7 +24,6 @@ import {
   ModelsError,
   modelPollerMiddleware,
 } from "./model-poller";
-import { unwrapResult } from "@reduxjs/toolkit";
 
 vi.mock("juju/api", () => ({
   disableControllerUUIDMasking: vi

--- a/src/store/middleware/model-poller.test.ts
+++ b/src/store/middleware/model-poller.test.ts
@@ -24,6 +24,7 @@ import {
   ModelsError,
   modelPollerMiddleware,
 } from "./model-poller";
+import { unwrapResult } from "@reduxjs/toolkit";
 
 vi.mock("juju/api", () => ({
   disableControllerUUIDMasking: vi
@@ -227,6 +228,35 @@ describe("model poller", () => {
       }),
     );
     expect(loginWithBakerySpy).toHaveBeenCalled();
+  });
+
+  it("handles whoami errors when logging in with OIDC", async () => {
+    vi.spyOn(fakeStore, "getState").mockReturnValue(storeState);
+    vi.spyOn(fakeStore, "dispatch").mockImplementation((action) => {
+      if (typeof action === "function") {
+        // This is a thunk so the action name is not accessible, so this just
+        // throws on the first thunk that is dispatched. If this test is
+        // failing then check if another thunk is being dispatched before the
+        // whoami() thunk.
+        throw new Error();
+      }
+      return { type: "not-whoami" };
+    });
+    const loginWithBakerySpy = vi.spyOn(jujuModule, "loginWithBakery");
+    await runMiddleware(
+      appActions.connectAndPollControllers({
+        controllers: [[wsControllerURL, undefined, AuthMethod.OIDC]],
+        isJuju: true,
+        poll: 0,
+      }),
+    );
+    expect(loginWithBakerySpy).not.toHaveBeenCalled();
+    expect(fakeStore.dispatch).toHaveBeenCalledWith(
+      generalActions.storeLoginError({
+        wsControllerURL: "wss://example.com",
+        error: LoginError.WHOAMI,
+      }),
+    );
   });
 
   it("fetches and stores data", async () => {


### PR DESCRIPTION
## Done

- Handle 500 errors when checking if the user is authenticated.

## QA

- Log in using OIDC.
- Using your browser's dev tools find the `jimm-browser-session` cookie and change the value to anything.
- Reload the dashboard.
- It should display the "Unable to check authentication status." error.

## Details

https://warthogs.atlassian.net/browse/WD-12178
https://warthogs.atlassian.net/browse/WD-12176