### PR TITLE
refactor: rename rebac relation state

### DIFF
--- a/src/components/PrimaryNav/PrimaryNav.test.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.test.tsx
@@ -18,7 +18,7 @@ import {
   jujuStateFactory,
   modelDataApplicationFactory,
   modelDataFactory,
-  rebacRelationFactory,
+  rebacAllowedFactory,
   relationshipTupleFactory,
 } from "testing/factories/juju/juju";
 import { rootStateFactory } from "testing/factories/root";
@@ -210,24 +210,26 @@ describe("PrimaryNav", () => {
         }),
       }),
       juju: jujuStateFactory.build({
-        rebacRelations: [
-          rebacRelationFactory.build({
-            tuple: relationshipTupleFactory.build({
-              object: "user-eggman@external",
-              relation: JIMMRelation.AUDIT_LOG_VIEWER,
-              target_object: JIMMTarget.JIMM_CONTROLLER,
+        rebac: {
+          allowed: [
+            rebacAllowedFactory.build({
+              tuple: relationshipTupleFactory.build({
+                object: "user-eggman@external",
+                relation: JIMMRelation.AUDIT_LOG_VIEWER,
+                target_object: JIMMTarget.JIMM_CONTROLLER,
+              }),
+              allowed: true,
             }),
-            allowed: true,
-          }),
-          rebacRelationFactory.build({
-            tuple: relationshipTupleFactory.build({
-              object: "user-eggman@external",
-              relation: JIMMRelation.ADMINISTRATOR,
-              target_object: JIMMTarget.JIMM_CONTROLLER,
+            rebacAllowedFactory.build({
+              tuple: relationshipTupleFactory.build({
+                object: "user-eggman@external",
+                relation: JIMMRelation.ADMINISTRATOR,
+                target_object: JIMMTarget.JIMM_CONTROLLER,
+              }),
+              allowed: true,
             }),
-            allowed: true,
-          }),
-        ],
+          ],
+        },
       }),
     });
     renderComponent(<PrimaryNav />, { state });
@@ -260,24 +262,26 @@ describe("PrimaryNav", () => {
         }),
       }),
       juju: jujuStateFactory.build({
-        rebacRelations: [
-          rebacRelationFactory.build({
-            tuple: relationshipTupleFactory.build({
-              object: "user-eggman@external",
-              relation: JIMMRelation.AUDIT_LOG_VIEWER,
-              target_object: JIMMTarget.JIMM_CONTROLLER,
+        rebac: {
+          allowed: [
+            rebacAllowedFactory.build({
+              tuple: relationshipTupleFactory.build({
+                object: "user-eggman@external",
+                relation: JIMMRelation.AUDIT_LOG_VIEWER,
+                target_object: JIMMTarget.JIMM_CONTROLLER,
+              }),
+              allowed: true,
             }),
-            allowed: true,
-          }),
-          rebacRelationFactory.build({
-            tuple: relationshipTupleFactory.build({
-              object: "user-eggman@external",
-              relation: JIMMRelation.ADMINISTRATOR,
-              target_object: JIMMTarget.JIMM_CONTROLLER,
+            rebacAllowedFactory.build({
+              tuple: relationshipTupleFactory.build({
+                object: "user-eggman@external",
+                relation: JIMMRelation.ADMINISTRATOR,
+                target_object: JIMMTarget.JIMM_CONTROLLER,
+              }),
+              allowed: true,
             }),
-            allowed: true,
-          }),
-        ],
+          ],
+        },
       }),
     });
     renderComponent(<PrimaryNav />, { state });
@@ -358,16 +362,18 @@ it("should not show Permissions navigation button if the controller doesn't supp
       }),
     }),
     juju: jujuStateFactory.build({
-      rebacRelations: [
-        rebacRelationFactory.build({
-          tuple: relationshipTupleFactory.build({
-            object: "user-eggman@external",
-            relation: JIMMRelation.ADMINISTRATOR,
-            target_object: JIMMTarget.JIMM_CONTROLLER,
+      rebac: {
+        allowed: [
+          rebacAllowedFactory.build({
+            tuple: relationshipTupleFactory.build({
+              object: "user-eggman@external",
+              relation: JIMMRelation.ADMINISTRATOR,
+              target_object: JIMMTarget.JIMM_CONTROLLER,
+            }),
+            allowed: true,
           }),
-          allowed: true,
-        }),
-      ],
+        ],
+      },
     }),
   });
   renderComponent(<PrimaryNav />, { state });
