### PR TITLE
fix: don't refetch nav permissions

### DIFF
--- a/src/store/juju/selectors.ts
+++ b/src/store/juju/selectors.ts
@@ -1062,13 +1062,16 @@ export const getReBACRelationsState = createSelector(
   (sliceState) => sliceState.rebacRelations,
 );
 
-export const hasReBACPermission = createSelector(
+export const getReBACPermission = createSelector(
   [getReBACRelationsState, (_state, tuple: RelationshipTuple) => tuple],
-  (rebacRelations, tuple) => {
-    const relation = rebacRelations.find((relation) =>
-      isEqual(relation.tuple, tuple),
-    );
-    return relation?.allowed ?? false;
+  (rebacRelations, tuple) =>
+    rebacRelations.find((relation) => isEqual(relation.tuple, tuple)),
+);
+
+export const hasReBACPermission = createSelector(
+  [(state, tuple: RelationshipTuple) => getReBACPermission(state, tuple)],
+  (permission) => {
+    return permission?.allowed ?? false;
   },
 );
 


### PR DESCRIPTION
## Done

- Check if the primary nav permissions have already been fetch and if so don't fetch them again. This is required as the nav is part of the layout that wraps each component and gets recreated on each top level route change.

## QA

- Connect to JIMM.
- Check that the logs and permissions nav items are visible.
- Click on a different page e.g. go from models to controllers.
- Check that the logs and permissions items don't disappear and then reappear during navigation.

## Details

https://warthogs.atlassian.net/browse/WD-18854
