### PR TITLE
fix: log in before displaying 404 for some routes

### DIFF
--- a/src/components/LogIn/LogIn.tsx
+++ b/src/components/LogIn/LogIn.tsx
@@ -23,7 +23,7 @@ import "./_login.scss";
 import IdentityProviderForm from "./IdentityProviderForm";
 import OIDCForm from "./OIDCForm";
 import UserPassForm from "./UserPassForm";
-import { ErrorResponse, Label } from "./types";
+import { ErrorResponse, Label, TestId } from "./types";
 
 export default function LogIn() {
   const viewedAuthRequests = useRef<string[]>([]);
@@ -87,7 +87,7 @@ export default function LogIn() {
   return (
     <>
       {!userIsLoggedIn && (
-        <div className="login">
+        <div className="login" data-testid={TestId.LOGIN_FORM}>
           <FadeUpIn isActive={!userIsLoggedIn}>
             <div className="login__inner p-card--highlighted">
               <Logo className="login__logo" dark isJuju={isJuju} />

--- a/src/components/LogIn/index.ts
+++ b/src/components/LogIn/index.ts
@@ -1,2 +1,2 @@
 export { default } from "./LogIn";
-export { Label as LogInLabel } from "./types";
+export { Label as LogInLabel, TestId as LogInTestId } from "./types";

--- a/src/components/LogIn/types.ts
+++ b/src/components/LogIn/types.ts
@@ -9,3 +9,7 @@ export enum Label {
   POLLING_ERROR = "Error when trying to connect and start polling models.",
   LOGIN_TO_DASHBOARD = "Log in to the dashboard",
 }
+
+export enum TestId {
+  LOGIN_FORM = "login-form",
+}

--- a/src/components/Routes/Routes.test.tsx
+++ b/src/components/Routes/Routes.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
+import { LogInTestId } from "components/LogIn";
 import { AdvancedSearchTestId } from "pages/AdvancedSearch";
 import { ControllersIndexTestId } from "pages/ControllersIndex/index";
 import { EntityDetailsTestId } from "pages/EntityDetails";
@@ -87,6 +88,23 @@ describe("Routes", () => {
     ).toBeInTheDocument();
   });
 
+  it("displays login for audit logs", async () => {
+    state.general.controllerConnections = {};
+    if (state.general.config) {
+      state.general.config.isJuju = false;
+    }
+    const store = mockStore(state);
+    changeURL(urls.logs);
+    render(
+      <Provider store={store}>
+        <Routes />
+      </Provider>,
+    );
+    expect(
+      await screen.findByTestId(LogInTestId.LOGIN_FORM),
+    ).toBeInTheDocument();
+  });
+
   it("handles audit logs if enabled", async () => {
     state.general.controllerFeatures = controllerFeaturesStateFactory.build({
       "wss://example.com/api": controllerFeaturesFactory.build({
@@ -117,6 +135,23 @@ describe("Routes", () => {
       </Provider>,
     );
     expect(screen.queryByTestId(LogsTestId.COMPONENT)).not.toBeInTheDocument();
+  });
+
+  it("displays login for cross model queries", async () => {
+    state.general.controllerConnections = {};
+    if (state.general.config) {
+      state.general.config.isJuju = false;
+    }
+    const store = mockStore(state);
+    changeURL(urls.search);
+    render(
+      <Provider store={store}>
+        <Routes />
+      </Provider>,
+    );
+    expect(
+      await screen.findByTestId(LogInTestId.LOGIN_FORM),
+    ).toBeInTheDocument();
   });
 
   it("handles cross model queries if enabled", async () => {
@@ -153,6 +188,23 @@ describe("Routes", () => {
     expect(
       screen.queryByTestId(AdvancedSearchTestId.COMPONENT),
     ).not.toBeInTheDocument();
+  });
+
+  it("displays login for permissions", async () => {
+    state.general.controllerConnections = {};
+    if (state.general.config) {
+      state.general.config.isJuju = false;
+    }
+    const store = mockStore(state);
+    changeURL(urls.permissions);
+    render(
+      <Provider store={store}>
+        <Routes />
+      </Provider>,
+    );
+    expect(
+      await screen.findByTestId(LogInTestId.LOGIN_FORM),
+    ).toBeInTheDocument();
   });
 
   it("handles permissions if enabled", async () => {


### PR DESCRIPTION
## Done

- Don't display the 404 page for some routes until after login.

## QA

- Connect your dashboard to JAAS.
- Log out.
- Go to /permissions.
- It should ask you to log in.

## Details

https://warthogs.atlassian.net/browse/WD-18219