@@ -395,16 +401,18 @@ it("should show Permissions navigation button if the controller supports it", ()
       }),
     }),
     juju: jujuStateFactory.build({
-      rebacRelations: [
-        rebacRelationFactory.build({
-          tuple: relationshipTupleFactory.build({
-            object: "user-eggman@external",
-            relation: JIMMRelation.ADMINISTRATOR,
-            target_object: JIMMTarget.JIMM_CONTROLLER,
+      rebac: {
+        allowed: [
+          rebacAllowedFactory.build({
+            tuple: relationshipTupleFactory.build({
+              object: "user-eggman@external",
+              relation: JIMMRelation.ADMINISTRATOR,
+              target_object: JIMMTarget.JIMM_CONTROLLER,
+            }),
+            allowed: true,
           }),
-          allowed: true,
-        }),
-      ],
+        ],
+      },
     }),
   });
   renderComponent(<PrimaryNav />, { state });

--- a/src/hooks/useCanConfigureModel.test.tsx
+++ b/src/hooks/useCanConfigureModel.test.tsx
@@ -22,7 +22,7 @@ import {
   modelDataFactory,
   modelDataInfoFactory,
   modelListInfoFactory,
-  rebacRelationFactory,
+  rebacAllowedFactory,
 } from "testing/factories/juju/juju";
 import { modelWatcherModelDataFactory } from "testing/factories/juju/model-watcher";
 import { renderWrappedHook } from "testing/utils";
