### PR TITLE
WD-12713 - feat: handle oidc refresh and revoke

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -63,6 +63,7 @@
     "default-case": 0,
     "no-param-reassign": 0,
     "no-case-declarations": 0,
+    "no-constant-condition": ["error", { "checkLoops": false }],
     "prefer-destructuring": 0,
     "react/no-unescaped-entities": 0,
     "react/display-name": 0,

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -2,3 +2,8 @@ export const DARK_THEME = true;
 
 // The date format used in datetime-local fields.
 export const DATETIME_LOCAL = "yyyy-MM-dd'T'HH:mm";
+
+// The interval at which the OIDC whoami endpoint is polled at (in milliseconds).
+// This is set to 5 minutes as that is how long a token is valid for in JIMM, so
+// if access is revoked this will poll and delete the cookie.
+export const OIDC_POLL_INTERVAL = 5 * 60 * 1000;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,7 @@ import { createRoot } from "react-dom/client";
 import { Provider } from "react-redux";
 
 import App from "components/App";
+import { addWhoamiListener } from "juju/jimm/listeners";
 import reduxStore from "store";
 import { thunks as appThunks } from "store/app";
 import { actions as generalActions } from "store/general";
@@ -14,6 +15,8 @@ import { AuthMethod } from "store/general/types";
 import type { WindowConfig } from "types";
 
 import packageJSON from "../package.json";
+
+import { listenerMiddleware } from "./store/listenerMiddleware";
 
 export const ROOT_ID = "root";
 export const RECHECK_TIME = 500;
