### PR TITLE
fix: prevent action log modal from breaking out of stacking context

### DIFF
--- a/src/pages/EntityDetails/Model/Logs/ActionLogs/ActionLogs.tsx
+++ b/src/pages/EntityDetails/Model/Logs/ActionLogs/ActionLogs.tsx
@@ -7,6 +7,7 @@ import {
   ContextualMenu,
   Icon,
   ModularTable,
+  usePortal,
 } from "@canonical/react-components";
 import type { ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -403,6 +404,8 @@ export default function ActionLogs() {
     [],
   );
 
+  const { Portal } = usePortal();
+
   const emptyMsg = `There are no action logs available yet for ${modelName}`;
 
   return (
@@ -420,12 +423,17 @@ export default function ActionLogs() {
           sortable
         />
       )}
-      <FadeIn isActive={Boolean(modalDetails)}>
-        <ActionPayloadModal
-          payload={modalDetails}
-          onClose={() => setModalDetails(null)}
-        />
-      </FadeIn>
+      <Portal>
+        <FadeIn
+          className="entity-details__payload-modal"
+          isActive={Boolean(modalDetails)}
+        >
+          <ActionPayloadModal
+            payload={modalDetails}
+            onClose={() => setModalDetails(null)}
+          />
+        </FadeIn>
+      </Portal>
     </div>
   );
 }

--- a/src/pages/EntityDetails/Model/Logs/ActionLogs/_action-logs.scss
+++ b/src/pages/EntityDetails/Model/Logs/ActionLogs/_action-logs.scss
@@ -28,6 +28,21 @@
     }
   }
 
+  .entity-details__payload-modal {
+    /* 
+     * Elements with opacity != 1 create a new stacking context, which occurs during modal
+     * transitions. To avoid the modal breaking out, position the parent so it creates it's own
+     * stacking context, which we can manually control the z-index of.
+     */
+    position: relative;
+
+    /*
+     * Pulled from Vanilla's Modal backdrop:
+     * https://github.com/canonical/vanilla-framework/blob/21fb5bbc409764a6c39b53a4de2a00eb489f15c8/scss/_patterns_modal.scss#L20
+     */
+    z-index: 150;
+  }
+
   .action-logs__stdout {
     display: block;
   }


### PR DESCRIPTION
## Done

Feels a little bit wacky, but the issue boils down to elements with an opacity != 0 will create a new stacking context, meaning the z-index set within for the backdrop doesn't interact with the rest of the page (eg navigation bars)

- render modal inside `Portal`

- add to framer element:

  - `position` to create a new stacking context which the modal can't break out of

  - `z-index` to imitate Vanilla's modal backdrop

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Navigate Models -> a model -> Action Logs -> click a result

## Details

- close #1784 
- WD-20084

## Screenshots

https://github.com/user-attachments/assets/811ba812-0da3-40ae-8884-775e6dc0baee