### PR TITLE
WD-16020 - refactor: replace BrowserRouter with createBrowserRouter

### DIFF
--- a/src/components/App/App.test.tsx
+++ b/src/components/App/App.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import * as reactGA from "react-ga";
 import { Provider } from "react-redux";
-import * as reactRouterDOM from "react-router-dom";
 import configureStore from "redux-mock-store";
 import { vi } from "vitest";
 
@@ -36,20 +35,6 @@ describe("App", () => {
     console.error = consoleError;
     vi.resetAllMocks();
     vi.unstubAllEnvs();
-  });
-
-  it("properly sets up Router", () => {
-    const BrowserRouterSpy = vi
-      .spyOn(reactRouterDOM, "BrowserRouter")
-      .mockImplementation(() => <div></div>);
-    const store = mockStore(rootStateFactory.withGeneralConfig().build());
-    render(
-      <Provider store={store}>
-        <App />
-      </Provider>,
-    );
-    expect(BrowserRouterSpy.mock.calls[0][0].basename).toBe("/");
-    BrowserRouterSpy.mockRestore();
   });
 
   it("catches and displays errors", () => {

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -1,17 +1,15 @@
 import { initialize, pageview } from "react-ga";
-import { BrowserRouter as Router } from "react-router-dom";
 
 import ConnectionError from "components/ConnectionError";
 import ErrorBoundary from "components/ErrorBoundary";
 import Routes from "components/Routes";
-import { getAnalyticsEnabled, getConfig } from "store/general/selectors";
+import { getAnalyticsEnabled } from "store/general/selectors";
 import { useAppSelector } from "store/store";
 
 import "../../scss/index.scss";
 
 function App() {
   const isProduction = import.meta.env.PROD;
-  const config = useAppSelector(getConfig);
   const analyticsEnabled = useAppSelector(getAnalyticsEnabled);
   if (isProduction && analyticsEnabled) {
     initialize("UA-1018242-68");
@@ -19,13 +17,11 @@ function App() {
   }
 
   return (
-    <Router basename={config?.baseAppURL}>
-      <ErrorBoundary>
-        <ConnectionError>
-          <Routes />
-        </ConnectionError>
-      </ErrorBoundary>
-    </Router>
+    <ErrorBoundary>
+      <ConnectionError>
+        <Routes />
+      </ConnectionError>
+    </ErrorBoundary>
   );
 }
 

--- a/src/components/CaptureRoutes/CaptureRoutes.test.tsx
+++ b/src/components/CaptureRoutes/CaptureRoutes.test.tsx
@@ -1,0 +1,48 @@
+import * as reactGA from "react-ga";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
+import type { MockInstance } from "vitest";
+import { vi } from "vitest";
+
+import type { RootState } from "store/store";
+import { configFactory, generalStateFactory } from "testing/factories/general";
+import { rootStateFactory } from "testing/factories/root";
+import { renderComponent } from "testing/utils";
+import { changeURL } from "testing/utils";
+
+import CaptureRoutes from "./CaptureRoutes";
+
+describe("CaptureRoutes", () => {
+  let pageviewSpy: MockInstance;
+  let state: RootState;
+
+  beforeEach(() => {
+    vi.stubEnv("PROD", true);
+    pageviewSpy = vi.spyOn(reactGA, "pageview");
+    state = rootStateFactory.build({
+      general: generalStateFactory.build({
+        config: configFactory.build({
+          analyticsEnabled: true,
+        }),
+      }),
+    });
+  });
+
+  it("sends path change events", async () => {
+    const {
+      result: { rerender },
+    } = renderComponent(<CaptureRoutes />, {
+      path: "*",
+      state,
+    });
+    changeURL("/new/path");
+    // Force the component to rerender so the useEffect runs.
+    rerender(
+      <BrowserRouter>
+        <Routes>
+          <Route path="*" element={<CaptureRoutes />} />
+        </Routes>
+      </BrowserRouter>,
+    );
+    expect(pageviewSpy).toHaveBeenCalledWith("/new/path");
+  });
+});

--- a/src/components/CaptureRoutes/CaptureRoutes.tsx
+++ b/src/components/CaptureRoutes/CaptureRoutes.tsx
@@ -1,0 +1,20 @@
+import { useEffect } from "react";
+import { Outlet, useLocation } from "react-router-dom";
+
+import useAnalytics from "hooks/useAnalytics";
+
+const CaptureRoutes = (): JSX.Element => {
+  const sendAnalytics = useAnalytics();
+  const location = useLocation();
+
+  useEffect(() => {
+    // Send an analytics event when the URL changes.
+    sendAnalytics({
+      path: window.location.href.replace(window.location.origin, ""),
+    });
+  }, [location, sendAnalytics]);
+
+  return <Outlet />;
+};
+
+export default CaptureRoutes;

--- a/src/components/CaptureRoutes/index.ts
+++ b/src/components/CaptureRoutes/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./CaptureRoutes";

--- a/src/components/LogIn/LogIn.test.tsx
+++ b/src/components/LogIn/LogIn.test.tsx
@@ -32,7 +32,11 @@ describe("LogIn", () => {
         },
       }),
     });