@@ -146,8 +149,12 @@ function bootstrap() {
   reduxStore.dispatch(generalActions.storeConfig(config));
   reduxStore.dispatch(generalActions.storeVersion(appVersion));
 
+  if (config.authMethod === AuthMethod.OIDC) {
+    addWhoamiListener(listenerMiddleware.startListening);
+  }
+
   if ([AuthMethod.CANDID, AuthMethod.OIDC].includes(config.authMethod)) {
-    // If using Candid authentication then try and connect automatically
+    // If using Candid or OIDC authentication then try and connect automatically
     // If not then wait for the login UI to trigger this
     reduxStore
       .dispatch(appThunks.connectAndStartPolling())

--- a/src/juju/jimm/listeners.test.ts
+++ b/src/juju/jimm/listeners.test.ts
@@ -1,0 +1,149 @@
+import type {
+  ListenerMiddlewareInstance,
+  UnknownAction,
+  EnhancedStore,
+  StoreEnhancer,
+  Tuple,
+} from "@reduxjs/toolkit";
+import {
+  createListenerMiddleware,
+  configureStore,
+  createSlice,
+} from "@reduxjs/toolkit";
+import { waitFor } from "@testing-library/react";
+import { vi } from "vitest";
+
+import { thunks as appThunks } from "store/app";
+import { actions as generalActions } from "store/general";
+import type { RootState, AppDispatch } from "store/store";
+import { rootStateFactory } from "testing/factories";
+
+import { endpoints } from "./api";
+import {
+  addWhoamiListener,
+  pollWhoamiStart,
+  Label,
+  pollWhoamiStop,
+} from "./listeners";
+
+vi.mock("consts", () => {
+  return { OIDC_POLL_INTERVAL: 1 };
+});
+
+vi.mock("store/general", async () => {
+  const actual = await vi.importActual("store/general");
+  return {
+    ...actual,
+    actions: {
+      storeLoginError: vi.fn(),
+    },
+  };
+});
+
+vi.mock("store/app/thunks", async () => {
+  const actual = await vi.importActual("store/app/thunks");
+  return {
+    ...actual,
+    logOut: vi.fn(),
+  };
+});
+
+describe("listeners", () => {
+  let listenerMiddleware: ListenerMiddlewareInstance<
+    RootState,
+    AppDispatch,
+    unknown
+  >;
+  let store: EnhancedStore<
+    RootState,
+    UnknownAction,
+    Tuple<
+      [
+        StoreEnhancer<{
+          dispatch: AppDispatch;
+        }>,
+        StoreEnhancer,
+      ]
+    >
+  >;
+
+  beforeEach(() => {
+    fetchMock.resetMocks();
+    listenerMiddleware = createListenerMiddleware<RootState, AppDispatch>();
+    const slice = createSlice({
+      name: "root",
+      initialState: rootStateFactory.withGeneralConfig().build(),
+      reducers: {},
+    });
+    store = configureStore({
+      reducer: slice.reducer,
+      middleware: (getDefaultMiddleware) => {
+        const middleware = getDefaultMiddleware();
+        middleware.push(listenerMiddleware.middleware);
+        return middleware;
+      },
+    });
+    addWhoamiListener(listenerMiddleware.startListening);
+  });
+
+  afterEach(() => {
+    listenerMiddleware.clearListeners();
+  });
+
+  it("starts polling when start action is dispatched", async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({}), { status: 200 });
+    expect(global.fetch).not.toHaveBeenCalled();
+    store.dispatch(pollWhoamiStart());
+    await waitFor(() =>
+      expect(global.fetch).toHaveBeenCalledWith(endpoints.whoami),
+    );
+  });
+
+  it("handles user logged out", async () => {
+    vi.spyOn(store, "dispatch");
+    vi.spyOn(generalActions, "storeLoginError").mockReturnValue({
+      type: "general/storeLoginError",
+      payload: { wsControllerURL: "", error: "" },
+    });
+    fetchMock.mockResponseOnce(JSON.stringify({}), { status: 401 });
+    store.dispatch(pollWhoamiStart());
+    await waitFor(() =>
+      expect(generalActions.storeLoginError).toHaveBeenCalledWith({
+        error: Label.ERROR_LOGGED_OUT,
+        wsControllerURL: "wss://controller.example.com",
+      }),
+    );
+    await waitFor(() => expect(appThunks.logOut).toHaveBeenCalled());
+  });
+
+  it("handles errors", async () => {
+    vi.spyOn(store, "dispatch");
+    vi.spyOn(generalActions, "storeLoginError").mockReturnValue({
+      type: "general/storeLoginError",
+      payload: { wsControllerURL: "", error: "" },
+    });
+    fetchMock.mockResponseOnce(JSON.stringify({}), { status: 500 });
+    store.dispatch(pollWhoamiStart());
+    await waitFor(() =>
+      expect(generalActions.storeLoginError).toHaveBeenCalledWith({
+        error: Label.ERROR_AUTHENTICATION,
+        wsControllerURL: "wss://controller.example.com",
+      }),
+    );
+    await waitFor(() => expect(appThunks.logOut).toHaveBeenCalled());
+  });
+
+  it("does not display an error when stopping the listener", async () => {
+    vi.spyOn(store, "dispatch");
+    vi.spyOn(generalActions, "storeLoginError").mockReturnValue({
+      type: "general/storeLoginError",
+      payload: { wsControllerURL: "", error: "" },
+    });
+    fetchMock.mockResponseOnce(JSON.stringify({}), { status: 500 });
+    store.dispatch(pollWhoamiStart());
+    store.dispatch(pollWhoamiStop());
+    await waitFor(() =>
+      expect(generalActions.storeLoginError).not.toHaveBeenCalled(),
+    );
+  });
+});