@@ -182,8 +182,8 @@ describe("useModelStatus", () => {
     if (state.general.config) {
       state.general.config.isJuju = false;
     }
-    state.juju.rebacRelations = [
-      rebacRelationFactory.build({
+    state.juju.rebac.allowed = [
+      rebacAllowedFactory.build({
         tuple: {
           object: "user-eggman@external",
           relation: JIMMRelation.WRITER,
@@ -202,8 +202,8 @@ describe("useModelStatus", () => {
     if (state.general.config) {
       state.general.config.isJuju = false;
     }
-    state.juju.rebacRelations = [
-      rebacRelationFactory.build({
+    state.juju.rebac.allowed = [
+      rebacAllowedFactory.build({
         tuple: {
           object: "user-eggman@external",
           relation: JIMMRelation.WRITER,

--- a/src/juju/api-hooks/permissions.test.tsx
+++ b/src/juju/api-hooks/permissions.test.tsx
@@ -13,7 +13,7 @@ import {
   controllerFeaturesStateFactory,
   authUserInfoFactory,
 } from "testing/factories/general";
-import { rebacRelationFactory } from "testing/factories/juju/juju";
+import { rebacAllowedFactory } from "testing/factories/juju/juju";
 import { ComponentProviders } from "testing/utils";
 
 import {
@@ -73,8 +73,8 @@ describe("useCheckPermissions", () => {
       relation: JIMMRelation.MEMBER,
       target_object: "group-admins",
     };
-    state.juju.rebacRelations = [
-      rebacRelationFactory.build({
+    state.juju.rebac.allowed = [
+      rebacAllowedFactory.build({
         tuple: tuple,
         loading: true,
         loaded: true,
@@ -149,8 +149,8 @@ describe("useCheckPermissions", () => {
       relation: JIMMRelation.MEMBER,
       target_object: "group-admins",
     };
-    state.juju.rebacRelations = [
-      rebacRelationFactory.build({
+    state.juju.rebac.allowed = [
+      rebacAllowedFactory.build({
         tuple: tuple,
         loading: true,
       }),
@@ -176,8 +176,8 @@ describe("useCheckPermissions", () => {
       relation: JIMMRelation.MEMBER,
       target_object: "group-admins",
     };
-    state.juju.rebacRelations = [
-      rebacRelationFactory.build({
+    state.juju.rebac.allowed = [
+      rebacAllowedFactory.build({
         tuple: tuple,
         loaded: true,
       }),
@@ -203,8 +203,8 @@ describe("useCheckPermissions", () => {
       relation: JIMMRelation.MEMBER,
       target_object: "group-admins",
     };
-    state.juju.rebacRelations = [
-      rebacRelationFactory.build({
+    state.juju.rebac.allowed = [
+      rebacAllowedFactory.build({
         tuple: tuple,
         loaded: true,
       }),
@@ -258,8 +258,8 @@ describe("useCheckPermissions", () => {
       relation: JIMMRelation.MEMBER,
       target_object: "group-admins",
     };
-    state.juju.rebacRelations = [
-      rebacRelationFactory.build({
+    state.juju.rebac.allowed = [
+      rebacAllowedFactory.build({
         tuple: tuple,
         loaded: true,
       }),
@@ -366,8 +366,8 @@ describe("useIsJIMMAdmin", () => {
       relation: JIMMRelation.ADMINISTRATOR,
       target_object: JIMMTarget.JIMM_CONTROLLER,
     };
-    state.juju.rebacRelations = [
-      rebacRelationFactory.build({
+    state.juju.rebac.allowed = [
+      rebacAllowedFactory.build({
         tuple: tuple,
         loading: true,
         loaded: true,
@@ -410,8 +410,8 @@ describe("useIsJIMMAdmin", () => {
       relation: JIMMRelation.ADMINISTRATOR,
       target_object: JIMMTarget.JIMM_CONTROLLER,
     };
-    state.juju.rebacRelations = [
-      rebacRelationFactory.build({
+    state.juju.rebac.allowed = [
+      rebacAllowedFactory.build({
         tuple: tuple,
         loaded: true,
       }),
@@ -502,14 +502,14 @@ describe("useAuditLogsPermitted", () => {
       relation: JIMMRelation.AUDIT_LOG_VIEWER,
       target_object: JIMMTarget.JIMM_CONTROLLER,
     };
-    state.juju.rebacRelations = [
-      rebacRelationFactory.build({
+    state.juju.rebac.allowed = [
+      rebacAllowedFactory.build({
         tuple: tuple,
         loading: true,
         loaded: true,
         allowed: true,
       }),
-      rebacRelationFactory.build({
+      rebacAllowedFactory.build({
         tuple: {
           object: "user-eggman@external",
           relation: JIMMRelation.ADMINISTRATOR,
@@ -583,8 +583,8 @@ describe("useAuditLogsPermitted", () => {
       relation: JIMMRelation.AUDIT_LOG_VIEWER,
       target_object: JIMMTarget.JIMM_CONTROLLER,
     };
-    state.juju.rebacRelations = [
-      rebacRelationFactory.build({
+    state.juju.rebac.allowed = [
+      rebacAllowedFactory.build({
         tuple: tuple,
         loaded: true,
       }),

--- a/src/pages/EntityDetails/Model/Logs/Logs.test.tsx
+++ b/src/pages/EntityDetails/Model/Logs/Logs.test.tsx
@@ -11,7 +11,7 @@ import {
   controllerFeaturesStateFactory,
   authUserInfoFactory,
 } from "testing/factories/general";
-import { rebacRelationFactory } from "testing/factories/juju/juju";
+import { rebacAllowedFactory } from "testing/factories/juju/juju";
 import { renderComponent } from "testing/utils";
 
 import Logs from "./Logs";
@@ -53,24 +53,26 @@ describe("Logs", () => {
         },
       }),
       juju: jujuStateFactory.build({
-        rebacRelations: [
-          rebacRelationFactory.build({
-            tuple: {
-              object: "user-eggman@external",
-              relation: JIMMRelation.AUDIT_LOG_VIEWER,
-              target_object: JIMMTarget.JIMM_CONTROLLER,
-            },
-            allowed: true,
-          }),
-          rebacRelationFactory.build({
-            tuple: {
-              object: "user-eggman@external",
-              relation: JIMMRelation.ADMINISTRATOR,
-              target_object: JIMMTarget.JIMM_CONTROLLER,
-            },
-            allowed: true,
-          }),
-        ],
+        rebac: {
+          allowed: [
+            rebacAllowedFactory.build({
+              tuple: {
+                object: "user-eggman@external",
+                relation: JIMMRelation.AUDIT_LOG_VIEWER,
+                target_object: JIMMTarget.JIMM_CONTROLLER,
+              },
+              allowed: true,
+            }),
+            rebacAllowedFactory.build({
+              tuple: {
+                object: "user-eggman@external",
+                relation: JIMMRelation.ADMINISTRATOR,
+                target_object: JIMMTarget.JIMM_CONTROLLER,
+              },
+              allowed: true,
+            }),
+          ],
+        },
       }),
     });
     renderComponent(<Logs />, {

--- a/src/pages/EntityDetails/Model/Model.test.tsx
+++ b/src/pages/EntityDetails/Model/Model.test.tsx
@@ -32,7 +32,7 @@ import {
   modelListInfoFactory,
   modelFeaturesStateFactory,
   modelFeaturesFactory,
-  rebacRelationFactory,
+  rebacAllowedFactory,
 } from "testing/factories/juju/juju";
 import {
   applicationInfoFactory,
@@ -373,8 +373,8 @@ describe("Model", () => {
         user: authUserInfoFactory.build(),
       },
     };
-    state.juju.rebacRelations = [
-      rebacRelationFactory.build({
+    state.juju.rebac.allowed = [
+      rebacAllowedFactory.build({
         tuple: {
           object: "user-eggman@external",
           relation: JIMMRelation.AUDIT_LOG_VIEWER,
@@ -382,7 +382,7 @@ describe("Model", () => {
         },
         allowed: true,
       }),
-      rebacRelationFactory.build({
+      rebacAllowedFactory.build({
         tuple: {
           object: "user-eggman@external",
           relation: JIMMRelation.ADMINISTRATOR,

--- a/src/pages/EntityDetails/Model/ModelTabs/ModelTabs.test.tsx
+++ b/src/pages/EntityDetails/Model/ModelTabs/ModelTabs.test.tsx
@@ -14,7 +14,7 @@ import {
 } from "testing/factories/general";
 import {
   modelListInfoFactory,
-  rebacRelationFactory,
+  rebacAllowedFactory,
 } from "testing/factories/juju/juju";
 import {
   modelFeaturesStateFactory,
@@ -120,8 +120,8 @@ describe("ModelTabs", () => {
         auditLogs: true,
       }),
     });
-    state.juju.rebacRelations = [
-      rebacRelationFactory.build({
+    state.juju.rebac.allowed = [
+      rebacAllowedFactory.build({
         tuple: {
           object: "user-eggman@external",
           relation: JIMMRelation.AUDIT_LOG_VIEWER,
@@ -129,7 +129,7 @@ describe("ModelTabs", () => {
         },
         allowed: true,
       }),
-      rebacRelationFactory.build({
+      rebacAllowedFactory.build({
         tuple: {
           object: "user-eggman@external",
           relation: JIMMRelation.ADMINISTRATOR,

--- a/src/pages/Logs/Logs.test.tsx
+++ b/src/pages/Logs/Logs.test.tsx
@@ -15,7 +15,7 @@ import {
 import { auditEventFactory } from "testing/factories/juju/jimm";
 import {
   auditEventsStateFactory,
-  rebacRelationFactory,
+  rebacAllowedFactory,
   relationshipTupleFactory,
 } from "testing/factories/juju/juju";
 import { renderComponent } from "testing/utils";
@@ -53,24 +53,26 @@ describe("Logs", () => {
           items: [auditEventFactory.build()],
           loaded: true,
         }),
-        rebacRelations: [
-          rebacRelationFactory.build({
-            tuple: relationshipTupleFactory.build({
-              object: "user-eggman@external",
-              relation: JIMMRelation.AUDIT_LOG_VIEWER,
-              target_object: JIMMTarget.JIMM_CONTROLLER,
+        rebac: {
+          allowed: [
+            rebacAllowedFactory.build({
+              tuple: relationshipTupleFactory.build({
+                object: "user-eggman@external",
+                relation: JIMMRelation.AUDIT_LOG_VIEWER,
+                target_object: JIMMTarget.JIMM_CONTROLLER,
+              }),
+              allowed: true,
             }),
-            allowed: true,
-          }),
-          rebacRelationFactory.build({
-            tuple: relationshipTupleFactory.build({
-              object: "user-eggman@external",
-              relation: JIMMRelation.ADMINISTRATOR,
-              target_object: JIMMTarget.JIMM_CONTROLLER,
+            rebacAllowedFactory.build({
+              tuple: relationshipTupleFactory.build({
+                object: "user-eggman@external",
+                relation: JIMMRelation.ADMINISTRATOR,
+                target_object: JIMMTarget.JIMM_CONTROLLER,
+              }),
+              allowed: true,
             }),
-            allowed: true,
-          }),
-        ],
+          ],
+        },
       }),
     });
   });
@@ -91,8 +93,8 @@ describe("Logs", () => {
   });
 
   it("doesn't display logs if the user doesn't have permission", () => {
-    state.juju.rebacRelations = [
-      rebacRelationFactory.build({
+    state.juju.rebac.allowed = [
+      rebacAllowedFactory.build({
         tuple: relationshipTupleFactory.build({
           object: "user-eggman@external",
           relation: JIMMRelation.AUDIT_LOG_VIEWER,

--- a/src/pages/Permissions/Permissions.test.tsx
+++ b/src/pages/Permissions/Permissions.test.tsx
@@ -18,7 +18,7 @@ import {
 } from "testing/factories/general";
 import {
   jujuStateFactory,
-  rebacRelationFactory,
+  rebacAllowedFactory,
   relationshipTupleFactory,
 } from "testing/factories/juju/juju";
 import { renderComponent } from "testing/utils";
@@ -58,16 +58,18 @@ describe("Permissions", () => {
         },
       }),
       juju: jujuStateFactory.build({
-        rebacRelations: [
-          rebacRelationFactory.build({
-            tuple: relationshipTupleFactory.build({
-              object: "user-eggman@external",
-              relation: JIMMRelation.ADMINISTRATOR,
-              target_object: JIMMTarget.JIMM_CONTROLLER,
+        rebac: {
+          allowed: [
+            rebacAllowedFactory.build({
+              tuple: relationshipTupleFactory.build({
+                object: "user-eggman@external",
+                relation: JIMMRelation.ADMINISTRATOR,
+                target_object: JIMMTarget.JIMM_CONTROLLER,
+              }),
+              allowed: true,
             }),
-            allowed: true,
-          }),
-        ],
+          ],
+        },
       }),
     });
   });
@@ -88,8 +90,8 @@ describe("Permissions", () => {
   });
 
   it("it doesn't display ReBAC Admin if the user does not have permission", () => {
-    state.juju.rebacRelations = [
-      rebacRelationFactory.build({
+    state.juju.rebac.allowed = [
+      rebacAllowedFactory.build({
         tuple: relationshipTupleFactory.build({
           object: "user-eggman@external",
           relation: JIMMRelation.ADMINISTRATOR,

--- a/src/store/juju/reducers.test.ts
+++ b/src/store/juju/reducers.test.ts
@@ -19,7 +19,7 @@ import {
   modelFeaturesStateFactory,
   modelSecretsContentFactory,
   relationshipTupleFactory,
-  rebacRelationFactory,
+  rebacAllowedFactory,
 } from "testing/factories/juju/juju";
 import {
   modelWatcherModelDataFactory,
@@ -1032,7 +1032,7 @@ describe("reducers", () => {
   it("checkRelation", () => {
     const tuple = relationshipTupleFactory.build();
     const state = jujuStateFactory.build({
-      rebacRelations: [],
+      rebac: { allowed: [] },
     });
     expect(
       reducer(
@@ -1044,24 +1044,28 @@ describe("reducers", () => {
       ),
     ).toStrictEqual({
       ...state,
-      rebacRelations: [
-        rebacRelationFactory.build({
-          tuple,
-          loading: true,
-        }),
-      ],
+      rebac: {
+        allowed: [
+          rebacAllowedFactory.build({
+            tuple,
+            loading: true,
+          }),
+        ],
+      },
     });
   });
 
   it("checkRelation already exists", () => {
     const tuple = relationshipTupleFactory.build();
     const state = jujuStateFactory.build({
-      rebacRelations: [
-        rebacRelationFactory.build({
-          tuple,
-          loaded: true,
-        }),
-      ],
+      rebac: {
+        allowed: [
+          rebacAllowedFactory.build({
+            tuple,
+            loaded: true,
+          }),
+        ],
+      },
     });
     expect(
       reducer(
@@ -1073,50 +1077,58 @@ describe("reducers", () => {
       ),
     ).toStrictEqual({
       ...state,
-      rebacRelations: [
-        rebacRelationFactory.build({
-          tuple,
-          loading: true,
-          loaded: false,
-        }),
-      ],
+      rebac: {
+        allowed: [
+          rebacAllowedFactory.build({
+            tuple,
+            loading: true,
+            loaded: false,
+          }),
+        ],
+      },
     });
   });
 
   it("addCheckRelation", () => {
     const tuple = relationshipTupleFactory.build();
     const state = jujuStateFactory.build({
-      rebacRelations: [
-        rebacRelationFactory.build({
-          tuple,
-          loading: true,
-        }),
-      ],
+      rebac: {
+        allowed: [
+          rebacAllowedFactory.build({
+            tuple,
+            loading: true,
+          }),
+        ],
+      },
     });
     expect(
       reducer(state, actions.addCheckRelation({ tuple, allowed: true })),
     ).toStrictEqual({
       ...state,
-      rebacRelations: [
-        rebacRelationFactory.build({
-          allowed: true,
-          tuple,
-          loading: false,
-          loaded: true,
-        }),
-      ],
+      rebac: {
+        allowed: [
+          rebacAllowedFactory.build({
+            allowed: true,
+            tuple,
+            loading: false,
+            loaded: true,
+          }),
+        ],
+      },
     });
   });
 
   it("addCheckRelationErrors", () => {
     const tuple = relationshipTupleFactory.build();
     const state = jujuStateFactory.build({
-      rebacRelations: [
-        rebacRelationFactory.build({
-          tuple,
-          loading: true,
-        }),
-      ],
+      rebac: {
+        allowed: [
+          rebacAllowedFactory.build({
+            tuple,
+            loading: true,
+          }),
+        ],
+      },
     });
     expect(
       reducer(
@@ -1125,43 +1137,49 @@ describe("reducers", () => {
       ),
     ).toStrictEqual({
       ...state,
-      rebacRelations: [
-        rebacRelationFactory.build({
-          tuple,
-          allowed: null,
-          errors: "Oops!",
-          loading: false,
-          loaded: false,
-        }),
-      ],
+      rebac: {
+        allowed: [
+          rebacAllowedFactory.build({
+            tuple,
+            allowed: null,
+            errors: "Oops!",
+            loading: false,
+            loaded: false,
+          }),
+        ],
+      },
     });
   });
 
   it("removeCheckRelation", () => {
     const tuple = relationshipTupleFactory.build();
     const state = jujuStateFactory.build({
-      rebacRelations: [
-        rebacRelationFactory.build({
-          tuple,
-        }),
-        rebacRelationFactory.build({
-          tuple: relationshipTupleFactory.build({
-            object: "model-1234",
+      rebac: {
+        allowed: [
+          rebacAllowedFactory.build({
+            tuple,
           }),
-        }),
-      ],
+          rebacAllowedFactory.build({
+            tuple: relationshipTupleFactory.build({
+              object: "model-1234",
+            }),
+          }),
+        ],
+      },
     });
     expect(
       reducer(state, actions.removeCheckRelation({ tuple })),
     ).toStrictEqual({
       ...state,
-      rebacRelations: [
-        rebacRelationFactory.build({
-          tuple: relationshipTupleFactory.build({
-            object: "model-1234",
+      rebac: {
+        allowed: [
+          rebacAllowedFactory.build({
+            tuple: relationshipTupleFactory.build({
+              object: "model-1234",
+            }),
           }),
-        }),
-      ],
+        ],
+      },
     });
   });
 });

--- a/src/store/juju/selectors.test.ts
+++ b/src/store/juju/selectors.test.ts
@@ -27,7 +27,7 @@ import {
   modelSecretsFactory,
   modelFeaturesFactory,
   modelFeaturesStateFactory,
-  rebacRelationFactory,
+  rebacAllowedFactory,
   relationshipTupleFactory,
   secretRevisionFactory,
 } from "testing/factories/juju/juju";
@@ -117,7 +117,7 @@ import {
   getSecretsContentLoaded,
   getSecretsContentLoading,
   isKubernetesModel,
-  getReBACRelationsState,
+  getReBACAllowedState,
   hasReBACPermission,
   getSecretLatestRevision,
   getReBACPermissionLoading,
@@ -676,9 +676,9 @@ describe("selectors", () => {
     ).toStrictEqual(controllers);
   });
 
-  it("getReBACRelationsState", () => {
-    const rebacRelations = [
-      rebacRelationFactory.build({
+  it("getReBACAllowedState", () => {
+    const allowed = [
+      rebacAllowedFactory.build({
         tuple: relationshipTupleFactory.build({
           object: "user-eggman@external",
           relation: JIMMRelation.ADMINISTRATOR,
@@ -688,14 +688,16 @@ describe("selectors", () => {
       }),
     ];
     expect(
-      getReBACRelationsState(
+      getReBACAllowedState(
         rootStateFactory.build({
           juju: jujuStateFactory.build({
-            rebacRelations,
+            rebac: {
+              allowed,
+            },
           }),
         }),
       ),
-    ).toStrictEqual(rebacRelations);
+    ).toStrictEqual(allowed);
   });
 
   it("getReBACPermissionLoading exists", () => {
@@ -708,12 +710,14 @@ describe("selectors", () => {
       getReBACPermissionLoading(
         rootStateFactory.build({
           juju: jujuStateFactory.build({
-            rebacRelations: [
-              rebacRelationFactory.build({
-                tuple,
-                loading: true,
-              }),
-            ],
+            rebac: {
+              allowed: [
+                rebacAllowedFactory.build({
+                  tuple,
+                  loading: true,
+                }),
+              ],
+            },
           }),
         }),
         tuple,
@@ -731,7 +735,7 @@ describe("selectors", () => {
       getReBACPermissionLoading(
         rootStateFactory.build({
           juju: jujuStateFactory.build({
-            rebacRelations: [],
+            rebac: { allowed: [] },
           }),
         }),
         tuple,
@@ -749,12 +753,14 @@ describe("selectors", () => {
       getReBACPermissionLoaded(
         rootStateFactory.build({
           juju: jujuStateFactory.build({
-            rebacRelations: [
-              rebacRelationFactory.build({
-                tuple,
-                loaded: true,
-              }),
-            ],
+            rebac: {
+              allowed: [
+                rebacAllowedFactory.build({
+                  tuple,
+                  loaded: true,
+                }),
+              ],
+            },
           }),
         }),
         tuple,
@@ -772,7 +778,7 @@ describe("selectors", () => {
       getReBACPermissionLoaded(
         rootStateFactory.build({
           juju: jujuStateFactory.build({
-            rebacRelations: [],
+            rebac: { allowed: [] },
           }),
         }),
         tuple,
@@ -790,12 +796,14 @@ describe("selectors", () => {
       hasReBACPermission(
         rootStateFactory.build({
           juju: jujuStateFactory.build({
-            rebacRelations: [
-              rebacRelationFactory.build({
-                tuple,
-                allowed: true,
-              }),
-            ],
+            rebac: {
+              allowed: [
+                rebacAllowedFactory.build({
+                  tuple,
+                  allowed: true,
+                }),
+              ],
+            },
           }),
         }),
         tuple,
@@ -813,7 +821,7 @@ describe("selectors", () => {
       hasReBACPermission(
         rootStateFactory.build({
           juju: jujuStateFactory.build({
-            rebacRelations: [],
+            rebac: { allowed: [] },
           }),
         }),
         tuple,

--- a/src/store/juju/selectors.ts
+++ b/src/store/juju/selectors.ts
@@ -1060,15 +1060,15 @@ export const isKubernetesModel = createSelector(
     modelInfo?.type === "kubernetes",
 );
 
-export const getReBACRelationsState = createSelector(
+export const getReBACAllowedState = createSelector(
   [slice],
-  (sliceState) => sliceState.rebacRelations,
+  (sliceState) => sliceState.rebac.allowed,
 );
 
 export const getReBACPermission = createSelector(
-  [getReBACRelationsState, (_state, tuple?: RelationshipTuple | null) => tuple],
-  (rebacRelations, tuple) =>
-    rebacRelations.find((relation) => fastDeepEqual(relation.tuple, tuple)),
+  [getReBACAllowedState, (_state, tuple?: RelationshipTuple | null) => tuple],
+  (allowed, tuple) =>
+    allowed.find((relation) => fastDeepEqual(relation.tuple, tuple)),
 );
 
 export const getReBACPermissionLoading = createSelector(

--- a/src/store/juju/slice.ts
+++ b/src/store/juju/slice.ts
@@ -32,7 +32,7 @@ import type {
   ModelFeatures,
   ModelSecrets,
   SecretsContent,
-  ReBACRelation,
+  ReBACAllowed,
 } from "./types";
 
 export const DEFAULT_AUDIT_EVENTS_LIMIT = 50;
@@ -90,7 +90,9 @@ const slice = createSlice({
     modelFeatures: {},
     modelWatcherData: {},
     charms: [],
-    rebacRelations: [],
+    rebac: {
+      allowed: [],
+    },
     secrets: {},
     selectedApplications: [],
   } as JujuState,
@@ -401,19 +403,19 @@ const slice = createSlice({
       }: PayloadAction<{ tuple: RelationshipTuple } & WsControllerURLParam>,
     ) => {
       const tuple = payload.tuple;
-      const relationState: ReBACRelation = {
+      const relationState: ReBACAllowed = {
         errors: null,
         loaded: false,
         loading: true,
         tuple,
       };
-      const existingIndex = state.rebacRelations.findIndex((relation) =>
+      const existingIndex = state.rebac.allowed.findIndex((relation) =>
         fastDeepEqual(relation.tuple, tuple),
       );
       if (existingIndex >= 0) {
-        state.rebacRelations[existingIndex] = relationState;
+        state.rebac.allowed[existingIndex] = relationState;
       } else {
-        state.rebacRelations.push(relationState);
+        state.rebac.allowed.push(relationState);
       }
     },
     addCheckRelation: (
@@ -422,12 +424,12 @@ const slice = createSlice({
         payload,
       }: PayloadAction<{ tuple: RelationshipTuple; allowed: boolean }>,
     ) => {
-      const existingIndex = state.rebacRelations.findIndex((relation) =>
+      const existingIndex = state.rebac.allowed.findIndex((relation) =>
         fastDeepEqual(relation.tuple, payload.tuple),
       );
       if (existingIndex >= 0) {
-        state.rebacRelations[existingIndex] = {
-          ...state.rebacRelations[existingIndex],
+        state.rebac.allowed[existingIndex] = {
+          ...state.rebac.allowed[existingIndex],
           allowed: payload.allowed,
           errors: null,
           loaded: true,
@@ -439,12 +441,12 @@ const slice = createSlice({
       state,
       { payload }: PayloadAction<{ tuple: RelationshipTuple; errors: string }>,
     ) => {
-      const existingIndex = state.rebacRelations.findIndex((relation) =>
+      const existingIndex = state.rebac.allowed.findIndex((relation) =>
         fastDeepEqual(relation.tuple, payload.tuple),
       );
       if (existingIndex >= 0) {
-        state.rebacRelations[existingIndex] = {
-          ...state.rebacRelations[existingIndex],
+        state.rebac.allowed[existingIndex] = {
+          ...state.rebac.allowed[existingIndex],
           allowed: null,
           errors: payload.errors,
           loaded: false,
@@ -456,11 +458,11 @@ const slice = createSlice({
       state,
       { payload }: PayloadAction<{ tuple: RelationshipTuple }>,
     ) => {
-      const existingIndex = state.rebacRelations.findIndex((relation) =>
+      const existingIndex = state.rebac.allowed.findIndex((relation) =>
         fastDeepEqual(relation.tuple, payload.tuple),
       );
       if (existingIndex >= 0) {
-        state.rebacRelations.splice(existingIndex, 1);
+        state.rebac.allowed.splice(existingIndex, 1);
       }
     },
   },

--- a/src/store/juju/types.ts
+++ b/src/store/juju/types.ts
@@ -92,9 +92,13 @@ export type ModelFeatures = {
 
 export type ModelFeaturesState = Record<string, ModelFeatures>;
 
-export type ReBACRelation = GenericState<string> & {
+export type ReBACAllowed = GenericState<string> & {
   tuple: RelationshipTuple;
   allowed?: boolean | null;
+};
+
+export type ReBACState = {
+  allowed: ReBACAllowed[];
 };
 
 export type JujuState = {
@@ -108,7 +112,7 @@ export type JujuState = {
   modelFeatures: ModelFeaturesState;
   modelWatcherData?: ModelWatcherData;
   charms: Charm[];
-  rebacRelations: ReBACRelation[];
+  rebac: ReBACState;
   secrets: SecretsState;
   selectedApplications: ApplicationInfo[];
 };

--- a/src/testing/factories/juju/juju.ts
+++ b/src/testing/factories/juju/juju.ts
@@ -27,7 +27,8 @@ import type {
   ModelFeaturesState,
   ModelListInfo,
   ModelSecrets,
-  ReBACRelation,
+  ReBACAllowed,
+  ReBACState,
   SecretsState,
 } from "store/juju/types";
 import type { SecretsContent } from "store/juju/types";
@@ -243,11 +244,15 @@ export const relationshipTupleFactory = Factory.define<RelationshipTuple>(
   }),
 );
 
-export const rebacRelationFactory = Factory.define<ReBACRelation>(() => ({
+export const rebacAllowedFactory = Factory.define<ReBACAllowed>(() => ({
   errors: null,
   loaded: false,
   loading: false,
   tuple: relationshipTupleFactory.build(),
+}));
+
+export const rebacState = Factory.define<ReBACState>(() => ({
+  allowed: [],
 }));
 
 export const jujuStateFactory = Factory.define<JujuState>(() => ({
@@ -261,7 +266,7 @@ export const jujuStateFactory = Factory.define<JujuState>(() => ({
   modelFeatures: {},
   modelWatcherData: {},
   charms: [],
-  rebacRelations: [],
+  rebac: rebacState.build(),
   secrets: {},
   selectedApplications: [],
 }));


### PR DESCRIPTION
## Done

Rename types and state for the ReBAC data related to the allowed responses. This is in preparation for some additional ReBAC data for relationships between two objects.

## Details

https://warthogs.atlassian.net/browse/WD-20082