### PR TITLE
fix: correctly disable routes for disabled features

### DIFF
--- a/src/components/CheckPermissions/CheckPermissions.test.tsx
+++ b/src/components/CheckPermissions/CheckPermissions.test.tsx
@@ -7,7 +7,7 @@ import { renderComponent } from "testing/utils";
 import CheckPermissions from "./CheckPermissions";
 
 describe("CheckPermissions", () => {
-  it("displays the loading state", async () => {
+  it("displays the loading state", () => {
     renderComponent(
       <CheckPermissions loading>secret content</CheckPermissions>,
     );
@@ -16,14 +16,14 @@ describe("CheckPermissions", () => {
     ).toBeInTheDocument();
   });
 
-  it("displays a page not found message if it's not allowed", async () => {
+  it("displays a page not found message if it's not allowed", () => {
     renderComponent(
       <CheckPermissions allowed={false}>secret content</CheckPermissions>,
     );
     expect(screen.getByText(PageNotFoundLabel.NOT_FOUND)).toBeInTheDocument();
   });
 
-  it("displays a page not found message if it's not allowed", async () => {
+  it("displays a page not found message if it's not allowed", () => {
     renderComponent(
       <CheckPermissions allowed>secret content</CheckPermissions>,
     );

--- a/src/components/CheckPermissions/CheckPermissions.test.tsx
+++ b/src/components/CheckPermissions/CheckPermissions.test.tsx
@@ -1,0 +1,32 @@
+import { screen } from "@testing-library/dom";
+
+import { LoadingSpinnerTestId } from "components/LoadingSpinner";
+import { PageNotFoundLabel } from "pages/PageNotFound";
+import { renderComponent } from "testing/utils";
+
+import CheckPermissions from "./CheckPermissions";
+
+describe("CheckPermissions", () => {
+  it("displays the loading state", async () => {
+    renderComponent(
+      <CheckPermissions loading>secret content</CheckPermissions>,
+    );
+    expect(
+      screen.getByTestId(LoadingSpinnerTestId.LOADING),
+    ).toBeInTheDocument();
+  });
+
+  it("displays a page not found message if it's not allowed", async () => {
+    renderComponent(
+      <CheckPermissions allowed={false}>secret content</CheckPermissions>,
+    );
+    expect(screen.getByText(PageNotFoundLabel.NOT_FOUND)).toBeInTheDocument();
+  });
+
+  it("displays a page not found message if it's not allowed", async () => {
+    renderComponent(
+      <CheckPermissions allowed>secret content</CheckPermissions>,
+    );
+    expect(screen.getByText("secret content")).toBeInTheDocument();
+  });
+});

--- a/src/components/CheckPermissions/CheckPermissions.tsx
+++ b/src/components/CheckPermissions/CheckPermissions.tsx
@@ -1,0 +1,20 @@
+import type { JSX } from "react";
+
+import BaseLayout from "layout/BaseLayout";
+import PageNotFound from "pages/PageNotFound";
+
+import type { Props } from "./types";
+
+const CheckPermissions = ({
+  allowed,
+  children,
+  loading,
+  ...props
+}: Props): JSX.Element => {
+  if (loading) {
+    return <BaseLayout {...props} loading />;
+  }
+  return allowed ? <>{children}</> : <PageNotFound {...props} />;
+};
+
+export default CheckPermissions;

--- a/src/components/CheckPermissions/index.ts
+++ b/src/components/CheckPermissions/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./CheckPermissions";

--- a/src/components/CheckPermissions/types.ts
+++ b/src/components/CheckPermissions/types.ts
@@ -1,0 +1,6 @@
+import type { PropsWithChildren } from "react";
+
+export type Props = {
+  allowed?: boolean;
+  loading?: boolean;
+} & PropsWithChildren;

--- a/src/components/Routes/Routes.test.tsx
+++ b/src/components/Routes/Routes.test.tsx
@@ -2,7 +2,6 @@ import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
-import { LogInTestId } from "components/LogIn";
 import { AdvancedSearchTestId } from "pages/AdvancedSearch";
 import { ControllersIndexTestId } from "pages/ControllersIndex/index";
 import { EntityDetailsTestId } from "pages/EntityDetails";
@@ -10,12 +9,7 @@ import { LogsTestId } from "pages/Logs/index";
 import { ModelsIndexTestId } from "pages/ModelsIndex/index";
 import { PermissionsTestId } from "pages/Permissions";
 import type { RootState } from "store/store";
-import {
-  configFactory,
-  controllerFeaturesFactory,
-  controllerFeaturesStateFactory,
-  generalStateFactory,
-} from "testing/factories/general";
+import { configFactory, generalStateFactory } from "testing/factories/general";
 import { rootStateFactory } from "testing/factories/root";
 import { changeURL } from "testing/utils";
 import urls from "urls";
@@ -88,29 +82,10 @@ describe("Routes", () => {
     ).toBeInTheDocument();
   });
 
-  it("displays login for audit logs", async () => {
-    state.general.controllerConnections = {};
+  it("displays audit logs for JAAS", async () => {
     if (state.general.config) {
       state.general.config.isJuju = false;
     }
-    const store = mockStore(state);
-    changeURL(urls.logs);
-    render(
-      <Provider store={store}>
-        <Routes />
-      </Provider>,
-    );
-    expect(
-      await screen.findByTestId(LogInTestId.LOGIN_FORM),
-    ).toBeInTheDocument();
-  });
-
-  it("handles audit logs if enabled", async () => {
-    state.general.controllerFeatures = controllerFeaturesStateFactory.build({
-      "wss://example.com/api": controllerFeaturesFactory.build({
-        auditLogs: true,
-      }),
-    });
     const store = mockStore(state);
     changeURL(urls.logs);
     render(
@@ -121,12 +96,10 @@ describe("Routes", () => {
     expect(await screen.findByTestId(LogsTestId.COMPONENT)).toBeInTheDocument();
   });
 
-  it("does not display audit logs if not enabled", async () => {
-    state.general.controllerFeatures = controllerFeaturesStateFactory.build({
-      "wss://example.com/api": controllerFeaturesFactory.build({
-        auditLogs: false,
-      }),
-    });
+  it("does not display audit logs for local Juju controllers", async () => {
+    if (state.general.config) {
+      state.general.config.isJuju = true;
+    }
     const store = mockStore(state);
     changeURL(urls.logs);
     render(
@@ -137,29 +110,10 @@ describe("Routes", () => {
     expect(screen.queryByTestId(LogsTestId.COMPONENT)).not.toBeInTheDocument();
   });
 
-  it("displays login for cross model queries", async () => {
-    state.general.controllerConnections = {};
+  it("displays cross model queries for JAAS", async () => {
     if (state.general.config) {
       state.general.config.isJuju = false;
     }
-    const store = mockStore(state);
-    changeURL(urls.search);
-    render(
-      <Provider store={store}>
-        <Routes />
-      </Provider>,
-    );
-    expect(
-      await screen.findByTestId(LogInTestId.LOGIN_FORM),
-    ).toBeInTheDocument();
-  });
-
-  it("handles cross model queries if enabled", async () => {
-    state.general.controllerFeatures = controllerFeaturesStateFactory.build({
-      "wss://example.com/api": controllerFeaturesFactory.build({
-        crossModelQueries: true,
-      }),
-    });
     const store = mockStore(state);
     changeURL(urls.search);
     render(
@@ -172,12 +126,10 @@ describe("Routes", () => {
     ).toBeInTheDocument();
   });
 
-  it("does not display cross model queries if not enabled", async () => {
-    state.general.controllerFeatures = controllerFeaturesStateFactory.build({
-      "wss://example.com/api": controllerFeaturesFactory.build({
-        crossModelQueries: false,
-      }),
-    });
+  it("does not display cross model queries for local Juju controllers", async () => {
+    if (state.general.config) {
+      state.general.config.isJuju = true;
+    }
     const store = mockStore(state);
     changeURL(urls.search);
     render(
@@ -190,29 +142,10 @@ describe("Routes", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("displays login for permissions", async () => {
-    state.general.controllerConnections = {};
+  it("displays permissions for JAAS", async () => {
     if (state.general.config) {
       state.general.config.isJuju = false;
     }
-    const store = mockStore(state);
-    changeURL(urls.permissions);
-    render(
-      <Provider store={store}>
-        <Routes />
-      </Provider>,
-    );
-    expect(
-      await screen.findByTestId(LogInTestId.LOGIN_FORM),
-    ).toBeInTheDocument();
-  });
-
-  it("handles permissions if enabled", async () => {
-    state.general.controllerFeatures = controllerFeaturesStateFactory.build({
-      "wss://example.com/api": controllerFeaturesFactory.build({
-        rebac: true,
-      }),
-    });
     const store = mockStore(state);
     changeURL(urls.permissions);
     render(
@@ -225,12 +158,10 @@ describe("Routes", () => {
     ).toBeInTheDocument();
   });
 
-  it("does not display permissions if not enabled", async () => {
-    state.general.controllerFeatures = controllerFeaturesStateFactory.build({
-      "wss://example.com/api": controllerFeaturesFactory.build({
-        rebac: false,
-      }),
-    });
+  it("does not display permissions for local Juju controllers", async () => {
+    if (state.general.config) {
+      state.general.config.isJuju = true;
+    }
     const store = mockStore(state);
     changeURL(urls.permissions);
     render(

--- a/src/layout/BaseLayout/BaseLayout.test.tsx
+++ b/src/layout/BaseLayout/BaseLayout.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, within } from "@testing-library/react";
 import { NavLink } from "react-router";
 
+import { LoadingSpinnerTestId } from "components/LoadingSpinner";
 import type { RootState } from "store/store";
 import { rootStateFactory } from "testing/factories/root";
 import { renderComponent } from "testing/utils";
@@ -47,7 +48,7 @@ describe("Base Layout", () => {
     expect(screen.getByText(Label.OFFLINE)).toBeInTheDocument();
   });
 
-  it("displays a message if the dashboard comes back on line", () => {
+  it("displays a message if the dashboard comes back online", () => {
     renderComponent(
       <BaseLayout>
         <p>foo</p>
@@ -102,5 +103,21 @@ describe("Base Layout", () => {
     );
     expect(document.querySelector(".secondary-navigation")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Settings" })).toBeInTheDocument();
+  });
+
+  it("can display a loading state", () => {
+    renderComponent(
+      <BaseLayout loading>
+        <p>children</p>
+      </BaseLayout>,
+      { state },
+    );
+    expect(
+      screen.getByTestId(LoadingSpinnerTestId.LOADING),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("children")).not.toBeInTheDocument();
+    expect(
+      document.querySelector(".secondary-navigation"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/layout/BaseLayout/BaseLayout.tsx
+++ b/src/layout/BaseLayout/BaseLayout.tsx
@@ -1,38 +1,27 @@
 import { ApplicationLayout, Panel } from "@canonical/react-components";
-import type { PanelProps } from "@canonical/react-components";
 import classNames from "classnames";
-import type { PropsWithChildren, ReactNode } from "react";
 import { Toaster } from "react-hot-toast";
 import { useSelector } from "react-redux";
 import { Link, useLocation } from "react-router";
 
 import FadeIn from "animations/FadeIn";
 import Banner from "components/Banner";
+import LoadingSpinner from "components/LoadingSpinner";
 import Logo from "components/Logo";
 import PrimaryNav from "components/PrimaryNav";
 import SecondaryNavigation from "components/SecondaryNavigation";
-import type { SecondaryNavigationProps } from "components/SecondaryNavigation/index";
 import { DARK_THEME } from "consts";
 import useOffline from "hooks/useOffline";
 import Panels from "panels";
 import { getIsJuju } from "store/general/selectors";
 import urls from "urls";
 
+import type { Props } from "./types";
 import { Label, TestId } from "./types";
-
-type Props = {
-  secondaryNav?: {
-    title: ReactNode;
-    items: SecondaryNavigationProps["items"];
-  };
-  status?: ReactNode;
-  title?: ReactNode;
-  titleClassName?: PanelProps["titleClassName"];
-  titleComponent?: PanelProps["titleComponent"];
-} & PropsWithChildren;
 
 const BaseLayout = ({
   children,
+  loading,
   secondaryNav,
   status,
   title,
@@ -84,24 +73,28 @@ const BaseLayout = ({
             "l-main__content--has-secondary-nav": hasSecondaryNav,
           })}
         >
-          {hasSecondaryNav ? (
-            <SecondaryNavigation
-              items={secondaryNav.items}
-              title={secondaryNav.title}
-            />
-          ) : null}
-          <Panel
-            className="l-main__panel"
-            data-testid={TestId.MAIN}
-            titleClassName={titleClassName}
-            titleComponent={titleComponent}
-            stickyHeader
-            title={title}
-          >
-            <div className="l-content" {...props}>
-              <FadeIn isActive={true}>{children}</FadeIn>
-            </div>
-          </Panel>
+          <>
+            {hasSecondaryNav && !loading ? (
+              <SecondaryNavigation
+                items={secondaryNav.items}
+                title={secondaryNav.title}
+              />
+            ) : null}
+            <Panel
+              className="l-main__panel"
+              data-testid={TestId.MAIN}
+              titleClassName={titleClassName}
+              titleComponent={titleComponent}
+              stickyHeader
+              title={title}
+            >
+              <div className="l-content" {...props}>
+                <FadeIn isActive={true}>
+                  {loading ? <LoadingSpinner /> : children}
+                </FadeIn>
+              </div>
+            </Panel>
+          </>
         </div>
       </ApplicationLayout>
       <Toaster

--- a/src/layout/BaseLayout/index.ts
+++ b/src/layout/BaseLayout/index.ts
@@ -1,2 +1,6 @@
 export { default } from "./BaseLayout";
-export { Label as BaseLayoutLabel, TestId as BaseLayoutTestId } from "./types";
+export {
+  Label as BaseLayoutLabel,
+  TestId as BaseLayoutTestId,
+  type Props as BaseLayoutProps,
+} from "./types";

--- a/src/layout/BaseLayout/types.ts
+++ b/src/layout/BaseLayout/types.ts
@@ -1,3 +1,8 @@
+import type { PanelProps } from "@canonical/react-components";
+import type { ReactNode, PropsWithChildren } from "react";
+
+import type { SecondaryNavigationProps } from "components/SecondaryNavigation";
+
 export enum TestId {
   MAIN = "main-children",
 }
@@ -7,3 +12,15 @@ export enum Label {
   MOBILE_MENU_OPEN_BUTTON = "Open menu",
   MOBILE_MENU_CLOSE_BUTTON = "Close menu",
 }
+
+export type Props = {
+  loading?: boolean;
+  secondaryNav?: {
+    title: ReactNode;
+    items: SecondaryNavigationProps["items"];
+  };
+  status?: ReactNode;
+  title?: ReactNode;
+  titleClassName?: PanelProps["titleClassName"];
+  titleComponent?: PanelProps["titleComponent"];
+} & PropsWithChildren;

--- a/src/pages/AdvancedSearch/AdvancedSearch.test.tsx
+++ b/src/pages/AdvancedSearch/AdvancedSearch.test.tsx
@@ -1,5 +1,6 @@
 import { screen } from "@testing-library/react";
 
+import { PageNotFoundLabel } from "pages/PageNotFound";
 import type { RootState } from "store/store";
 import { rootStateFactory } from "testing/factories";
 import {
@@ -30,6 +31,18 @@ describe("AdvancedSearch", () => {
       }),
     });
   });
+
+  it("shouldn't display the content if the feature is disabled", () => {
+    state.general.controllerFeatures = controllerFeaturesStateFactory.build({
+      "wss://controller.example.com": controllerFeaturesFactory.build({
+        crossModelQueries: false,
+      }),
+    });
+    renderComponent(<AdvancedSearch />, { state });
+    expect(screen.queryByTestId("search-form")).not.toBeInTheDocument();
+    expect(screen.getByText(PageNotFoundLabel.NOT_FOUND)).toBeInTheDocument();
+  });
+
   it("should render the page", () => {
     renderComponent(<AdvancedSearch />, { state });
     expect(screen.getByRole("heading")).toHaveTextContent("Advanced search");

--- a/src/pages/AdvancedSearch/AdvancedSearch.tsx
+++ b/src/pages/AdvancedSearch/AdvancedSearch.tsx
@@ -1,18 +1,29 @@
 import type { JSX } from "react";
 
+import CheckPermissions from "components/CheckPermissions";
 import BaseLayout from "layout/BaseLayout/BaseLayout";
+import { isCrossModelQueriesEnabled } from "store/general/selectors";
+import { useAppSelector } from "store/store";
 
 import ErrorsBlock from "./ErrorsBlock";
 import ResultsBlock from "./ResultsBlock";
 import SearchForm from "./SearchForm";
 import { TestId } from "./types";
 
-const AdvancedSearch = (): JSX.Element => (
-  <BaseLayout data-testid={TestId.COMPONENT} title="Advanced search">
-    <SearchForm />
-    <ErrorsBlock />
-    <ResultsBlock />
-  </BaseLayout>
-);
+const AdvancedSearch = (): JSX.Element => {
+  const crossModelQueriesEnabled = useAppSelector(isCrossModelQueriesEnabled);
+  return (
+    <CheckPermissions
+      allowed={crossModelQueriesEnabled}
+      data-testid={TestId.COMPONENT}
+    >
+      <BaseLayout data-testid={TestId.COMPONENT} title="Advanced search">
+        <SearchForm />
+        <ErrorsBlock />
+        <ResultsBlock />
+      </BaseLayout>
+    </CheckPermissions>
+  );
+};
 
 export default AdvancedSearch;

--- a/src/pages/Logs/Logs.test.tsx
+++ b/src/pages/Logs/Logs.test.tsx
@@ -79,7 +79,7 @@ describe("Logs", () => {
     vi.restoreAllMocks();
   });
 
-  it("doesn't display logs if the feature is disabled", async () => {
+  it("doesn't display logs if the feature is disabled", () => {
     state.general.controllerFeatures = controllerFeaturesStateFactory.build({
       "wss://controller.example.com": controllerFeaturesFactory.build({
         rebac: false,
@@ -90,7 +90,7 @@ describe("Logs", () => {
     expect(screen.getByText(PageNotFoundLabel.NOT_FOUND)).toBeInTheDocument();
   });
 
-  it("doesn't display logs if the user doesn't have permission", async () => {
+  it("doesn't display logs if the user doesn't have permission", () => {
     state.juju.rebacRelations = [
       rebacRelationFactory.build({
         tuple: relationshipTupleFactory.build({
@@ -112,7 +112,7 @@ describe("Logs", () => {
     expect(await screen.findAllByRole("cell")).toHaveLength(6);
   });
 
-  it("should display the actions", async () => {
+  it("should display the actions", () => {
     renderComponent(<Logs />, { state });
     expect(
       screen.getByRole("button", { name: AuditLogsTableActionsLabel.FILTER }),

--- a/src/pages/Logs/Logs.test.tsx
+++ b/src/pages/Logs/Logs.test.tsx
@@ -2,11 +2,22 @@ import { screen } from "@testing-library/react";
 import { vi } from "vitest";
 
 import { AuditLogsTableActionsLabel } from "components/AuditLogsTable/AuditLogsTableActions";
+import { JIMMRelation, JIMMTarget } from "juju/jimm/JIMMV4";
+import { PageNotFoundLabel } from "pages/PageNotFound";
 import type { RootState } from "store/store";
 import { rootStateFactory, jujuStateFactory } from "testing/factories";
-import { generalStateFactory, configFactory } from "testing/factories/general";
+import {
+  generalStateFactory,
+  configFactory,
+  controllerFeaturesFactory,
+  controllerFeaturesStateFactory,
+} from "testing/factories/general";
 import { auditEventFactory } from "testing/factories/juju/jimm";
-import { auditEventsStateFactory } from "testing/factories/juju/juju";
+import {
+  auditEventsStateFactory,
+  rebacRelationFactory,
+  relationshipTupleFactory,
+} from "testing/factories/juju/juju";
 import { renderComponent } from "testing/utils";
 
 import Logs from "./Logs";
@@ -19,6 +30,7 @@ describe("Logs", () => {
       general: generalStateFactory.build({
         config: configFactory.build({
           controllerAPIEndpoint: "wss://example.com/api",
+          isJuju: false,
         }),
         controllerConnections: {
           "wss://example.com/api": {
@@ -30,18 +42,68 @@ describe("Logs", () => {
             },
           },
         },
+        controllerFeatures: controllerFeaturesStateFactory.build({
+          "wss://example.com/api": controllerFeaturesFactory.build({
+            auditLogs: true,
+          }),
+        }),
       }),
       juju: jujuStateFactory.build({
         auditEvents: auditEventsStateFactory.build({
           items: [auditEventFactory.build()],
           loaded: true,
         }),
+        rebacRelations: [
+          rebacRelationFactory.build({
+            tuple: relationshipTupleFactory.build({
+              object: "user-eggman@external",
+              relation: JIMMRelation.AUDIT_LOG_VIEWER,
+              target_object: JIMMTarget.JIMM_CONTROLLER,
+            }),
+            allowed: true,
+          }),
+          rebacRelationFactory.build({
+            tuple: relationshipTupleFactory.build({
+              object: "user-eggman@external",
+              relation: JIMMRelation.ADMINISTRATOR,
+              target_object: JIMMTarget.JIMM_CONTROLLER,
+            }),
+            allowed: true,
+          }),
+        ],
       }),
     });
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it("doesn't display logs if the feature is disabled", async () => {
+    state.general.controllerFeatures = controllerFeaturesStateFactory.build({
+      "wss://controller.example.com": controllerFeaturesFactory.build({
+        rebac: false,
+      }),
+    });
+    renderComponent(<Logs />, { state });
+    expect(screen.queryByText("Audit logs")).not.toBeInTheDocument();
+    expect(screen.getByText(PageNotFoundLabel.NOT_FOUND)).toBeInTheDocument();
+  });
+
+  it("doesn't display logs if the user doesn't have permission", async () => {
+    state.juju.rebacRelations = [
+      rebacRelationFactory.build({
+        tuple: relationshipTupleFactory.build({
+          object: "user-eggman@external",
+          relation: JIMMRelation.AUDIT_LOG_VIEWER,
+          target_object: JIMMTarget.JIMM_CONTROLLER,
+        }),
+        allowed: false,
+      }),
+    ];
+    renderComponent(<Logs />, { state });
+    expect(screen.queryByText("Audit logs")).not.toBeInTheDocument();
+    expect(screen.getByText(PageNotFoundLabel.NOT_FOUND)).toBeInTheDocument();
   });
 
   it("should render the page", async () => {

--- a/src/pages/Logs/Logs.tsx
+++ b/src/pages/Logs/Logs.tsx
@@ -3,17 +3,28 @@ import type { JSX } from "react";
 import ActionBar from "components/ActionBar";
 import AuditLogsTable from "components/AuditLogsTable/AuditLogsTable";
 import AuditLogsTableActions from "components/AuditLogsTable/AuditLogsTableActions";
+import CheckPermissions from "components/CheckPermissions";
+import { useAuditLogsPermitted } from "juju/api-hooks/permissions";
 import BaseLayout from "layout/BaseLayout/BaseLayout";
 
 import { TestId } from "./types";
 
-const Logs = (): JSX.Element => (
-  <BaseLayout data-testid={TestId.COMPONENT} title="Audit logs">
-    <ActionBar>
-      <AuditLogsTableActions />
-    </ActionBar>
-    <AuditLogsTable />
-  </BaseLayout>
-);
+const Logs = (): JSX.Element => {
+  const { loading, permitted } = useAuditLogsPermitted();
+  return (
+    <CheckPermissions
+      allowed={permitted}
+      data-testid={TestId.COMPONENT}
+      loading={loading}
+    >
+      <BaseLayout data-testid={TestId.COMPONENT} title="Audit logs">
+        <ActionBar>
+          <AuditLogsTableActions />
+        </ActionBar>
+        <AuditLogsTable />
+      </BaseLayout>
+    </CheckPermissions>
+  );
+};
 
 export default Logs;

--- a/src/pages/PageNotFound/PageNotFound.tsx
+++ b/src/pages/PageNotFound/PageNotFound.tsx
@@ -2,15 +2,16 @@ import { Link } from "react-router";
 
 import NotFound from "components/NotFound";
 import useWindowTitle from "hooks/useWindowTitle";
+import type { BaseLayoutProps } from "layout/BaseLayout";
 import BaseLayout from "layout/BaseLayout";
 import urls from "urls";
 
 import { Label } from "./types";
 
-export default function PageNotFound() {
+export default function PageNotFound(props: Partial<BaseLayoutProps>) {
   useWindowTitle("404 - Page not found");
   return (
-    <BaseLayout>
+    <BaseLayout {...props}>
       <div className="p-strip">
         <div className="row">
           <NotFound message={Label.NOT_FOUND}>

--- a/src/pages/Permissions/Permissions.tsx
+++ b/src/pages/Permissions/Permissions.tsx
@@ -5,9 +5,13 @@ import { useRef } from "react";
 import { NavLink } from "react-router";
 
 import { axiosInstance } from "axios-instance";
+import CheckPermissions from "components/CheckPermissions";
 import useLogout from "hooks/useLogout";
+import { useIsJIMMAdmin } from "juju/api-hooks/permissions";
 import { endpoints } from "juju/jimm/api";
 import BaseLayout from "layout/BaseLayout/BaseLayout";
+import { isReBACEnabled } from "store/general/selectors";
+import { useAppSelector } from "store/store";
 import { rebacURLS } from "urls";
 
 import { Label, TestId } from "./types";
@@ -37,6 +41,8 @@ const navItems = [
 
 const Permissions = (): JSX.Element => {
   const logout = useLogout();
+  const rebacEnabled = useAppSelector(isReBACEnabled);
+  const { permitted, loading } = useIsJIMMAdmin();
 
   useRef(
     axiosInstance.interceptors.response.use(
@@ -59,20 +65,26 @@ const Permissions = (): JSX.Element => {
   );
 
   return (
-    <BaseLayout
+    <CheckPermissions
+      allowed={rebacEnabled && permitted}
       data-testid={TestId.COMPONENT}
-      secondaryNav={{
-        title: "Permissions",
-        items: [
-          {
-            className: "menu-one",
-            items: navItems,
-          },
-        ],
-      }}
+      loading={loading}
     >
-      <ReBACAdmin axiosInstance={axiosInstance} asidePanelId="app-layout" />
-    </BaseLayout>
+      <BaseLayout
+        data-testid={TestId.COMPONENT}
+        secondaryNav={{
+          title: "Permissions",
+          items: [
+            {
+              className: "menu-one",
+              items: navItems,
+            },
+          ],
+        }}
+      >
+        <ReBACAdmin axiosInstance={axiosInstance} asidePanelId="app-layout" />
+      </BaseLayout>
+    </CheckPermissions>
   );
 };
 


### PR DESCRIPTION
## Done

- Correctly disable routes for disabled features.
- Check user permissions if the feature is enabled.

## QA

- Connect to a local Juju controller.
- Visit one of the disabled features by typing the URL e.g. /search or /logs or /permissions (these won't be in the side nav).
- It should not require you to log in and instead display a 404 page.
- Connect to JIMM.
- Make sure rebac is enabled with `?enable-flag=rebac`
- You should see the search, logs and permissions nav items.
- Clicking on them should display the pages.
- Enter `?disable-flag=rebac` and then visit /permissions
- It should display a 404 page.

## Details

https://warthogs.atlassian.net/browse/WD-19883
