### PR TITLE
feat: update useCanConfigureModel hook to check permissions via rebac

### DIFF
--- a/src/hooks/useCanConfigureModel.ts
+++ b/src/hooks/useCanConfigureModel.ts
@@ -2,18 +2,49 @@ import { useParams } from "react-router";
 
 import type { EntityDetailsRoute } from "components/Routes";
 import useModelStatus from "hooks/useModelStatus";
+import { useCheckPermissions } from "juju/api-hooks";
+import { JIMMRelation } from "juju/jimm/JIMMV4";
+import { getIsJuju, getControllerUserTag } from "store/general/selectors";
 import { getActiveUser, getModelUUIDFromList } from "store/juju/selectors";
 import { canAdministerModel } from "store/juju/utils/models";
 import { useAppSelector } from "store/store";
 
-const useCanConfigureModel = () => {
-  const { userName, modelName } = useParams<EntityDetailsRoute>();
-  const modelUUID = useAppSelector(getModelUUIDFromList(modelName, userName));
+const useCheckJujuPermissions = (modelUUID: string, enabled?: boolean) => {
   const activeUser = useAppSelector((state) => getActiveUser(state, modelUUID));
   const modelStatusData = useModelStatus();
   return (
-    !!activeUser && canAdministerModel(activeUser, modelStatusData?.info?.users)
+    enabled &&
+    !!activeUser &&
+    canAdministerModel(activeUser, modelStatusData?.info?.users)
   );
+};
+
+const useCheckJIMMPermissions = (
+  modelUUID: string,
+  enabled?: boolean,
+  cleanup?: boolean,
+) => {
+  const controllerUser = useAppSelector((state) => getControllerUserTag(state));
+  const { permitted } = useCheckPermissions(
+    enabled && controllerUser && modelUUID
+      ? {
+          object: controllerUser,
+          relation: JIMMRelation.WRITER,
+          target_object: `model-${modelUUID}`,
+        }
+      : null,
+    cleanup,
+  );
+  return permitted;
+};
+
+const useCanConfigureModel = (cleanup?: boolean) => {
+  const isJuju = useAppSelector(getIsJuju);
+  const { userName, modelName } = useParams<EntityDetailsRoute>();
+  const modelUUID = useAppSelector(getModelUUIDFromList(modelName, userName));
+  const jujuPermissions = useCheckJujuPermissions(modelUUID, isJuju);
+  const jimmPermissions = useCheckJIMMPermissions(modelUUID, !isJuju, cleanup);
+  return isJuju ? jujuPermissions : jimmPermissions;
 };
 
 export default useCanConfigureModel;

--- a/src/hooks/useCanManageSecrets.test.tsx
+++ b/src/hooks/useCanManageSecrets.test.tsx
@@ -51,6 +51,7 @@ describe("useCanManageSecrets", () => {
     state = rootStateFactory.build({
       general: generalStateFactory.build({
         config: configFactory.build({
+          isJuju: true,
           controllerAPIEndpoint: "wss://jimm.jujucharms.com/api",
         }),
         controllerConnections: {

--- a/src/pages/EntityDetails/App/App.test.tsx
+++ b/src/pages/EntityDetails/App/App.test.tsx
@@ -54,6 +54,7 @@ describe("Entity Details App", () => {
     state = rootStateFactory.build({
       general: generalStateFactory.build({
         config: configFactory.build({
+          isJuju: true,
           controllerAPIEndpoint: "wss://jimm.jujucharms.com/api",
         }),
         credentials: {

--- a/src/pages/EntityDetails/EntityDetails.tsx
+++ b/src/pages/EntityDetails/EntityDetails.tsx
@@ -11,6 +11,7 @@ import NotFound from "components/NotFound";
 import type { EntityDetailsRoute } from "components/Routes";
 import WebCLI from "components/WebCLI";
 import { useEntityDetailsParams } from "components/hooks";
+import useCanConfigureModel from "hooks/useCanConfigureModel";
 import useWindowTitle from "hooks/useWindowTitle";
 import BaseLayout from "layout/BaseLayout/BaseLayout";
 import { getIsJuju, getUserPass } from "store/general/selectors";
@@ -49,6 +50,12 @@ const EntityDetails = ({ modelWatcherError }: Props) => {
   const modelUUID = useSelector(getModelUUIDFromList(modelName, userName));
   const modelInfo = useSelector(getModelInfo(modelUUID));
   const { isNestedEntityPage } = useEntityDetailsParams();
+
+  // Cleanup is set for this hook, but not for the instances of
+  // useCanConfigureModel in other model components as this component wraps all
+  // model routes so the model permissions are removed once the user navigates
+  // away from the model.
+  useCanConfigureModel(true);
 
   const isJuju = useSelector(getIsJuju);
 

--- a/src/pages/EntityDetails/Model/ApplicationsTab/LocalAppsTable/LocalAppsTable.test.tsx
+++ b/src/pages/EntityDetails/Model/ApplicationsTab/LocalAppsTable/LocalAppsTable.test.tsx
@@ -4,7 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { actions as jujuActions } from "store/juju";
 import type { RootState } from "store/store";
 import { jujuStateFactory, rootStateFactory } from "testing/factories";
-import { generalStateFactory } from "testing/factories/general";
+import { generalStateFactory, configFactory } from "testing/factories/general";
 import { charmApplicationFactory } from "testing/factories/juju/Charms";
 import { modelUserInfoFactory } from "testing/factories/juju/ModelManagerV9";
 import {
@@ -26,6 +26,9 @@ describe("LocalAppsTable", () => {
   beforeEach(() => {
     state = rootStateFactory.build({
       general: generalStateFactory.build({
+        config: configFactory.build({
+          isJuju: true,
+        }),
         controllerConnections: {
           "wss://jimm.jujucharms.com/api": {
             user: {

--- a/src/pages/EntityDetails/Model/Model.test.tsx
+++ b/src/pages/EntityDetails/Model/Model.test.tsx
@@ -89,6 +89,7 @@ describe("Model", () => {
     state = rootStateFactory.build({
       general: generalStateFactory.build({
         config: configFactory.build({
+          isJuju: true,
           controllerAPIEndpoint: "wss://jimm.jujucharms.com/api",
         }),
         controllerConnections: {
@@ -346,6 +347,9 @@ describe("Model", () => {
   });
 
   it("can display the audit logs table", async () => {
+    if (state.general.config) {
+      state.general.config.isJuju = false;
+    }
     state.juju.modelWatcherData = {
       abc123: modelWatcherModelDataFactory.build({
         applications: {

--- a/src/pages/EntityDetails/Model/Model.tsx
+++ b/src/pages/EntityDetails/Model/Model.tsx
@@ -87,11 +87,7 @@ const Model = () => {
   const canListSecrets = useAppSelector((state) =>
     getCanListSecrets(state, modelUUID),
   );
-  // Cleanup is set for this hook, but not for the instances of
-  // useCanConfigureModel in other model components as this component wraps all
-  // model routes so the model permissions are removed once the user navigates
-  // away from the model.
-  const canConfigureModel = useCanConfigureModel(true);
+  const canConfigureModel = useCanConfigureModel();
 
   const machinesTableRows = useMemo(() => {
     return modelName && userName

--- a/src/pages/EntityDetails/Model/Model.tsx
+++ b/src/pages/EntityDetails/Model/Model.tsx
@@ -87,7 +87,11 @@ const Model = () => {
   const canListSecrets = useAppSelector((state) =>
     getCanListSecrets(state, modelUUID),
   );
-  const canConfigureModel = useCanConfigureModel();
+  // Cleanup is set for this hook, but not for the instances of
+  // useCanConfigureModel in other model components as this component wraps all
+  // model routes so the model permissions are removed once the user navigates
+  // away from the model.
+  const canConfigureModel = useCanConfigureModel(true);
 
   const machinesTableRows = useMemo(() => {
     return modelName && userName

--- a/src/pages/EntityDetails/Model/Secrets/Secrets.test.tsx
+++ b/src/pages/EntityDetails/Model/Secrets/Secrets.test.tsx
@@ -55,6 +55,7 @@ describe("Secrets", () => {
           "wss://example.com/api": credentialFactory.build(),
         },
         config: configFactory.build({
+          isJuju: true,
           controllerAPIEndpoint: "wss://example.com/api",
         }),
         controllerConnections: {

--- a/src/pages/EntityDetails/Model/Secrets/SecretsTable/SecretsTable.test.tsx
+++ b/src/pages/EntityDetails/Model/Secrets/SecretsTable/SecretsTable.test.tsx
@@ -50,6 +50,7 @@ describe("SecretsTable", () => {
     state = rootStateFactory.build({
       general: generalStateFactory.build({
         config: configFactory.build({
+          isJuju: true,
           controllerAPIEndpoint: "wss://example.com/api",
         }),
         controllerConnections: {

--- a/src/panels/ConfigPanel/ConfigPanel.test.tsx
+++ b/src/panels/ConfigPanel/ConfigPanel.test.tsx
@@ -68,6 +68,7 @@ describe("ConfigPanel", () => {
     state = rootStateFactory.build({
       general: generalStateFactory.build({
         config: configFactory.build({
+          isJuju: true,
           controllerAPIEndpoint: "wss://example.com/api",
         }),
         controllerConnections: {

--- a/src/panels/ConfigPanel/SecretsPicker/SecretsPicker.test.tsx
+++ b/src/panels/ConfigPanel/SecretsPicker/SecretsPicker.test.tsx
@@ -43,6 +43,7 @@ describe("SecretsPicker", () => {
           "wss://example.com/api": credentialFactory.build(),
         },
         config: configFactory.build({
+          isJuju: true,
           controllerAPIEndpoint: "wss://example.com/api",
         }),
         controllerConnections: {

--- a/src/panels/Panels.test.tsx
+++ b/src/panels/Panels.test.tsx
@@ -73,6 +73,7 @@ describe("Panels", () => {
       state = rootStateFactory.build({
         general: generalStateFactory.build({
           config: configFactory.build({
+            isJuju: true,
             controllerAPIEndpoint: "wss://jimm.jujucharms.com/api",
           }),
           controllerConnections: {


### PR DESCRIPTION
## Done

- Update useCanConfigureModel hook to check permissions via rebac when using JIMM.

## QA

- Connect to JIMM.
- Go to a model details page
- Check that model access button appears on the left hand side.
- Click on an app and check that the configure button appears.

## Details

https://warthogs.atlassian.net/browse/WD-19055
