### PR TITLE
WD-16080 - feat: add ReBAC Admin

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@canonical/jujulib": "7.0.0",
     "@canonical/macaroon-bakery": "1.3.2",
     "@canonical/react-components": "0.59.0",
+    "@canonical/rebac-admin": "0.0.1-alpha.7",
     "@reduxjs/toolkit": "2.2.4",
     "@sentry/browser": "7.114.0",
     "ansi-to-html": "0.7.2",

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -7,6 +7,7 @@ import {
   SideNavigationText,
 } from "@canonical/react-components";
 import type { NavItem } from "@canonical/react-components/dist/components/SideNavigation/SideNavigation";
+import { urls as generateReBACURLS } from "@canonical/rebac-admin";
 import type { HTMLProps, ReactNode } from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useSelector } from "react-redux";
@@ -31,6 +32,8 @@ import urls, { externalURLs } from "urls";
 
 import "./_primary-nav.scss";
 import { Label } from "./types";
+
+const rebacURLS = generateReBACURLS(urls.permissions);
 
 const useControllersLink = () => {
   const controllers: Controllers | null = useSelector(getControllerData);
@@ -123,6 +126,35 @@ const PrimaryNav = () => {
       label: <>{Label.ADVANCED_SEARCH}</>,
     });
   }
+  // TODO: only display for JAAS admins (WD-16027).
+  const rebacNav: NavItem<NavLinkProps>[] = [
+    {
+      icon: "user",
+      label: <>{Label.PERMISSIONS}</>,
+      nonInteractive: true,
+    },
+    // TODO: display in subnav (WD-16060).
+    {
+      component: NavLink,
+      to: rebacURLS.users.index,
+      label: <>{Label.USERS}</>,
+    },
+    {
+      component: NavLink,
+      to: rebacURLS.groups.index,
+      label: <>{Label.GROUPS}</>,
+    },
+    {
+      component: NavLink,
+      to: rebacURLS.entitlements,
+      label: <>{Label.ENTITLEMENTS}</>,
+    },
+    {
+      component: NavLink,
+      to: rebacURLS.resources.index,
+      label: <>{Label.RESOURCES}</>,
+    },
+  ];
   const extraNav = [
     {
       href: externalURLs.newIssue,
@@ -150,7 +182,11 @@ const PrimaryNav = () => {
     <>
       <SideNavigation<NavLinkProps | HTMLProps<HTMLAnchorElement>>
         dark={DARK_THEME}
-        items={[{ items: navigation }, { items: extraNav }]}
+        items={[
+          { items: navigation },
+          { items: rebacNav },
+          { items: extraNav },
+        ]}
         className="p-primary-nav"
       />
       <UserMenu />

--- a/src/components/PrimaryNav/types.ts
+++ b/src/components/PrimaryNav/types.ts
@@ -1,4 +1,10 @@
 export enum Label {
   ADVANCED_SEARCH = "Advanced search",
+  ENTITLEMENTS = "Entitlements",
+  GROUPS = "Groups",
   LOGS = "Logs",
+  PERMISSIONS = "Permissions",
+  RESOURCES = "Resources",
+  ROLES = "Roles",
+  USERS = "Users",
 }

--- a/src/components/Routes/Routes.tsx
+++ b/src/components/Routes/Routes.tsx
@@ -12,6 +12,7 @@ import Logs from "pages/Logs";
 import ModelDetails from "pages/ModelDetails";
 import ModelsIndex from "pages/ModelsIndex";
 import PageNotFound from "pages/PageNotFound";
+import Permissions from "pages/Permissions";
 import {
   isCrossModelQueriesEnabled,
   isAuditLogsEnabled,
@@ -53,6 +54,12 @@ export function Routes() {
       element: <AdvancedSearch />,
     });
   }
+
+  // TODO: only display for JAAS admins (WD-16027).
+  authenticatedRoutes.push({
+    path: `${urls.permissions}/*`,
+    element: <Permissions />,
+  });
 
   const router = createBrowserRouter(
     [

--- a/src/layout/BaseLayout/BaseLayout.tsx
+++ b/src/layout/BaseLayout/BaseLayout.tsx
@@ -58,6 +58,7 @@ const BaseLayout = ({
       <ApplicationLayout
         aside={<Panels />}
         dark={DARK_THEME}
+        id="app-layout"
         logo={
           <Logo
             component={Link}

--- a/src/pages/Permissions/Permissions.test.tsx
+++ b/src/pages/Permissions/Permissions.test.tsx
@@ -1,0 +1,12 @@
+import { screen } from "@testing-library/react";
+
+import { renderComponent } from "testing/utils";
+
+import Permissions from "./Permissions";
+
+describe("Permissions", () => {
+  it("displays ReBAC Admin", () => {
+    renderComponent(<Permissions />);
+    expect(screen.getByText("Canonical ReBAC Admin")).toBeInTheDocument();
+  });
+});

--- a/src/pages/Permissions/Permissions.tsx
+++ b/src/pages/Permissions/Permissions.tsx
@@ -1,0 +1,11 @@
+import { ReBACAdmin } from "@canonical/rebac-admin";
+
+import BaseLayout from "layout/BaseLayout/BaseLayout";
+
+const Permissions = (): JSX.Element => (
+  <BaseLayout>
+    <ReBACAdmin apiURL="/rebac/v1" asidePanelId="app-layout" />
+  </BaseLayout>
+);
+
+export default Permissions;

--- a/src/pages/Permissions/index.ts
+++ b/src/pages/Permissions/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Permissions";

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -5,6 +5,8 @@
 $increase-font-size-on-larger-screens: false;
 $color-link-visited: $color-link;
 
+@import "@canonical/rebac-admin/dist/rebac-admin.css";
+
 // Import settings
 @import "settings";
 

--- a/src/urls.ts
+++ b/src/urls.ts
@@ -53,6 +53,7 @@ const urls = {
     }>("/models?groupedby=:groupedby"),
   },
   logs: "/logs",
+  permissions: "/permissions",
   search: "/search",
 };
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -39,6 +39,9 @@ export default defineConfig(({ mode }) => {
         "/auth": {
           target: env.VITE_JIMM_API_URL ?? "/",
         },
+        "/rebac/v1": {
+          target: env.VITE_JIMM_API_URL ?? "/",
+        },
       },
     },
     test: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -673,6 +673,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@canonical/rebac-admin@npm:0.0.1-alpha.7":
+  version: 0.0.1-alpha.7
+  resolution: "@canonical/rebac-admin@npm:0.0.1-alpha.7"
+  dependencies:
+    classnames: "npm:2.5.1"
+    clone-deep: "npm:4.0.1"
+    lodash.isequal: "npm:4.5.0"
+    loglevel: "npm:1.9.1"
+    react-hot-toast: "npm:2.4.1"
+  peerDependencies:
+    "@canonical/react-components": ^1.2.1
+    "@tanstack/react-query": ^5.24.7
+    "@types/react": ^18.0.0
+    "@types/react-dom": ^18.0.0
+    axios: ^1.6.7
+    formik: ^2.4.5
+    react: ^18.0.0
+    react-dom: ^18.0.0
+    react-router-dom: ^6.18.0
+    vanilla-framework: ^4.0.0
+    yup: ^1.4.0
+  checksum: 10c0/5665b9d80f039d0bbf88edb179cdf17ab1f0e079fa48e336c4e0ec4e727062a5d5eff9c6db6b896faf2a7ff58549528171e5528e62045eebae1702d316d2f150
+  languageName: node
+  linkType: hard
+
 "@csstools/css-parser-algorithms@npm:^2.6.1":
   version: 2.6.3
   resolution: "@csstools/css-parser-algorithms@npm:2.6.3"
@@ -7487,6 +7512,7 @@ __metadata:
     "@canonical/jujulib": "npm:7.0.0"
     "@canonical/macaroon-bakery": "npm:1.3.2"
     "@canonical/react-components": "npm:0.59.0"
+    "@canonical/rebac-admin": "npm:0.0.1-alpha.7"
     "@reduxjs/toolkit": "npm:2.2.4"
     "@sentry/browser": "npm:7.114.0"
     "@testing-library/jest-dom": "npm:6.4.5"
@@ -7742,6 +7768,13 @@ __metadata:
     chalk: "npm:^4.1.0"
     is-unicode-supported: "npm:^0.1.0"
   checksum: 10c0/67f445a9ffa76db1989d0fa98586e5bc2fd5247260dafb8ad93d9f0ccd5896d53fb830b0e54dade5ad838b9de2006c826831a3c528913093af20dff8bd24aca6
+  languageName: node
+  linkType: hard
+
+"loglevel@npm:1.9.1":
+  version: 1.9.1
+  resolution: "loglevel@npm:1.9.1"
+  checksum: 10c0/152f0501cea367cf998c844a38b19f0b5af555756ad7d8650214a1f8c6a5b045e31b8cf5dae27d28339a061624ce3f618aadb333aed386cac041d6ddc5101a39
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Done

- Display ReBAC Admin in the dashboard.

## QA

- Point your dashboard to a [local JIMM](https://github.com/canonical/juju-dashboard/blob/main/HACKING.md#jimm-controller).
- Click on the Permissions Links in the sidebar and ReBAC Admin should be displayed.

## Details

https://warthogs.atlassian.net/browse/WD-16080