-    renderComponent(<LogIn>App content</LogIn>, { state });
+    renderComponent(<LogIn />, {
+      state,
+      path: "*",
+      routeChildren: [{ path: "", element: <>App content</> }],
+    });
     expect(document.querySelector(".login")).not.toBeInTheDocument();
     const content = screen.getByText("App content");
     expect(content).toBeInTheDocument();
@@ -48,7 +52,7 @@ describe("LogIn", () => {
         }),
       }),
     });
-    renderComponent(<LogIn>App content</LogIn>, { state });
+    renderComponent(<LogIn />, { state });
     expect(
       screen.getByRole("link", { name: Label.LOGIN_TO_DASHBOARD }),
     ).toHaveAttribute("data-testid", IdentityProviderFormTestId.CANDID_LOGIN);
@@ -65,7 +69,7 @@ describe("LogIn", () => {
         }),
       }),
     });
-    renderComponent(<LogIn>App content</LogIn>, { state });
+    renderComponent(<LogIn />, { state });
     expect(
       screen.getByRole("link", { name: Label.LOGIN_TO_DASHBOARD }),
     ).toHaveAttribute("data-testid", OIDCFormTestId.OIDC_LOGIN);
@@ -82,7 +86,7 @@ describe("LogIn", () => {
         }),
       }),
     });
-    renderComponent(<LogIn>App content</LogIn>, { state });
+    renderComponent(<LogIn />, { state });
     expect(screen.getByRole("button")).toHaveTextContent(
       Label.LOGIN_TO_DASHBOARD,
     );
@@ -102,7 +106,7 @@ describe("LogIn", () => {
         }),
       }),
     });
-    renderComponent(<LogIn>App content</LogIn>, { state });
+    renderComponent(<LogIn />, { state });
     const error = screen.getByText("Controller rejected request");
     expect(error).toBeInTheDocument();
     expect(error).toHaveClass("error-message");
@@ -119,7 +123,7 @@ describe("LogIn", () => {
         }),
       }),
     });
-    renderComponent(<LogIn>App content</LogIn>, { state });
+    renderComponent(<LogIn />, { state });
     expect(screen.getByText(Label.INVALID_NAME)).toBeInTheDocument();
   });
 
@@ -134,7 +138,7 @@ describe("LogIn", () => {
         }),
       }),
     });
-    renderComponent(<LogIn>App content</LogIn>, { state });
+    renderComponent(<LogIn />, { state });
     expect(screen.getByText(Label.INVALID_FIELD)).toBeInTheDocument();
   });
 
@@ -147,7 +151,7 @@ describe("LogIn", () => {
         visitURLs: ["http://example.com/log-in"],
       }),
     });
-    renderComponent(<LogIn>App content</LogIn>, { state });
+    renderComponent(<LogIn />, { state });
     const card = await screen.findByTestId("toast-card");
     expect(
       await within(card).findByText("Controller authentication required"),
@@ -170,7 +174,7 @@ describe("LogIn", () => {
         visitURLs: ["http://example.com/log-in"],
       }),
     });
-    renderComponent(<LogIn>App content</LogIn>, { state });
+    renderComponent(<LogIn />, { state });
     const card = await screen.findByTestId("toast-card");
     expect(card).toBeInTheDocument();
     await userEvent.click(

--- a/src/components/LogIn/LogIn.tsx
+++ b/src/components/LogIn/LogIn.tsx
@@ -1,7 +1,8 @@
-import type { PropsWithChildren, ReactNode } from "react";
+import type { ReactNode } from "react";
 import { useEffect, useRef } from "react";
 import reactHotToast from "react-hot-toast";
 import { useSelector } from "react-redux";
+import { Outlet } from "react-router-dom";
 
 import FadeUpIn from "animations/FadeUpIn";
 import AuthenticationButton from "components/AuthenticationButton";
@@ -24,7 +25,7 @@ import OIDCForm from "./OIDCForm";
 import UserPassForm from "./UserPassForm";
 import { ErrorResponse, Label } from "./types";
 
-export default function LogIn({ children }: PropsWithChildren) {
+export default function LogIn() {
   const viewedAuthRequests = useRef<string[]>([]);
   const config = useSelector(getConfig);
   const isJuju = useSelector(getIsJuju);
@@ -96,7 +97,9 @@ export default function LogIn({ children }: PropsWithChildren) {
           </FadeUpIn>
         </div>
       )}
-      <div className="app-content">{children}</div>
+      <div className="app-content">
+        <Outlet />
+      </div>
     </>
   );
 }

--- a/src/components/Routes/Routes.tsx
+++ b/src/components/Routes/Routes.tsx
@@ -1,13 +1,11 @@
-import { useEffect } from "react";
 import {
   Navigate,
-  Route,
-  Routes as ReactRouterRoutes,
-  useLocation,
+  createBrowserRouter,
+  RouterProvider,
 } from "react-router-dom";
 
