### PR TITLE
feat: check audit logs access via jimm

### DIFF
--- a/src/pages/EntityDetails/EntityDetails.test.tsx
+++ b/src/pages/EntityDetails/EntityDetails.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor, within } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
 
@@ -11,11 +11,7 @@ import {
   configFactory,
 } from "testing/factories/general";
 import { modelListInfoFactory } from "testing/factories/juju/juju";
-import {
-  controllerFactory,
-  modelFeaturesStateFactory,
-  modelFeaturesFactory,
-} from "testing/factories/juju/juju";
+import { controllerFactory } from "testing/factories/juju/juju";
 import {
   applicationInfoFactory,
   modelWatcherModelDataFactory,
@@ -23,7 +19,6 @@ import {
 } from "testing/factories/juju/model-watcher";
 import { renderComponent } from "testing/utils";
 import urls from "urls";
-import { ModelTab } from "urls";
 
 import EntityDetails from "./EntityDetails";
 import { Label } from "./types";
@@ -116,94 +111,6 @@ describe("Entity Details Container", () => {
     expect(
       screen.getByRole("heading", { name: Label.NOT_FOUND }),
     ).toBeInTheDocument();
-  });
-
-  it("lists the correct tabs", () => {
-    renderComponent(<EntityDetails />, { path, url, state });
-    expect(screen.getByTestId("view-selector")).toHaveTextContent(
-      /^ApplicationsIntegrationsLogsMachines$/,
-    );
-  });
-
-  it("lists the correct tabs for kubernetes", () => {
-    state.juju.modelWatcherData = {
-      abc123: modelWatcherModelDataFactory.build({
-        applications: {
-          "ceph-mon": applicationInfoFactory.build(),
-        },
-        model: modelWatcherModelInfoFactory.build({
-          name: "enterprise",
-          owner: "kirk@external",
-          type: "kubernetes",
-        }),
-      }),
-    };
-    renderComponent(<EntityDetails />, { path, url, state });
-    expect(screen.getByTestId("view-selector")).toHaveTextContent(
-      /^ApplicationsIntegrationsLogs$/,
-    );
-  });
-
-  it("lists the secrets tab", () => {
-    state.juju.modelFeatures = modelFeaturesStateFactory.build({
-      abc123: modelFeaturesFactory.build({
-        listSecrets: true,
-      }),
-    });
-    renderComponent(<EntityDetails />, { path, url, state });
-    expect(screen.getByTestId("view-selector")).toHaveTextContent(
-      /^ApplicationsIntegrationsLogsSecretsMachines$/,
-    );
-  });
-
-  it("clicking the tabs changes the visible section", async () => {
-    state.juju.modelFeatures = modelFeaturesStateFactory.build({
-      abc123: modelFeaturesFactory.build({
-        listSecrets: true,
-      }),
-    });
-    const { router } = renderComponent(<EntityDetails />, { path, url, state });
-    const viewSelector = screen.getByTestId("view-selector");
-    const sections = [
-      {
-        text: "Applications",
-        query: ModelTab.APPS,
-      },
-      {
-        text: "Integrations",
-        query: ModelTab.INTEGRATIONS,
-      },
-      {
-        text: "Logs",
-        query: ModelTab.LOGS,
-      },
-      {
-        text: "Machines",
-        query: ModelTab.MACHINES,
-      },
-      {
-        text: "Secrets",
-        query: ModelTab.SECRETS,
-      },
-    ];
-    sections.forEach((section) => {
-      const scrollIntoView = vi.fn();
-      fireEvent.click(within(viewSelector).getByText(section.text), {
-        target: {
-          scrollIntoView,
-        },
-      });
-      expect(scrollIntoView.mock.calls[0]).toEqual([
-        {
-          behavior: "smooth",
-          block: "end",
-          inline: "nearest",
-        },
-      ]);
-      expect(router.state.location.search).toEqual(
-        `?activeView=${section.query}`,
-      );
-    });
   });
 
   it("shows the supplied child", async () => {
@@ -419,27 +326,5 @@ describe("Entity Details Container", () => {
     expect(window.location.reload).toHaveBeenCalledTimes(1);
 
     window.location = location;
-  });
-
-  it("should navigate correctly when pressing Action Logs tab under Juju", () => {
-    state.general.config = configFactory.build({
-      isJuju: true,
-    });
-    const { router } = renderComponent(<EntityDetails />, { path, url, state });
-    const viewSelector = screen.getByTestId("view-selector");
-    const scrollIntoView = vi.fn();
-    fireEvent.click(within(viewSelector).getByText("Action Logs"), {
-      target: {
-        scrollIntoView,
-      },
-    });
-    expect(scrollIntoView.mock.calls[0]).toEqual([
-      {
-        behavior: "smooth",
-        block: "end",
-        inline: "nearest",
-      },
-    ]);
-    expect(router.state.location.search).toEqual("?activeView=logs");
   });
 });

--- a/src/pages/EntityDetails/Model/Logs/Logs.tsx
+++ b/src/pages/EntityDetails/Model/Logs/Logs.tsx
@@ -4,6 +4,7 @@ import ActionBar from "components/ActionBar";
 import AuditLogsTableActions from "components/AuditLogsTable/AuditLogsTableActions";
 import SegmentedControl from "components/SegmentedControl";
 import { useQueryParams } from "hooks/useQueryParams";
+import { useAuditLogsPermitted } from "juju/api-hooks/permissions";
 import { getIsJuju } from "store/general/selectors";
 
 import "./_logs.scss";
@@ -18,6 +19,7 @@ const BUTTON_DETAILS = [
 
 const Logs = () => {
   const isJuju = useSelector(getIsJuju);
+  const { permitted: auditLogsAllowed } = useAuditLogsPermitted();
   const [{ tableView }, setQueryParams] = useQueryParams<{
     activeView: string | null;
     panel: string | null;
@@ -45,7 +47,7 @@ const Logs = () => {
         </ActionBar>
       )}
       {tableView === "action-logs" && <ActionLogs />}
-      {!isJuju && tableView === "audit-logs" && <AuditLogs />}
+      {auditLogsAllowed && tableView === "audit-logs" && <AuditLogs />}
     </div>
   );
 };

--- a/src/pages/EntityDetails/Model/Model.test.tsx
+++ b/src/pages/EntityDetails/Model/Model.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
 
 import { TestId as InfoPanelTestId } from "components/InfoPanel/types";
+import { JIMMRelation, JIMMTarget } from "juju/jimm/JIMMV4";
 import { TestId as SecretsTestId } from "pages/EntityDetails/Model/Secrets/types";
 import type { RootState } from "store/store";
 import { jujuStateFactory, rootStateFactory } from "testing/factories";
@@ -10,6 +11,9 @@ import {
   configFactory,
   credentialFactory,
   generalStateFactory,
+  controllerFeaturesFactory,
+  controllerFeaturesStateFactory,
+  authUserInfoFactory,
 } from "testing/factories/general";
 import {
   actionResultsFactory,
@@ -28,6 +32,7 @@ import {
   modelListInfoFactory,
   modelFeaturesStateFactory,
   modelFeaturesFactory,
+  rebacRelationFactory,
 } from "testing/factories/juju/juju";
 import {
   applicationInfoFactory,
@@ -354,6 +359,34 @@ describe("Model", () => {
         },
       }),
     };
+    state.general.controllerFeatures = controllerFeaturesStateFactory.build({
+      "wss://jimm.jujucharms.com/api": controllerFeaturesFactory.build({
+        auditLogs: true,
+      }),
+    });
+    state.general.controllerConnections = {
+      "wss://jimm.jujucharms.com/api": {
+        user: authUserInfoFactory.build(),
+      },
+    };
+    state.juju.rebacRelations = [
+      rebacRelationFactory.build({
+        tuple: {
+          object: "user-eggman@external",
+          relation: JIMMRelation.AUDIT_LOG_VIEWER,
+          target_object: JIMMTarget.JIMM_CONTROLLER,
+        },
+        allowed: true,
+      }),
+      rebacRelationFactory.build({
+        tuple: {
+          object: "user-eggman@external",
+          relation: JIMMRelation.ADMINISTRATOR,
+          target_object: JIMMTarget.JIMM_CONTROLLER,
+        },
+        allowed: true,
+      }),
+    ];
     renderComponent(<Model />, {
       state,
       url: "/models/eggman@external/test1?activeView=logs&tableView=audit-logs",

--- a/src/pages/EntityDetails/Model/ModelTabs/ModelTabs.test.tsx
+++ b/src/pages/EntityDetails/Model/ModelTabs/ModelTabs.test.tsx
@@ -1,0 +1,196 @@
+import { fireEvent, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+
+import { JIMMRelation, JIMMTarget } from "juju/jimm/JIMMV4";
+import type { RootState } from "store/store";
+import { jujuStateFactory, rootStateFactory } from "testing/factories";
+import {
+  generalStateFactory,
+  configFactory,
+  controllerFeaturesFactory,
+  controllerFeaturesStateFactory,
+  authUserInfoFactory,
+} from "testing/factories/general";
+import {
+  modelListInfoFactory,
+  rebacRelationFactory,
+} from "testing/factories/juju/juju";
+import {
+  modelFeaturesStateFactory,
+  modelFeaturesFactory,
+} from "testing/factories/juju/juju";
+import {
+  modelWatcherModelDataFactory,
+  modelWatcherModelInfoFactory,
+} from "testing/factories/juju/model-watcher";
+import { renderComponent } from "testing/utils";
+import { ModelTab } from "urls";
+
+import ModelTabs from "./ModelTabs";
+import { Label } from "./types";
+
+describe("ModelTabs", () => {
+  let state: RootState;
+  const path = "/models/:userName/:modelName";
+  const url = "/models/eggman@external/enterprise";
+
+  beforeEach(() => {
+    state = rootStateFactory.withGeneralConfig().build({
+      general: generalStateFactory.build({
+        config: configFactory.build({
+          controllerAPIEndpoint: "wss://jimm.jujucharms.com/api",
+        }),
+        controllerConnections: {
+          "wss://jimm.jujucharms.com/api": {
+            user: authUserInfoFactory.build(),
+          },
+        },
+      }),
+      juju: jujuStateFactory.build({
+        models: {
+          abc123: modelListInfoFactory.build({
+            uuid: "abc123",
+            name: "enterprise",
+          }),
+        },
+      }),
+    });
+  });
+
+  it("lists tabs", () => {
+    renderComponent(<ModelTabs />, { path, url, state });
+    const sections = [
+      {
+        text: Label.APPLICATIONS,
+        query: ModelTab.APPS,
+      },
+      {
+        text: Label.INTEGRATIONS,
+        query: ModelTab.INTEGRATIONS,
+      },
+      {
+        text: Label.ACTION_LOGS,
+        query: ModelTab.LOGS,
+      },
+      {
+        text: Label.MACHINES,
+        query: ModelTab.MACHINES,
+      },
+    ];
+    expect(screen.getAllByRole("link")).toHaveLength(sections.length);
+    sections.forEach((section) => {
+      expect(
+        screen.getByRole("link", { name: section.text }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("does not display the machine tab for kubernetes", () => {
+    state.juju.modelWatcherData = {
+      abc123: modelWatcherModelDataFactory.build({
+        model: modelWatcherModelInfoFactory.build({
+          name: "enterprise",
+          owner: "eggman@external",
+          type: "kubernetes",
+        }),
+      }),
+    };
+    renderComponent(<ModelTabs />, { path, url, state });
+    expect(
+      screen.queryByRole("link", { name: Label.MACHINES }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("displays the secrets tab if available", () => {
+    state.juju.modelFeatures = modelFeaturesStateFactory.build({
+      abc123: modelFeaturesFactory.build({
+        listSecrets: true,
+      }),
+    });
+    renderComponent(<ModelTabs />, { path, url, state });
+    expect(
+      screen.getByRole("link", { name: Label.SECRETS }),
+    ).toBeInTheDocument();
+  });
+
+  it("displays a logs link if audit logs are available", () => {
+    state.general.controllerFeatures = controllerFeaturesStateFactory.build({
+      "wss://jimm.jujucharms.com/api": controllerFeaturesFactory.build({
+        auditLogs: true,
+      }),
+    });
+    state.juju.rebacRelations = [
+      rebacRelationFactory.build({
+        tuple: {
+          object: "user-eggman@external",
+          relation: JIMMRelation.AUDIT_LOG_VIEWER,
+          target_object: JIMMTarget.JIMM_CONTROLLER,
+        },
+        allowed: true,
+      }),
+      rebacRelationFactory.build({
+        tuple: {
+          object: "user-eggman@external",
+          relation: JIMMRelation.ADMINISTRATOR,
+          target_object: JIMMTarget.JIMM_CONTROLLER,
+        },
+        allowed: true,
+      }),
+    ];
+    renderComponent(<ModelTabs />, { path, url, state });
+    expect(screen.getByRole("link", { name: Label.LOGS })).toBeInTheDocument();
+  });
+
+  it("clicking the tabs changes the visible section", async () => {
+    state.juju.modelFeatures = modelFeaturesStateFactory.build({
+      abc123: modelFeaturesFactory.build({
+        listSecrets: true,
+      }),
+    });
+    const { router } = renderComponent(<ModelTabs />, { path, url, state });
+    const sections = [
+      {
+        text: Label.APPLICATIONS,
+        query: ModelTab.APPS,
+      },
+      {
+        text: Label.INTEGRATIONS,
+        query: ModelTab.INTEGRATIONS,
+      },
+      {
+        text: Label.ACTION_LOGS,
+        query: ModelTab.LOGS,
+      },
+      {
+        text: Label.MACHINES,
+        query: ModelTab.MACHINES,
+      },
+      {
+        text: Label.SECRETS,
+        query: ModelTab.SECRETS,
+      },
+    ];
+    for (const section of sections) {
+      await userEvent.click(screen.getByRole("link", { name: section.text }));
+      expect(router.state.location.search).toEqual(
+        `?activeView=${section.query}`,
+      );
+    }
+  });
+
+  it("scrolls tabs into view", async () => {
+    renderComponent(<ModelTabs />, { path, url, state });
+    const scrollIntoView = vi.fn();
+    fireEvent.click(screen.getByRole("link", { name: Label.APPLICATIONS }), {
+      target: {
+        scrollIntoView,
+      },
+    });
+    expect(scrollIntoView).toHaveBeenCalledWith({
+      behavior: "smooth",
+      block: "end",
+      inline: "nearest",
+    });
+  });
+});

--- a/src/pages/EntityDetails/Model/ModelTabs/ModelTabs.tsx
+++ b/src/pages/EntityDetails/Model/ModelTabs/ModelTabs.tsx
@@ -1,0 +1,96 @@
+import type { TabsProps } from "@canonical/react-components";
+import { Tabs } from "@canonical/react-components";
+import type { MouseEvent } from "react";
+import { useSelector } from "react-redux";
+import type { LinkProps } from "react-router";
+import { useParams, Link } from "react-router";
+
+import type { EntityDetailsRoute } from "components/Routes";
+import { useQueryParams } from "hooks/useQueryParams";
+import { useAuditLogsPermitted } from "juju/api-hooks/permissions";
+import {
+  isKubernetesModel,
+  getCanListSecrets,
+  getModelUUIDFromList,
+} from "store/juju/selectors";
+import { useAppSelector } from "store/store";
+import urls from "urls";
+import { ModelTab } from "urls";
+
+import { Label } from "./types";
+
+const ModelTabs = () => {
+  const { userName, modelName } = useParams<EntityDetailsRoute>();
+  const modelUUID = useSelector(getModelUUIDFromList(modelName, userName));
+  const isK8s = useAppSelector((state) => isKubernetesModel(state, modelUUID));
+  const canListSecrets = useAppSelector((state) =>
+    getCanListSecrets(state, modelUUID),
+  );
+  const { permitted: auditLogsAllowed } = useAuditLogsPermitted();
+  const [query] = useQueryParams({
+    panel: null,
+    entity: null,
+    activeView: "apps",
+    filterQuery: "",
+  });
+  const { activeView } = query;
+
+  const handleNavClick = (e: MouseEvent) => {
+    (e.target as HTMLAnchorElement)?.scrollIntoView({
+      behavior: "smooth",
+      block: "end",
+      inline: "nearest",
+    });
+  };
+
+  const tabs: TabsProps<LinkProps>["links"] = [];
+  if (userName && modelName) {
+    tabs.push(
+      {
+        active: activeView === ModelTab.APPS,
+        label: Label.APPLICATIONS,
+        onClick: (e: MouseEvent) => handleNavClick(e),
+        to: urls.model.tab({ userName, modelName, tab: ModelTab.APPS }),
+        component: Link,
+      },
+      {
+        active: activeView === ModelTab.INTEGRATIONS,
+        label: Label.INTEGRATIONS,
+        onClick: (e: MouseEvent) => handleNavClick(e),
+        to: urls.model.tab({ userName, modelName, tab: ModelTab.INTEGRATIONS }),
+        component: Link,
+      },
+      {
+        active: activeView === "logs",
+        label: auditLogsAllowed ? Label.LOGS : Label.ACTION_LOGS,
+        onClick: (e: MouseEvent) => handleNavClick(e),
+        to: urls.model.tab({ userName, modelName, tab: ModelTab.LOGS }),
+        component: Link,
+      },
+    );
+
+    if (canListSecrets) {
+      tabs.push({
+        active: activeView === "secrets",
+        label: Label.SECRETS,
+        onClick: (e: MouseEvent) => handleNavClick(e),
+        to: urls.model.tab({ userName, modelName, tab: ModelTab.SECRETS }),
+        component: Link,
+      });
+    }
+
+    if (!isK8s) {
+      tabs.push({
+        active: activeView === ModelTab.MACHINES,
+        label: Label.MACHINES,
+        onClick: (e: MouseEvent) => handleNavClick(e),
+        to: urls.model.tab({ userName, modelName, tab: ModelTab.MACHINES }),
+        component: Link,
+      });
+    }
+  }
+
+  return <Tabs links={tabs} />;
+};
+
+export default ModelTabs;

--- a/src/pages/EntityDetails/Model/ModelTabs/index.ts
+++ b/src/pages/EntityDetails/Model/ModelTabs/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./ModelTabs";
+export { Label as ModelTabsLabel } from "./types";

--- a/src/pages/EntityDetails/Model/ModelTabs/types.ts
+++ b/src/pages/EntityDetails/Model/ModelTabs/types.ts
@@ -1,0 +1,8 @@
+export enum Label {
+  ACTION_LOGS = "Action Logs",
+  APPLICATIONS = "Applications",
+  INTEGRATIONS = "Integrations",
+  LOGS = "Logs",
+  MACHINES = "Machines",
+  SECRETS = "Secrets",
+}


### PR DESCRIPTION
## Done

- Refactor tabs into a component.
- Check permissions for audit logs via JIMM.

## QA

- Connect to JIMM.
- Go to a model and check that there is a Logs tab.
- Click on the logs tab and check that there are two sub-tabs: "Audit logs" and "Action logs" and that you can view the "Audit logs" tab.
- Connect to a local (non-jimm) controller.
- Go to a model and check that there is an "Action logs" tab and no sub-tabs.

## Details

https://warthogs.atlassian.net/browse/WD-19056
