### PR TITLE
WD-12291 - fix: remove error notification when there are 0 models

### DIFF
--- a/src/juju/api.ts
+++ b/src/juju/api.ts
@@ -406,9 +406,9 @@ export async function fetchAllModelStatuses(
   });
   return new Promise<void>((resolve, reject) => {
     queue.onDone(() => {
-      // If errors appear in more than 10% of models, the promise should be
+      // If errors exist and appear in more than 10% of models, the promise is
       // rejected and the error further handled in modelPollerMiddleware().
-      modelErrorCount >= 0.1 * modelUUIDList.length
+      modelErrorCount && modelErrorCount >= 0.1 * modelUUIDList.length
         ? reject(
             new Error(
               modelErrorCount === modelUUIDList.length


### PR DESCRIPTION
## Done

- Removed error notification when there are 0 models and fetch models is successful.

## Details

- Fixes: https://github.com/canonical/juju-dashboard/issues/1780
- https://warthogs.atlassian.net/browse/WD-12291

## Screenshots

Before:
![Screenshot from 2024-06-18 16-02-10](https://github.com/canonical/juju-dashboard/assets/108150922/13497761-f0e9-4f84-9167-c6c938f022d3)

After:
![Screenshot from 2024-06-18 20-20-32](https://github.com/canonical/juju-dashboard/assets/108150922/0c41db24-b268-4190-9bcc-8a75b22ddae8)

