### PR TITLE
fix: remove additional margin on action button

### DIFF
--- a/src/panels/ActionsPanel/ActionsPanel.tsx
+++ b/src/panels/ActionsPanel/ActionsPanel.tsx
@@ -182,6 +182,7 @@ export default function ActionsPanel(): JSX.Element {
           loading={isExecutingAction}
           disabled={disableSubmit || isExecutingAction}
           onClick={handleSubmit}
+          className="u-no-margin--bottom"
         >
           Run action
         </ActionButton>


### PR DESCRIPTION
## Done

- remove default button margin

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Select a unit, and click 'Run action'

## Details

- close #1538 
- WD-20085

## Screenshots

### Before

![image](https://github.com/user-attachments/assets/98a4d432-329c-473a-8318-55b39f227306)

### After

![image](https://github.com/user-attachments/assets/9ae3289d-542c-4d77-be74-cb7d60261f8f)
