### PR TITLE
refactor(tests): migrate test queries from rebac-admin

### DIFF
--- a/src/components/AuditLogsTable/AuditLogsTable.test.tsx
+++ b/src/components/AuditLogsTable/AuditLogsTable.test.tsx
@@ -1,4 +1,4 @@
-import { screen, within } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import { add } from "date-fns";
 import { vi } from "vitest";
 
@@ -9,6 +9,7 @@ import { rootStateFactory, jujuStateFactory } from "testing/factories";
 import { configFactory, generalStateFactory } from "testing/factories/general";
 import { auditEventFactory } from "testing/factories/juju/jimm";
 import { auditEventsStateFactory } from "testing/factories/juju/juju";
+import { customWithin } from "testing/queries/within";
 import { renderComponent } from "testing/utils";
 import urls from "urls";
 
@@ -112,18 +113,29 @@ describe("AuditLogsTable", () => {
       }),
     ];
     renderComponent(<AuditLogsTable />, { state });
-    expect(await screen.findByRole("table")).toBeInTheDocument();
+    const table = await screen.findByRole("table");
+    expect(table).toBeInTheDocument();
     expect(
       screen.queryByTestId(LoadingSpinnerTestId.LOADING),
     ).not.toBeInTheDocument();
-    const row = screen.getAllByRole("row")[1];
-    const cells = within(row).getAllByRole("cell");
-    expect(cells[0]).toHaveTextContent("eggman");
-    expect(cells[1]).toHaveTextContent("microk8s");
-    expect(cells[2]).toHaveTextContent("1 day ago");
-    expect(cells[3]).toHaveTextContent("ModelManager");
-    expect(cells[4]).toHaveTextContent("AddModel");
-    expect(cells[5]).toHaveTextContent("3");
+    expect(customWithin(table).getCellByHeader("user")).toHaveTextContent(
+      "eggman",
+    );
+    expect(customWithin(table).getCellByHeader("model")).toHaveTextContent(
+      "microk8s",
+    );
+    expect(customWithin(table).getCellByHeader("time")).toHaveTextContent(
+      "1 day ago",
+    );
+    expect(
+      customWithin(table).getCellByHeader("facade name"),
+    ).toHaveTextContent("ModelManager");
+    expect(
+      customWithin(table).getCellByHeader("facade method"),
+    ).toHaveTextContent("AddModel");
+    expect(
+      customWithin(table).getCellByHeader("facade version"),
+    ).toHaveTextContent("3");
   });
 
   it("should display filters", async () => {

--- a/src/pages/ModelsIndex/ModelsIndex.test.tsx
+++ b/src/pages/ModelsIndex/ModelsIndex.test.tsx
@@ -190,10 +190,10 @@ describe("Models Index page", () => {
   it("clears spinner if initial error occurs", async () => {
     state.juju.modelsLoaded = false;
     state.juju.modelsError = "An error occured";
-    renderComponent(<ModelsIndex />, { state });
-    expect(
-      screen.queryByTestId(LoadingSpinnerTestId.LOADING),
-    ).not.toBeInTheDocument();
+    const {
+      result: { queryAllSpinnersByLabel },
+    } = renderComponent(<ModelsIndex />, { state });
+    expect(queryAllSpinnersByLabel("Loading")).toHaveLength(0);
     expect(screen.getByText(/An error occured/)).toBeInTheDocument();
     expect(screen.getByTestId(TestId.COMPONENT).childElementCount).toEqual(1);
   });

--- a/src/pages/ModelsIndex/ModelsIndex.tsx
+++ b/src/pages/ModelsIndex/ModelsIndex.tsx
@@ -93,7 +93,7 @@ export default function Models() {
 
   const modelCount = blocked + alert + running;
 
-  let content: ReactNode = <></>;
+  let content: ReactNode = null;
   if (!modelsError) {
     if (!modelsLoaded) {
       return <LoadingSpinner />;

--- a/src/panels/CharmsAndActionsPanel/CharmsAndActionsPanel.test.tsx
+++ b/src/panels/CharmsAndActionsPanel/CharmsAndActionsPanel.test.tsx
@@ -63,11 +63,9 @@ describe("CharmsAndActionsPanel", () => {
       Promise.resolve([]),
     );
     const {
-      result: { container },
+      result: { getSpinnerByLabel },
     } = renderComponent(<CharmsAndActionsPanel />, { path, url, state });
-    expect(
-      container.querySelector(".l-aside")?.querySelector(".p-icon--spinner"),
-    ).toBeVisible();
+    expect(getSpinnerByLabel("Loading")).toBeVisible();
     await waitFor(() => {
       expect(getCharmsURLFromApplications).toHaveBeenCalledTimes(1);
     });

--- a/src/panels/ConfigPanel/ConfigPanel.test.tsx
+++ b/src/panels/ConfigPanel/ConfigPanel.test.tsx
@@ -719,7 +719,10 @@ describe("ConfigPanel", () => {
         loaded: true,
       }),
     });
-    const { router } = renderComponent(<ConfigPanel />, { state, path, url });
+    const {
+      router,
+      result: { getNotificationByText },
+    } = renderComponent(<ConfigPanel />, { state, path, url });
     await userEvent.type(
       within(await screen.findByTestId("email")).getByRole("textbox"),
       "secret:aabbccdd",
@@ -740,8 +743,8 @@ describe("ConfigPanel", () => {
     expect(router.state.location.search).toBe(`?${params.toString()}`);
     await waitFor(() => {
       expect(
-        document.querySelector(".p-notification--negative"),
-      ).toHaveTextContent(ConfirmationDialogLabel.GRANT_ERROR);
+        getNotificationByText(ConfirmationDialogLabel.GRANT_ERROR),
+      ).toBeInTheDocument();
     });
   });
 

--- a/src/testing/queries/index.ts
+++ b/src/testing/queries/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./queries";

--- a/src/testing/queries/notifications.ts
+++ b/src/testing/queries/notifications.ts
@@ -1,0 +1,60 @@
+import { NotificationSeverity } from "@canonical/react-components";
+import { buildQueries, within } from "@testing-library/dom";
+
+type Options = {
+  appearance?: "banner" | "toast";
+  severity?: string;
+};
+
+export const queryAllNotificationsByText = (
+  container: HTMLElement,
+  text: string,
+  {
+    appearance = "banner",
+    severity = NotificationSeverity.NEGATIVE,
+  }: Options = {},
+) => {
+  const messages = within(container).queryAllByText(text);
+  const notifications: HTMLElement[] = [];
+  messages.forEach((message) => {
+    const notification: HTMLElement | null = message.closest(
+      appearance === "banner"
+        ? `.p-notification--${severity}`
+        : `.toast-card[data-type="${severity}"]`,
+    );
+    if (message && notification) {
+      notifications.push(notification);
+    }
+  });
+  return notifications;
+};
+
+const [
+  queryNotificationByText,
+  getAllNotificationsByText,
+  getNotificationByText,
+  findAllNotificationsByText,
+  findNotificationByText,
+] = buildQueries(
+  queryAllNotificationsByText,
+  (
+    _element,
+    text,
+    { appearance = "banner", severity = NotificationSeverity.NEGATIVE } = {},
+  ) =>
+    `More than one ${appearance} notification with severity "${severity}" and text "${text}" was found.`,
+  (
+    _element,
+    text,
+    { appearance = "banner", severity = NotificationSeverity.NEGATIVE } = {},
+  ) =>
+    `A ${appearance} notification with severity "${severity}" and text "${text}" was not found.`,
+);
+
+export {
+  findAllNotificationsByText,
+  findNotificationByText,
+  getAllNotificationsByText,
+  getNotificationByText,
+  queryNotificationByText,
+};

--- a/src/testing/queries/queries.ts
+++ b/src/testing/queries/queries.ts
@@ -1,0 +1,14 @@
+import { queries } from "@testing-library/react";
+
+import * as notificationQueries from "./notifications";
+import * as spinnerQueries from "./spinners";
+import * as tableQueries from "./tables";
+
+const customQueries = {
+  ...notificationQueries,
+  ...queries,
+  ...spinnerQueries,
+  ...tableQueries,
+};
+
+export default customQueries;

--- a/src/testing/queries/spinners.ts
+++ b/src/testing/queries/spinners.ts
@@ -1,0 +1,37 @@
+import { buildQueries, within } from "@testing-library/dom";
+
+export const queryAllSpinnersByLabel = (
+  container: HTMLElement,
+  label: string,
+) => {
+  const labels = within(container).queryAllByText(label);
+  const spinners: HTMLElement[] = [];
+  labels.forEach((text) => {
+    const spinner: HTMLElement | null = text?.closest('[role="alert"]') ?? null;
+    const icon = spinner?.querySelector(".p-icon--spinner");
+    if (spinner && icon) {
+      spinners.push(spinner);
+    }
+  });
+  return spinners;
+};
+
+const [
+  querySpinnerByLabel,
+  getAllSpinnersByLabel,
+  getSpinnerByLabel,
+  findAllSpinnersByLabel,
+  findSpinnerByLabel,
+] = buildQueries(
+  queryAllSpinnersByLabel,
+  (_element, label) => `More than one Spinner with label "${label}" was found.`,
+  (_element, label) => `A Spinner with label "${label}" was not found.`,
+);
+
+export {
+  findAllSpinnersByLabel,
+  findSpinnerByLabel,
+  getAllSpinnersByLabel,
+  getSpinnerByLabel,
+  querySpinnerByLabel,
+};

--- a/src/testing/queries/tables.ts
+++ b/src/testing/queries/tables.ts
@@ -1,0 +1,21 @@
+import { getAllByRole, queryHelpers } from "@testing-library/dom";
+
+export const getCellByHeader = (container: HTMLElement, header: string) => {
+  const table = container.closest("table");
+  if (!table) {
+    throw queryHelpers.getElementError(
+      "This row doesn't appear within a table.",
+      container,
+    );
+  }
+  const th = getAllByRole(table, "columnheader", { name: header });
+  if (th.length > 1) {
+    throw queryHelpers.getElementError(
+      `Found multiple elements with columnheader "${header}".`,
+      container,
+    );
+  }
+  const index = getAllByRole(table, "columnheader").indexOf(th[0]);
+  const result = getAllByRole(container, "cell");
+  return result[index];
+};

--- a/src/testing/queries/within.ts
+++ b/src/testing/queries/within.ts
@@ -1,0 +1,5 @@
+import { within } from "@testing-library/react";
+
+import queries from "./queries";
+
+export const customWithin = (element: HTMLElement) => within(element, queries);

--- a/src/testing/utils.tsx
+++ b/src/testing/utils.tsx
@@ -17,6 +17,8 @@ import configureStore from "redux-mock-store";
 import type { RootState } from "store/store";
 import { rootStateFactory } from "testing/factories";
 
+import queries from "./queries";
+
 type Router = ReturnType<typeof createMemoryRouter>;
 
 type OptionsWithStore = {
@@ -113,6 +115,7 @@ export const renderComponent = (
     options,
   );
   const result = render(<Component />, {
+    queries,
     wrapper: Wrapper,
   });
   return { router, result, store };
@@ -129,6 +132,7 @@ export const renderWrappedHook = <Result, Props>(
   let router: Router | null = null;
   let store: OptionsWithStore["store"] | null = null;
   const { result } = renderHook(hook, {
+    queries,
     wrapper: ({ children }: PropsWithChildren) => {
       const {
         router: returnedRouter,


### PR DESCRIPTION
## Done

- copy queries into `src/testing`
- update a handful of tests to use each available query
- includes suggestion from #1878 which was missed in original PR