--- a/src/juju/jimm/listeners.ts
+++ b/src/juju/jimm/listeners.ts
@@ -1,0 +1,69 @@
+import type { ListenerMiddlewareInstance } from "@reduxjs/toolkit";
+import { createAction, TaskAbortError } from "@reduxjs/toolkit";
+
+import { OIDC_POLL_INTERVAL } from "consts";
+import { thunks as appThunks } from "store/app";
+import { actions as generalActions } from "store/general";
+import { getWSControllerURL } from "store/general/selectors";
+import type { RootState, AppDispatch } from "store/store";
+import { toErrorString } from "utils";
+
+import { endpoints } from "./api";
+
+export enum Label {
+  ERROR_AUTHENTICATION = "Authentication error.",
+  ERROR_LOGGED_OUT = "You have been logged out.",
+}
+
+export const pollWhoamiStart = createAction("jimm/pollWhoami/start");
+export const pollWhoamiStop = createAction("jimm/pollWhoami/stop");
+
+export const addWhoamiListener = (
+  startListening: ListenerMiddlewareInstance<
+    RootState,
+    AppDispatch,
+    unknown
+  >["startListening"],
+) => {
+  startListening({
+    actionCreator: pollWhoamiStart,
+    effect: async (_action, listenerApi) => {
+      listenerApi.unsubscribe();
+      const pollingTask = listenerApi.fork(async (forkApi) => {
+        try {
+          while (true) {
+            await forkApi.delay(OIDC_POLL_INTERVAL);
+            const response = await forkApi.pause(fetch(endpoints.whoami));
+            // Handle the user no longer logged in:
+            if (response.status === 401 || response.status === 403) {
+              throw new Error(Label.ERROR_LOGGED_OUT);
+            }
+            // Handle all other API errors:
+            if (!response.ok) {
+              throw new Error(Label.ERROR_AUTHENTICATION);
+            }
+          }
+        } catch (error) {
+          if (error instanceof TaskAbortError) {
+            // Polling was aborted e.g. when clicking "log out". Don't display
+            // this to the user.
+            return;
+          }
+          const wsControllerURL = getWSControllerURL(listenerApi.getState());
+          if (wsControllerURL) {
+            listenerApi.dispatch(
+              generalActions.storeLoginError({
+                error: toErrorString(error),
+                wsControllerURL,
+              }),
+            );
+          }
+          // If the user no longer has access then clean up state and display the login screen.
+          await listenerApi.dispatch(appThunks.logOut());
+        }
+      });
+      await listenerApi.condition(pollWhoamiStop.match);
+      pollingTask.cancel();
+    },
+  });
+};

--- a/src/juju/jimm/thunks.test.ts
+++ b/src/juju/jimm/thunks.test.ts
@@ -47,6 +47,14 @@ describe("thunks", () => {
     expect(unwrapResult(response)).toBeNull();
   });
 