+import CaptureRoutes from "components/CaptureRoutes";
 import Login from "components/LogIn";
-import useAnalytics from "hooks/useAnalytics";
 import AdvancedSearch from "pages/AdvancedSearch";
 import ControllersIndex from "pages/ControllersIndex";
 import Logs from "pages/Logs";
@@ -17,73 +15,71 @@ import PageNotFound from "pages/PageNotFound";
 import {
   isCrossModelQueriesEnabled,
   isAuditLogsEnabled,
+  getConfig,
 } from "store/general/selectors";
 import { useAppSelector } from "store/store";
 import urls from "urls";
 
 export function Routes() {
-  const sendAnalytics = useAnalytics();
-  const location = useLocation();
   const crossModelQueriesEnabled = useAppSelector(isCrossModelQueriesEnabled);
   const auditLogsEnabled = useAppSelector(isAuditLogsEnabled);
+  const config = useAppSelector(getConfig);
 
-  useEffect(() => {
-    // Send an analytics event when the URL changes.
-    sendAnalytics({
-      path: window.location.href.replace(window.location.origin, ""),
+  const authenticatedRoutes = [
+    {
+      path: urls.models.index,
+      element: <ModelsIndex />,
+    },
+    {
+      path: `${urls.model.index(null)}/*`,
+      element: <ModelDetails />,
+    },
+    {
+      path: urls.controllers,
+      element: <ControllersIndex />,
+    },
+  ];
+
+  if (auditLogsEnabled) {
+    authenticatedRoutes.push({
+      path: urls.logs,
+      element: <Logs />,
     });
-  }, [location, sendAnalytics]);
+  }
 
-  return (
-    <ReactRouterRoutes>
-      <Route path={urls.index} element={<Navigate to={urls.models.index} />} />
-      <Route
-        path={urls.models.index}
-        element={
-          <Login>
-            <ModelsIndex />
-          </Login>
-        }
-      />
-      <Route
-        path={`${urls.model.index(null)}/*`}
-        element={
-          <Login>
-            <ModelDetails />
-          </Login>
-        }
-      />
-      <Route
-        path={urls.controllers}
-        element={
-          <Login>
-            <ControllersIndex />
-          </Login>
-        }
-      />
-      <Route path="*" element={<PageNotFound />} />
-      {auditLogsEnabled && (
-        <Route
-          path={urls.logs}
-          element={
-            <Login>
-              <Logs />
-            </Login>
-          }
-        />
-      )}
-      {crossModelQueriesEnabled && (
-        <Route
-          path={urls.search}
-          element={
-            <Login>
-              <AdvancedSearch />
-            </Login>
-          }
-        />
-      )}
-    </ReactRouterRoutes>
+  if (crossModelQueriesEnabled) {
+    authenticatedRoutes.push({
+      path: urls.search,
+      element: <AdvancedSearch />,
+    });
+  }
+
+  const router = createBrowserRouter(
+    [
+      {
+        path: "/",
+        element: <CaptureRoutes />,
+        children: [
+          {
+            path: urls.index,
+            element: <Navigate to={urls.models.index} />,
+          },
+          {
+            path: "/",
+            element: <Login />,
+            children: authenticatedRoutes,
+          },
+          {
+            path: "*",
+            element: <PageNotFound />,
+          },
+        ],
+      },
+    ],
+    { basename: config?.baseAppURL },
   );
+
+  return <RouterProvider router={router} />;
 }
 
 export default Routes;

--- a/src/pages/PageNotFound/PageNotFound.test.tsx
+++ b/src/pages/PageNotFound/PageNotFound.test.tsx
@@ -1,14 +1,25 @@
-import { screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
 
 import Routes from "components/Routes";
 import { BaseLayoutTestId } from "layout/BaseLayout";
-import { renderComponent } from "testing/utils";
+import { rootStateFactory } from "testing/factories/root";
+import { changeURL } from "testing/utils";
 
 import { Label } from "./types";
 
+const mockStore = configureStore([]);
+
 describe("PageNotFound page", () => {
   it("should display when unknown route is accessed", () => {
-    renderComponent(<Routes />, { url: "/foobar11" });
+    const store = mockStore(rootStateFactory.withGeneralConfig().build());
+    changeURL("/unknown");
+    render(
+      <Provider store={store}>
+        <Routes />
+      </Provider>,
+    );
     expect(screen.getByText(Label.NOT_FOUND)).toBeInTheDocument();
     // Ensure only one route is rendered
     expect(screen.getAllByTestId(BaseLayoutTestId.MAIN)).toHaveLength(1);


### PR DESCRIPTION
## Done

- replace BrowserRouter with createBrowserRouter to support the routing in ReBACAdmin as they require the data APIs that are not supported by BrowserRouter.

## QA

- Check that the routing works as before.

## Details

https://warthogs.atlassian.net/browse/WD-16020