### PR TITLE
fix: overflowing tooltip on model page

### DIFF
--- a/src/components/EntityInfo/EntityInfo.test.tsx
+++ b/src/components/EntityInfo/EntityInfo.test.tsx
@@ -1,17 +1,11 @@
 import { screen } from "@testing-library/react";
-import { vi } from "vitest";
 
 import { renderComponent } from "testing/utils";
 
 import EntityInfo from "./EntityInfo";
 
-vi.mock("components/Topology", () => {
-  const Topology = () => <div className="topology"></div>;
-  return { default: Topology };
-});
-
 describe("Entity info", () => {
-  it("renders the expanded topology on click", () => {
+  it("renders the data", () => {
     renderComponent(
       <EntityInfo
         data={{
@@ -20,13 +14,16 @@ describe("Entity info", () => {
           region: "eu1",
         }}
       />,
-      {
-        path: "/models/:userName/:modelName",
-        url: "/models/user-eggman@external/group-test",
-      },
     );
     expect(screen.getByText("model1")).toHaveClass("u-truncate");
     expect(screen.getByText("controller1")).not.toHaveClass("u-truncate");
     expect(screen.getByText("eu1")).toHaveClass("u-truncate");
+  });
+
+  it("renders empty data", () => {
+    const {
+      result: { container },
+    } = renderComponent(<EntityInfo data={{}} />);
+    expect(container.querySelector(".entity-info__grid")).toBeEmptyDOMElement();
   });
 });

--- a/src/components/SecondaryNavigation/_secondary-navigation.scss
+++ b/src/components/SecondaryNavigation/_secondary-navigation.scss
@@ -1,6 +1,3 @@
-@include vf-b-placeholders;
-@include vf-b-typography-definitions;
-
 .secondary-navigation {
   background-color: #373737;
 

--- a/src/components/TruncatedTooltip/TruncatedTooltip.test.tsx
+++ b/src/components/TruncatedTooltip/TruncatedTooltip.test.tsx
@@ -80,6 +80,9 @@ describe("TruncatedTooltip", () => {
     const innerElement = screen.getByText(content);
     expect(innerElement.tagName.toLowerCase()).toBe("div");
     expect(innerElement).toHaveClass("u-truncate");
+    expect(innerElement.parentElement).toHaveStyle({
+      display: "inline-block",
+    });
   });
 
   it("should render an inner custom element type", () => {

--- a/src/pages/EntityDetails/_entity-details.scss
+++ b/src/pages/EntityDetails/_entity-details.scss
@@ -1,5 +1,3 @@
-@include vf-b-placeholders;
-
 @mixin entity-details-layout {
   .entity-details {
     display: grid;

--- a/src/panels/ShareModelPanel/_share-model.scss
+++ b/src/panels/ShareModelPanel/_share-model.scss
@@ -1,6 +1,3 @@
-@include vf-p-icons;
-@include vf-b-placeholders;
-
 .share-model {
   .add-user-btn {
     display: flex;

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -74,6 +74,7 @@ $color-navigation-background: $color-brand;
 @import "../components/SecondaryNavigation/secondary-navigation";
 @import "../components/ShareCard/share-card";
 @import "../components/ToastCard/toast-card";
+@import "../components/TruncatedTooltip/truncated-tooltip";
 @import "../components/UserMenu/user-menu";
 @import "../components/WebCLI/webcli";
 @import "../layout/BaseLayout/base-layout";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,7 @@ export default defineConfig(({ mode }) => {
       outDir: "build",
     },
     css: {
+      devSourcemap: true,
       preprocessorOptions: {
         scss: {
           api: "modern-compiler",


### PR DESCRIPTION
## Done

- Fix `EntityInfo` overflowing items by importing `truncated-tooltip` into top level SCSS file
  - Include new test case in `TruncatedTooltip` to ensure the style is overridden
- Update `EntityInfo` tests
  - Clean up references to `topology`
  - Add new test for empty entity data
- Clean up duplicated SCSS includes (close #1866, close #1867)
- Turn on CSS source maps in dev mode

## Details

- closes #1870 
- https://warthogs.atlassian.net/jira/software/c/projects/WD/issues/WD-19878

## Screenshots

![image](https://github.com/user-attachments/assets/b6d2c068-c15a-497d-91d2-9b125ba49f13)