### PR TITLE
fix: apply word break in config panel

### DIFF
--- a/src/panels/ConfigPanel/_config-panel.scss
+++ b/src/panels/ConfigPanel/_config-panel.scss
@@ -8,9 +8,10 @@
     background-color: inherit;
     border: none;
     padding: 0;
+
     // extra styles
     white-space: pre-wrap;
-    word-break: keep-all;
+    word-break: break-word;
   }
 
   .config-panel__hide-button {


### PR DESCRIPTION
## Done

- use `break-word` in `pre` containing configuration description, to prevent wrapping from changing panel aside width

## Details

- close #1868 
- WD-19882

## Screenshots

![image](https://github.com/user-attachments/assets/3c2965ae-2b00-42b7-8d54-807a014f62bd)