### PR TITLE
chore: update tics coverage frequency

### DIFF
--- a/.github/workflows/tics-coverage.yml
+++ b/.github/workflows/tics-coverage.yml
@@ -1,8 +1,7 @@
 name: Upload TICS report
 on:
-  push:
-    branches:
-      - main
+  schedule:
+    - cron: "0 22 * * 5"
 
 jobs:
   TICS:


### PR DESCRIPTION
## Done
From the request of the Tiobe team, reducing the number of submissions to once per week. Specifically, on Friday night at 10pm.

## QA
- Check back next week to see the job ran on Friday