### PR TITLE
fix: show error on initial model error

### DIFF
--- a/src/pages/ModelsIndex/ModelsIndex.test.tsx
+++ b/src/pages/ModelsIndex/ModelsIndex.test.tsx
@@ -19,7 +19,7 @@ import { rootStateFactory } from "testing/factories/root";
 import { renderComponent } from "testing/utils";
 
 import ModelsIndex from "./ModelsIndex";
-import { Label } from "./types";
+import { Label, TestId } from "./types";
 
 describe("Models Index page", () => {
   let state: RootState;
@@ -185,6 +185,17 @@ describe("Models Index page", () => {
     state.juju.modelsError = "Oops!";
     renderComponent(<ModelsIndex />, { state });
     expect(screen.getByText(/Oops!/)).toBeInTheDocument();
+  });
+
+  it("clears spinner if initial error occurs", async () => {
+    state.juju.modelsLoaded = false;
+    state.juju.modelsError = "An error occured";
+    renderComponent(<ModelsIndex />, { state });
+    expect(
+      screen.queryByTestId(LoadingSpinnerTestId.LOADING),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(/An error occured/)).toBeInTheDocument();
+    expect(screen.getByTestId(TestId.COMPONENT).childElementCount).toEqual(1);
   });
 
   it("should refresh the window when pressing the button in error notification", async () => {

--- a/src/pages/ModelsIndex/ModelsIndex.tsx
+++ b/src/pages/ModelsIndex/ModelsIndex.tsx
@@ -93,33 +93,35 @@ export default function Models() {
 
   const modelCount = blocked + alert + running;
 
-  let content: ReactNode;
-  if (!modelsLoaded) {
-    return <LoadingSpinner />;
-  } else if (!hasSomeModels) {
-    content = (
-      <div className="models">
-        <h3>{Label.NOT_FOUND}</h3>
-        <p>
-          Learn about{" "}
-          <a href="https://juju.is/docs/olm/manage-models#heading--add-a-model">
-            adding models
-          </a>{" "}
-          or{" "}
-          <a href="https://juju.is/docs/olm/manage-users#heading--model-access">
-            granting access
-          </a>{" "}
-          to existing models.
-        </p>
-      </div>
-    );
-  } else {
-    content = (
-      <div className="models">
-        <ChipGroup chips={{ blocked, alert, running }} />
-        <ModelTableList groupedBy={queryParams.groupedby} filters={filters} />
-      </div>
-    );
+  let content: ReactNode = <></>;
+  if (!modelsError) {
+    if (!modelsLoaded) {
+      return <LoadingSpinner />;
+    } else if (!hasSomeModels) {
+      content = (
+        <div className="models">
+          <h3>{Label.NOT_FOUND}</h3>
+          <p>
+            Learn about{" "}
+            <a href="https://juju.is/docs/olm/manage-models#heading--add-a-model">
+              adding models
+            </a>{" "}
+            or{" "}
+            <a href="https://juju.is/docs/olm/manage-users#heading--model-access">
+              granting access
+            </a>{" "}
+            to existing models.
+          </p>
+        </div>
+      );
+    } else {
+      content = (
+        <div className="models">
+          <ChipGroup chips={{ blocked, alert, running }} />
+          <ModelTableList groupedBy={queryParams.groupedby} filters={filters} />
+        </div>
+      );
+    }
   }
 
   return (


### PR DESCRIPTION

## Done

- previously `modelsLoaded` took precedence over checking `modelError`
- includes test to ensure spinner is hidden and no other content is displayed on the page

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Apply patch to `model-poller` (see below)
- Open dashboard

<details>
<summary>Patch with error</summary>

```patch
diff --git a/src/store/middleware/model-poller.ts b/src/store/middleware/model-poller.ts
index 39d9b6e6..7012da47 100644
--- a/src/store/middleware/model-poller.ts
+++ b/src/store/middleware/model-poller.ts
@@ -217,6 +217,7 @@ export const modelPollerMiddleware: Middleware<
               const models = await conn.facades.modelManager?.listModels({
                 tag: identity,
               });
+              throw new Error("model loading failure");
               if (models) {
                 reduxStore.dispatch(
                   jujuActions.updateModelList({ models, wsControllerURL }),
```

</details>

## Details

- Close #1865
- WD-19967

## Screenshots

![image](https://github.com/user-attachments/assets/91cb35a9-9a33-49d3-bc6e-a436e5755b1a)
