### PR TITLE
fix: unit link generation

### DIFF
--- a/src/pages/AdvancedSearch/CodeSnippetBlock/CodeSnippetBlock.test.tsx
+++ b/src/pages/AdvancedSearch/CodeSnippetBlock/CodeSnippetBlock.test.tsx
@@ -214,7 +214,7 @@ describe("CodeSnippetBlock", () => {
         userName: "eggman@external",
         modelName: "test-model",
         appName: "easyrsa",
-        unitId: "0",
+        unitId: "easyrsa-0",
       }),
     );
   });

--- a/src/pages/AdvancedSearch/CodeSnippetBlock/Label/Label.test.tsx
+++ b/src/pages/AdvancedSearch/CodeSnippetBlock/Label/Label.test.tsx
@@ -67,7 +67,7 @@ describe("Label", () => {
         userName: "eggman@external",
         modelName: "test-model",
         appName: "easyrsa",
-        unitId: "0",
+        unitId: "easyrsa-0",
       }),
     );
   });
@@ -92,7 +92,7 @@ describe("Label", () => {
         userName: "eggman@external",
         modelName: "test-model",
         appName: "easyrsa",
-        unitId: "0",
+        unitId: "easyrsa-0",
       }),
     );
   });

--- a/src/pages/AdvancedSearch/CodeSnippetBlock/Label/Label.tsx
+++ b/src/pages/AdvancedSearch/CodeSnippetBlock/Label/Label.tsx
@@ -32,7 +32,9 @@ const Label = ({ keyPath }: Props): ReturnType<LabelRenderer> => {
   }
   // Link units[unit-key] to unit in model details.
   if (parentKey === "units" && typeof currentKey === "string") {
-    const [appName, unitId] = currentKey.split("/");
+    // NOTE: See `generateUnitURL@tableRows.tsx` for a similar implementation
+    const [appName, index] = currentKey.split("/");
+    const unitId = `${appName}-${index}`;
     return (
       <UnitLink uuid={modelUUID} appName={appName} unitId={unitId}>
         {currentKey}:

--- a/src/pages/EntityDetails/Unit/Unit.test.tsx
+++ b/src/pages/EntityDetails/Unit/Unit.test.tsx
@@ -16,6 +16,7 @@ import { renderComponent } from "testing/utils";
 import urls from "urls";
 
 import Unit from "./Unit";
+import { Label } from "./types";
 
 vi.mock("components/Topology", () => {
   const Topology = () => <div className="topology"></div>;
@@ -94,5 +95,30 @@ describe("Unit", () => {
     expect(
       document.querySelector(".entity-details__machines"),
     ).not.toBeInTheDocument();
+  });
+
+  it("handles invalid unit", async () => {
+    renderComponent(<Unit />, {
+      path: urls.model.unit(null),
+      url: urls.model.unit({
+        appName: "etcd",
+        modelName: "canonical-kubernetes",
+        unitId: "0",
+        userName: "eggman@external",
+      }),
+    });
+    expect(
+      screen.getByRole("heading", { name: Label.NOT_FOUND }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: Label.VIEW_ALL_UNITS }),
+    ).toHaveAttribute(
+      "href",
+      urls.model.app.index({
+        appName: "etcd",
+        modelName: "canonical-kubernetes",
+        userName: "eggman@external",
+      }),
+    );
   });
 });

--- a/src/pages/EntityDetails/Unit/index.ts
+++ b/src/pages/EntityDetails/Unit/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./Unit";
+export { Label as UnitLabel } from "./types";

--- a/src/pages/EntityDetails/Unit/types.ts
+++ b/src/pages/EntityDetails/Unit/types.ts
@@ -1,0 +1,4 @@
+export enum Label {
+  NOT_FOUND = "Unit not found",
+  VIEW_ALL_UNITS = "View all units",
+}

--- a/src/pages/EntityDetails/_entity-details.scss
+++ b/src/pages/EntityDetails/_entity-details.scss
@@ -50,7 +50,10 @@
 
     @include desktop {
       gap: 1rem;
-      grid-template-columns: 230px 1fr;
+
+      &:not(:has(> .full-width)) {
+        grid-template-columns: 230px 1fr;
+      }
     }
 
     @include mobile {


### PR DESCRIPTION
## Done

- correctly generate unit links in advanced search
- create not found page for units instead of crashing

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/search?q=.
- Expand root -> 0 -> units, click on a unit (eg `source/4`)
- Should correctly navigate to source page
- Navigate to junk unit page (add something to end of current URL) for not found page

## Details

- WD-19966
- close #1869 

## Screenshots

https://github.com/user-attachments/assets/14059413-baca-44a3-b337-ac320904d38b

