### PR TITLE
WD-11708 - feat: log out using OIDC

### DIFF
--- a/src/store/app/thunks.test.ts
+++ b/src/store/app/thunks.test.ts
@@ -16,7 +16,7 @@ import {
   jujuStateFactory,
 } from "testing/factories/juju/juju";
 
-import { logOut, connectAndStartPolling } from "./thunks";
+import { logOut, connectAndStartPolling, Label } from "./thunks";
 
 describe("thunks", () => {
   const consoleError = console.error;
@@ -24,6 +24,7 @@ describe("thunks", () => {
 
   beforeEach(() => {
     console.error = vi.fn();
+    fetchMock.resetMocks();
     state = rootStateFactory.build({
       general: generalStateFactory.build({
         config: configFactory.build({
@@ -83,6 +84,62 @@ describe("thunks", () => {
       null,
     );
     expect(dispatchedThunk.type).toBe("app/connectAndStartPolling/fulfilled");
+  });
+
+  it("logOut from OIDC", async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({}), { status: 200 });
+    const action = logOut();
+    const dispatch = vi.fn();
+    const getState = vi.fn(() =>
+      rootStateFactory.build({
+        general: generalStateFactory.build({
+          config: configFactory.build({
+            authMethod: AuthMethod.OIDC,
+          }),
+        }),
+      }),
+    );
+    await action(dispatch, getState, null);
+    expect(dispatch).toHaveBeenCalledWith(jujuActions.clearModelData());
+    expect(dispatch).toHaveBeenCalledWith(jujuActions.clearControllerData());
+    expect(dispatch).toHaveBeenCalledWith(generalActions.logOut());
+    const dispatchedThunk = await dispatch.mock.calls[4][0](
+      dispatch,
+      getState,
+      null,
+    );
+    expect(dispatchedThunk.type).toBe("jimm/logout/fulfilled");
+  });
+
+  it("handles OIDC log out errors", async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({}), { status: 400 });
+    const action = logOut();
+    const dispatch = vi.fn().mockImplementation((action) => {
+      if (typeof action === "function") {
+        // This is a thunk so the action name is not accessible, so this just
+        // throws on the first thunk that is dispatched. If this test is
+        // failing then check if another thunk is being dispatched before the
+        // logout() thunk.
+        return { type: "jimm/logout/rejected", error: "Uh oh" };
+      }
+      return action;
+    });
+    const getState = vi.fn(() =>
+      rootStateFactory.build({
+        general: generalStateFactory.build({
+          config: configFactory.build({
+            authMethod: AuthMethod.OIDC,
+          }),
+        }),
+      }),
+    );
+    await action(dispatch, getState, null);
+    expect(dispatch).toHaveBeenCalledWith(jujuActions.clearModelData());
+    expect(dispatch).toHaveBeenCalledWith(jujuActions.clearControllerData());
+    expect(dispatch).toHaveBeenCalledWith(generalActions.logOut());
+    expect(dispatch).toHaveBeenCalledWith(
+      generalActions.storeConnectionError(Label.OIDC_LOGOUT_ERROR),
+    );
   });
 
   it("connectAndStartPolling", async () => {

--- a/src/store/app/thunks.ts
+++ b/src/store/app/thunks.ts
@@ -1,6 +1,7 @@
 import { createAsyncThunk } from "@reduxjs/toolkit";
 
 import bakery from "juju/bakery";
+import { logout } from "juju/jimm/thunks";
 import { actions as appActions } from "store/app";
 import { actions as generalActions } from "store/general";
 import {
@@ -15,6 +16,10 @@ import { actions as jujuActions } from "store/juju";
 import type { RootState } from "store/store";
 
 import type { ControllerArgs } from "./actions";
+
+export enum Label {
+  OIDC_LOGOUT_ERROR = "Unable to log out.",
+}
 
 export const logOut = createAsyncThunk<
   void,
@@ -38,6 +43,13 @@ export const logOut = createAsyncThunk<
     // to the controller to get another wait url and start polling on it
     // again.
     await thunkAPI.dispatch(connectAndStartPolling());
+  } else if (authMethod === AuthMethod.OIDC) {
+    const response = await thunkAPI.dispatch(logout());
+    if ("error" in response) {
+      thunkAPI.dispatch(
+        generalActions.storeConnectionError(Label.OIDC_LOGOUT_ERROR),
+      );
+    }
   }
 });
 


### PR DESCRIPTION
## Done

- Log out when using OIDC

## QA

- Log in using OIDC.
- Open the user menu (bottom of the left nav panel).
- Click "Log out".
- Refresh the dashboard and you should see the login button.
- Log in again.
- Using your browser's dev tools find the jimm-browser-session cookie and change the value to anything.
- Open the user menu and click "Log out".
- You should see an error.
Note: the reason this logout error takes over the entire screen is because at the point this error is returned by the API the dashboard has already disconnected from the websocket connections and cleared all the data for models, controllers etc. so we don't have anything to display.


## Details

https://warthogs.atlassian.net/browse/WD-11708
