### PR TITLE
WD-15784 - fix: fix issues observed in k8s charm

### DIFF
--- a/src/components/EntityInfo/EntityInfo.test.tsx
+++ b/src/components/EntityInfo/EntityInfo.test.tsx
@@ -25,6 +25,7 @@ describe("Entity info", () => {
         url: "/models/user-eggman@external/group-test",
       },
     );
-    expect(screen.getByText("eu1")).toHaveAttribute("data-name", "region");
+    expect(screen.getByText("region")).toBeInTheDocument();
+    expect(screen.getByText("eu1")).toBeInTheDocument();
   });
 });

--- a/src/components/EntityInfo/EntityInfo.test.tsx
+++ b/src/components/EntityInfo/EntityInfo.test.tsx
@@ -16,7 +16,7 @@ describe("Entity info", () => {
       <EntityInfo
         data={{
           name: "model1",
-          controller: "controller1",
+          controller: <span>controller1</span>,
           region: "eu1",
         }}
       />,
@@ -25,7 +25,8 @@ describe("Entity info", () => {
         url: "/models/user-eggman@external/group-test",
       },
     );
-    expect(screen.getByText("region")).toBeInTheDocument();
-    expect(screen.getByText("eu1")).toBeInTheDocument();
+    expect(screen.getByText("model1")).toHaveClass("u-truncate");
+    expect(screen.getByText("controller1")).not.toHaveClass("u-truncate");
+    expect(screen.getByText("eu1")).toHaveClass("u-truncate");
   });
 });

--- a/src/components/EntityInfo/EntityInfo.tsx
+++ b/src/components/EntityInfo/EntityInfo.tsx
@@ -15,7 +15,13 @@ export default function EntityInfo({ data }: Props): JSX.Element {
         return (
           <div className="entity-info__grid-item" key={label}>
             <h4 className="p-muted-heading">{label}</h4>
-            <TruncatedTooltip message={value}>{value}</TruncatedTooltip>
+            {typeof value === "string" || typeof value === "number" ? (
+              <TruncatedTooltip message={value} element="p">
+                {value}
+              </TruncatedTooltip>
+            ) : (
+              <p>{value}</p>
+            )}
           </div>
         );
       })}

--- a/src/components/EntityInfo/EntityInfo.tsx
+++ b/src/components/EntityInfo/EntityInfo.tsx
@@ -1,5 +1,7 @@
 import type { ReactNode } from "react";
 
+import TruncatedTooltip from "components/TruncatedTooltip";
+
 import "./_entity-info.scss";
 
 type Props = {
@@ -13,7 +15,7 @@ export default function EntityInfo({ data }: Props): JSX.Element {
         return (
           <div className="entity-info__grid-item" key={label}>
             <h4 className="p-muted-heading">{label}</h4>
-            <p data-name={label}>{value}</p>
+            <TruncatedTooltip message={value}>{value}</TruncatedTooltip>
           </div>
         );
       })}

--- a/src/components/EntityInfo/_entity-info.scss
+++ b/src/components/EntityInfo/_entity-info.scss
@@ -7,7 +7,9 @@
     }
 
     &-item {
+      min-width: 0;
       overflow-wrap: anywhere;
+      width: 100%;
 
       .p-muted-heading {
         font-size: 0.75rem;

--- a/src/components/EntityInfo/_entity-info.scss
+++ b/src/components/EntityInfo/_entity-info.scss
@@ -2,10 +2,6 @@
   &__grid {
     display: grid;
 
-    @media (width >= 1580px) {
-      grid-template-columns: repeat(2, 1fr);
-    }
-
     &-item {
       min-width: 0;
       overflow-wrap: anywhere;

--- a/src/components/TruncatedTooltip/TruncatedTooltip.test.tsx
+++ b/src/components/TruncatedTooltip/TruncatedTooltip.test.tsx
@@ -71,4 +71,26 @@ describe("TruncatedTooltip", () => {
     });
     expect(screen.getByTestId("tooltip-portal")).not.toHaveClass("u-hide");
   });
+
+  it("should render an inner div by default", () => {
+    const content = "Some content";
+    render(
+      <TruncatedTooltip message="Tooltip content">{content}</TruncatedTooltip>,
+    );
+    const innerElement = screen.getByText(content);
+    expect(innerElement.tagName.toLowerCase()).toBe("div");
+    expect(innerElement).toHaveClass("u-truncate");
+  });
+
+  it("should render an inner custom element type", () => {
+    const content = "Some content";
+    render(
+      <TruncatedTooltip message="Tooltip content" element="button">
+        {content}
+      </TruncatedTooltip>,
+    );
+    expect(screen.getByRole("button", { name: content })).toHaveClass(
+      "u-truncate",
+    );
+  });
 });

--- a/src/components/TruncatedTooltip/TruncatedTooltip.tsx
+++ b/src/components/TruncatedTooltip/TruncatedTooltip.tsx
@@ -1,7 +1,7 @@
 import type { TooltipProps } from "@canonical/react-components";
 import { Tooltip } from "@canonical/react-components";
 import classNames from "classnames";
-import type { PropsWithChildren } from "react";
+import type { ComponentType, ElementType, PropsWithChildren } from "react";
 import { useCallback, useEffect, useMemo, useState, useRef } from "react";
 
 import "./_truncated-tooltip.scss";
@@ -10,6 +10,7 @@ type Props = {
   tooltipClassName?: TooltipProps["tooltipClassName"];
   positionElementClassName?: TooltipProps["positionElementClassName"];
   wrapperClassName?: string;
+  element?: ElementType | ComponentType;
 } & TooltipProps &
   PropsWithChildren;
 
@@ -21,6 +22,7 @@ const TruncatedTooltip = ({
   positionElementClassName,
   tooltipClassName,
   wrapperClassName,
+  element: Component = "div",
   ...tooltipProps
 }: Props) => {
   const truncatedNode = useRef<HTMLDivElement>(null);
@@ -70,9 +72,9 @@ const TruncatedTooltip = ({
           "u-hide": !truncated,
         })}
       >
-        <div ref={truncatedNode} className="u-truncate">
+        <Component ref={truncatedNode} className="u-truncate">
           {children}
-        </div>
+        </Component>
       </Tooltip>
     </div>
   );

--- a/src/pages/AdvancedSearch/SearchForm/SearchHelp/SearchHelp.tsx
+++ b/src/pages/AdvancedSearch/SearchForm/SearchHelp/SearchHelp.tsx
@@ -41,7 +41,7 @@ const SearchHelp = ({ search }: Props): JSX.Element => {
           <li>
             Get all available models:{" "}
             <QueryLink
-              query={`. | select(."model-status".current=="available")`}
+              query={`. | select(.model."model-status".current=="available")`}
               handleQuery={handleQuery}
             />
           </li>


### PR DESCRIPTION
## Done

- Fixed the second JQ query example which was wrong beforehand.
- Fixed the model info that showed the model owner's name in the left hand side. It got wrapped a fair bit as the owner was a service account.

## Details

- https://warthogs.atlassian.net/browse/WD-15784

## Screenshots

- Screen width < 1580px:
![Screenshot from 2024-10-11 06-16-29](https://github.com/user-attachments/assets/7b496452-3b09-4b16-822a-ed13c05fa4e5)

- Screen width >= 1580px:
![Screenshot from 2024-10-11 06-16-13](https://github.com/user-attachments/assets/611f92b1-2f9d-46aa-8824-dc5bb9cf5afb)