+  it("whoami handles non-authenticated user", async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({}), { status: 401 });
+    const action = whoami();
+    const response = await action(vi.fn(), vi.fn(), null);
+    expect(global.fetch).toHaveBeenCalledWith(endpoints.whoami);
+    expect(unwrapResult(response)).toBeNull();
+  });
+
   it("whoami unsuccessful requests", async () => {
     fetchMock.mockResponse(JSON.stringify({}), { status: 500 });
     const action = whoami();

--- a/src/juju/jimm/thunks.ts
+++ b/src/juju/jimm/thunks.ts
@@ -38,7 +38,7 @@ export const whoami = createAsyncThunk<
 >("jimm/whoami", async () => {
   try {
     const response = await fetch(endpoints.whoami);
-    if (response.status === 403) {
+    if (response.status === 401 || response.status === 403) {
       // The user is not authenticated so return null instead of throwing an error.
       return null;
     }

--- a/src/pages/EntityDetails/EntityDetails.test.tsx
+++ b/src/pages/EntityDetails/EntityDetails.test.tsx
@@ -218,6 +218,9 @@ describe("Entity Details Container", () => {
   });
 
   it("shows the CLI in juju 2.9", async () => {
+    state.general.config = configFactory.build({
+      isJuju: true,
+    });
     renderComponent(<EntityDetails />, { path, url, state });
     await waitFor(() => {
       expect(screen.queryByTestId("webcli")).toBeInTheDocument();
@@ -225,6 +228,9 @@ describe("Entity Details Container", () => {
   });
 
   it("shows the CLI in juju higher than 2.9", async () => {
+    state.general.config = configFactory.build({
+      isJuju: true,
+    });
     state.juju.modelWatcherData = {
       abc123: modelWatcherModelDataFactory.build({
         applications: {
@@ -244,7 +250,33 @@ describe("Entity Details Container", () => {
     });
   });
 
+  it("does not show the CLI in JAAS", async () => {
+    state.general.config = configFactory.build({
+      isJuju: false,
+    });
+    state.juju.modelWatcherData = {
+      abc123: modelWatcherModelDataFactory.build({
+        applications: {
+          "ceph-mon": applicationInfoFactory.build(),
+        },
+        model: modelWatcherModelInfoFactory.build({
+          name: "enterprise",
+          owner: "kirk@external",
+          version: "3.0.7",
+          "controller-uuid": "controller123",
+        }),
+      }),
+    };
+    renderComponent(<EntityDetails />, { path, url, state });
+    await waitFor(() => {
+      expect(screen.queryByTestId("webcli")).not.toBeInTheDocument();
+    });
+  });
+
   it("does not show the webCLI in juju 2.8", async () => {
+    state.general.config = configFactory.build({
+      isJuju: true,
+    });
     state.juju.modelWatcherData = {
       abc123: modelWatcherModelDataFactory.build({
         applications: {
@@ -264,6 +296,9 @@ describe("Entity Details Container", () => {
   });
 
   it("passes the controller details to the webCLI", () => {
+    state.general.config = configFactory.build({
+      isJuju: true,
+    });
     const cliComponent = vi
       .spyOn(WebCLIModule, "default")
       .mockImplementation(vi.fn());

--- a/src/pages/EntityDetails/EntityDetails.tsx
+++ b/src/pages/EntityDetails/EntityDetails.tsx
@@ -99,14 +99,14 @@ const EntityDetails = ({ modelWatcherError }: Props) => {
   };
 
   useEffect(() => {
-    if (getMajorMinorVersion(modelInfo?.version) >= 2.9) {
+    if (isJuju && getMajorMinorVersion(modelInfo?.version) >= 2.9) {
       // The Web CLI is only available in Juju controller versions 2.9 and
       // above. This will allow us to only show the shell on multi-controller
       // setups with different versions where the correct controller version
       // is available.
       setShowWebCLI(true);
     }
-  }, [modelInfo]);
+  }, [modelInfo, isJuju]);
 
   useWindowTitle(modelInfo?.name ? `Model: ${modelInfo?.name}` : "...");
 

--- a/src/store/app/thunks.ts
+++ b/src/store/app/thunks.ts
@@ -1,6 +1,7 @@
 import { createAsyncThunk } from "@reduxjs/toolkit";
 
 import bakery from "juju/bakery";
+import { pollWhoamiStop } from "juju/jimm/listeners";
 import { logout } from "juju/jimm/thunks";
 import { actions as appActions } from "store/app";
 import { actions as generalActions } from "store/general";
@@ -16,10 +17,6 @@ import { actions as jujuActions } from "store/juju";
 import type { RootState } from "store/store";
 
 import type { ControllerArgs } from "./actions";
-
-export enum Label {
-  OIDC_LOGOUT_ERROR = "Unable to log out.",
-}
 
 export const logOut = createAsyncThunk<
   void,
@@ -44,12 +41,8 @@ export const logOut = createAsyncThunk<
     // again.
     await thunkAPI.dispatch(connectAndStartPolling());
   } else if (authMethod === AuthMethod.OIDC) {
-    const response = await thunkAPI.dispatch(logout());
-    if ("error" in response) {
-      thunkAPI.dispatch(
-        generalActions.storeConnectionError(Label.OIDC_LOGOUT_ERROR),
-      );
-    }
+    thunkAPI.dispatch(pollWhoamiStop());
+    await thunkAPI.dispatch(logout());
   }
 });
 
@@ -82,7 +75,6 @@ export const connectAndStartPolling = createAsyncThunk<
       // remove controllers we're already connected to.
       return !connectedControllers.includes(controllerData[0]);
     });
-
     thunkAPI.dispatch(
       appActions.connectAndPollControllers({
         controllers: controllerList,

--- a/src/store/listenerMiddleware.ts
+++ b/src/store/listenerMiddleware.ts
@@ -1,0 +1,8 @@
+import { createListenerMiddleware } from "@reduxjs/toolkit";
+
+import type { AppDispatch, RootState } from "store/store";
+
+export const listenerMiddleware = createListenerMiddleware<
+  RootState,
+  AppDispatch
+>();

--- a/src/store/middleware/check-auth.ts
+++ b/src/store/middleware/check-auth.ts
@@ -5,6 +5,7 @@
 
 import { isAction, type Middleware } from "redux";
 
+import * as jimmListeners from "juju/jimm/listeners";
 import * as jimmThunks from "juju/jimm/thunks";
 import { actions as appActions, thunks as appThunks } from "store/app";
 import { actions as generalActions } from "store/general";
@@ -72,6 +73,8 @@ export const checkAuthMiddleware: Middleware<
       generalActions.storeVisitURL.type,
       generalActions.updateControllerConnection.type,
       generalActions.updatePingerIntervalId.type,
+      jimmListeners.pollWhoamiStart.type,
+      jimmListeners.pollWhoamiStop.type,
       jujuActions.populateMissingAllWatcherData.type,
       jujuActions.processAllWatcherDeltas.type,
       jujuActions.updateAuditEvents.type,

--- a/src/store/middleware/model-poller.test.ts
+++ b/src/store/middleware/model-poller.test.ts
@@ -5,6 +5,7 @@ import { vi } from "vitest";
 
 import * as jujuModule from "juju/api";
 import type { RelationshipTuple } from "juju/jimm/JIMMV4";
+import { pollWhoamiStart } from "juju/jimm/listeners";
 import { actions as appActions, thunks as appThunks } from "store/app";
 import type { ControllerArgs } from "store/app/actions";
 import { actions as generalActions } from "store/general";
@@ -226,6 +227,7 @@ describe("model poller", () => {
         poll: 0,
       }),
     );
+    expect(fakeStore.dispatch).toHaveBeenCalledWith(pollWhoamiStart());
     expect(loginWithBakerySpy).toHaveBeenCalled();
   });
 

--- a/src/store/middleware/model-poller.ts
+++ b/src/store/middleware/model-poller.ts
@@ -13,6 +13,7 @@ import {
   setModelSharingPermissions,
 } from "juju/api";
 import { JIMMRelation } from "juju/jimm/JIMMV4";
+import { pollWhoamiStart } from "juju/jimm/listeners";
 import { whoami } from "juju/jimm/thunks";
 import type { ConnectionWithFacades } from "juju/types";
 import { actions as appActions, thunks as appThunks } from "store/app";
@@ -84,7 +85,11 @@ export const modelPollerMiddleware: Middleware<
           try {
             const whoamiResponse = await reduxStore.dispatch(whoami());
             const user = unwrapResult(whoamiResponse);
-            if (!user) {
+            if (user) {
+              // Start polling the whoami endpoint to handle refresh tokens
+              // and revoked sessions.
+              reduxStore.dispatch(pollWhoamiStart());
+            } else {
               // If there's no response that means the user is not
               // authenticated, so halt the connection attempt.
               return;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -10,6 +10,8 @@ import checkAuth from "store/middleware/check-auth";
 import { modelPollerMiddleware } from "store/middleware/model-poller";
 import uiReducer from "store/ui";
 
+import { listenerMiddleware } from "./listenerMiddleware";
+
 let preloadedState: Record<string, unknown> | undefined;
 if (!import.meta.env.PROD && process.env.VITE_APP_MOCK_STORE) {
   try {
@@ -28,6 +30,7 @@ const store = configureStore({
     const middleware = getDefaultMiddleware();
     // The checkAuth middleware must be first.
     middleware.unshift(checkAuth);
+    middleware.push(listenerMiddleware.middleware);
     middleware.push(modelPollerMiddleware);
     return middleware;
   },


### PR DESCRIPTION
## Done

- Poll the whoami endpoint to handle refreshing and revoking tokens.
- Log out if the user is no longer authenticated.

## QA

- Set up an OIDC enabled JIMM with the session max age to something short e.g. 30 seconds by changing `JIMM_SESSION_COOKIE_MAX_AGE: 30` in `docker-compose.yaml` before you set up the env.
- In the dashboard open `src/consts.ts`.
- Set the poll interval to less than the max age above e.g. `export const OIDC_POLL_INTERVAL = 20 * 1000;`.
- Run the dashboard.
- Log in.
- Using the network tab you should see that the whoami endpoint is pinged at the interval you set above.
- Inside the container running JIMM run the following commands to revoke the token (but don't stop the running environment or your dashboard you want this to keep pinging the API):
```
docker exec -it postgres bash
psql -U jimm -d jimm
DELETE FROM http_sessions;
```
- Next time the dashboard polls it should return you to the login screen with a message about being logged out.

## Details

https://warthogs.atlassian.net/browse/WD-12713
