### PR TITLE
feat: fetch and display the ReBAC model access

### DIFF
--- a/src/components/EntityInfo/EntityInfo.tsx
+++ b/src/components/EntityInfo/EntityInfo.tsx
@@ -12,13 +12,21 @@ export default function EntityInfo({ data }: Props): JSX.Element {
       {Object.entries(data).map(([label, value]) => {
         return (
           <div className="entity-info__grid-item" key={label}>
-            <h4 className="p-muted-heading">{label}</h4>
+            <h4 className="p-muted-heading" id={label}>
+              {label}
+            </h4>
             {typeof value === "string" || typeof value === "number" ? (
-              <TruncatedTooltip message={value} element="p">
+              <TruncatedTooltip
+                message={value}
+                element="p"
+                elementProps={{
+                  "aria-labelledby": label,
+                }}
+              >
                 {value}
               </TruncatedTooltip>
             ) : (
-              <p>{value}</p>
+              <p aria-labelledby={label}>{value}</p>
             )}
           </div>
         );

--- a/src/components/TruncatedTooltip/TruncatedTooltip.tsx
+++ b/src/components/TruncatedTooltip/TruncatedTooltip.tsx
@@ -1,7 +1,12 @@
 import type { TooltipProps } from "@canonical/react-components";
 import { Tooltip } from "@canonical/react-components";
 import classNames from "classnames";
-import type { ComponentType, ElementType, PropsWithChildren } from "react";
+import type {
+  ComponentType,
+  ElementType,
+  HTMLProps,
+  PropsWithChildren,
+} from "react";
 import { useCallback, useEffect, useMemo, useState, useRef } from "react";
 
 type Props = {
@@ -9,6 +14,7 @@ type Props = {
   positionElementClassName?: TooltipProps["positionElementClassName"];
   wrapperClassName?: string;
   element?: ElementType | ComponentType;
+  elementProps?: HTMLProps<HTMLElement>;
 } & TooltipProps &
   PropsWithChildren;
 
@@ -21,6 +27,7 @@ const TruncatedTooltip = ({
   tooltipClassName,
   wrapperClassName,
   element: Component = "div",
+  elementProps,
   ...tooltipProps
 }: Props) => {
   const truncatedNode = useRef<HTMLDivElement>(null);
@@ -70,7 +77,7 @@ const TruncatedTooltip = ({
           "u-hide": !truncated,
         })}
       >
-        <Component ref={truncatedNode} className="u-truncate">
+        <Component ref={truncatedNode} className="u-truncate" {...elementProps}>
           {children}
         </Component>
       </Tooltip>

--- a/src/hooks/useModelAccess.test.tsx
+++ b/src/hooks/useModelAccess.test.tsx
@@ -1,0 +1,241 @@
+import { waitFor } from "@testing-library/react";
+
+import { JIMMRelation } from "juju/jimm/JIMMV4";
+import { actions as jujuActions } from "store/juju";
+import type { RootState } from "store/store";
+import { rootStateFactory } from "testing/factories";
+import {
+  generalStateFactory,
+  credentialFactory,
+  authUserInfoFactory,
+  controllerFeaturesFactory,
+  controllerFeaturesStateFactory,
+  configFactory,
+} from "testing/factories/general";
+import { modelUserInfoFactory } from "testing/factories/juju/ModelManagerV9";
+import {
+  jujuStateFactory,
+  modelDataFactory,
+  modelDataInfoFactory,
+  modelListInfoFactory,
+  relationshipTupleFactory,
+  rebacAllowedFactory,
+  rebacState,
+} from "testing/factories/juju/juju";
+import { modelWatcherModelDataFactory } from "testing/factories/juju/model-watcher";
+import { renderWrappedHook, createStore } from "testing/utils";
+
+import useModelAccess from "./useModelAccess";
+
+describe("useModelAccess", () => {
+  let state: RootState;
+  const url = "/models/eggman@external/test1";
+  const path = "/models/:userName/:modelName";
+
+  beforeEach(() => {
+    state = rootStateFactory.build({
+      general: generalStateFactory.build({
+        config: configFactory.build({
+          controllerAPIEndpoint: "wss://jimm.jujucharms.com/api",
+        }),
+        controllerConnections: {
+          "wss://jimm.jujucharms.com/api": {
+            user: authUserInfoFactory.build(),
+          },
+        },
+        credentials: {
+          "wss://jimm.jujucharms.com/api": credentialFactory.build(),
+        },
+      }),
+      juju: jujuStateFactory.build({
+        modelData: {
+          abc123: modelDataFactory.build(),
+        },
+        models: {
+          abc123: modelListInfoFactory.build({
+            uuid: "abc123",
+            name: "test1",
+            wsControllerURL: "wss://jimm.jujucharms.com/api",
+          }),
+        },
+        modelWatcherData: {
+          abc123: modelWatcherModelDataFactory.build(),
+        },
+      }),
+    });
+  });
+
+  it("gets access for a Juju controller", () => {
+    if (state.general.config) {
+      state.general.config.isJuju = true;
+    }
+    state.juju.modelData = {
+      abc123: modelDataFactory.build({
+        info: modelDataInfoFactory.build({
+          users: [
+            modelUserInfoFactory.build({
+              user: "eggman@external",
+              access: "read",
+            }),
+          ],
+        }),
+      }),
+    };
+    const { result } = renderWrappedHook(() => useModelAccess("abc123"), {
+      state,
+      path,
+      url,
+    });
+    expect(result.current).toBe("read");
+  });
+
+  it("requests permissions for JIMM controllers", async () => {
+    if (state.general.config) {
+      state.general.config.isJuju = false;
+    }
+    state.general.controllerFeatures = controllerFeaturesStateFactory.build({
+      "wss://jimm.jujucharms.com/api": controllerFeaturesFactory.build({
+        rebac: true,
+      }),
+    });
+    const [store, actions] = createStore(state, { trackActions: true });
+    renderWrappedHook(() => useModelAccess("abc123"), {
+      store,
+      path,
+      url,
+    });
+    const action = jujuActions.checkRelations({
+      requestId: expect.any(String),
+      tuples: [
+        relationshipTupleFactory.build({
+          object: "user-eggman@external",
+          relation: JIMMRelation.ADMINISTRATOR,
+          target_object: "model-abc123",
+        }),
+        relationshipTupleFactory.build({
+          object: "user-eggman@external",
+          relation: JIMMRelation.WRITER,
+          target_object: "model-abc123",
+        }),
+        relationshipTupleFactory.build({
+          object: "user-eggman@external",
+          relation: JIMMRelation.READER,
+          target_object: "model-abc123",
+        }),
+      ],
+      wsControllerURL: "wss://jimm.jujucharms.com/api",
+    });
+    await waitFor(() => {
+      expect(
+        actions.find((dispatch) => dispatch.type === action.type),
+      ).toMatchObject(action);
+    });
+  });
+
+  it("handles admin access for JIMM controllers", () => {
+    if (state.general.config) {
+      state.general.config.isJuju = false;
+    }
+    state.juju.rebac = rebacState.build({
+      allowed: [
+        rebacAllowedFactory.build({
+          tuple: relationshipTupleFactory.build({
+            relation: JIMMRelation.READER,
+          }),
+          loaded: true,
+        }),
+        rebacAllowedFactory.build({
+          tuple: relationshipTupleFactory.build({
+            object: "user-eggman@external",
+            target_object: "model-abc123",
+            relation: JIMMRelation.WRITER,
+          }),
+          loaded: true,
+        }),
+        rebacAllowedFactory.build({
+          tuple: relationshipTupleFactory.build({
+            object: "user-eggman@external",
+            target_object: "model-abc123",
+            relation: JIMMRelation.ADMINISTRATOR,
+          }),
+          loaded: true,
+        }),
+      ],
+    });
+    const { result } = renderWrappedHook(() => useModelAccess("abc123"), {
+      state,
+      path,
+      url,
+    });
+    expect(result.current).toBe(JIMMRelation.ADMINISTRATOR);
+  });
+
+  it("handles write access for JIMM controllers", () => {
+    if (state.general.config) {
+      state.general.config.isJuju = false;
+    }
+    state.juju.rebac = rebacState.build({
+      allowed: [
+        rebacAllowedFactory.build({
+          tuple: relationshipTupleFactory.build({
+            relation: JIMMRelation.READER,
+          }),
+          loaded: true,
+        }),
+        rebacAllowedFactory.build({
+          tuple: relationshipTupleFactory.build({
+            object: "user-eggman@external",
+            target_object: "model-abc123",
+            relation: JIMMRelation.WRITER,
+          }),
+          loaded: true,
+        }),
+      ],
+    });
+    const { result } = renderWrappedHook(() => useModelAccess("abc123"), {
+      state,
+      path,
+      url,
+    });
+    expect(result.current).toBe(JIMMRelation.WRITER);
+  });
+
+  it("handles read access for JIMM controllers", () => {
+    if (state.general.config) {
+      state.general.config.isJuju = false;
+    }
+    state.juju.rebac = rebacState.build({
+      allowed: [
+        rebacAllowedFactory.build({
+          tuple: relationshipTupleFactory.build({
+            object: "user-eggman@external",
+            target_object: "model-abc123",
+            relation: JIMMRelation.READER,
+          }),
+          loaded: true,
+        }),
+      ],
+    });
+    const { result } = renderWrappedHook(() => useModelAccess("abc123"), {
+      state,
+      path,
+      url,
+    });
+    expect(result.current).toBe(JIMMRelation.READER);
+  });
+
+  it("handles no access for JIMM controllers", () => {
+    if (state.general.config) {
+      state.general.config.isJuju = false;
+    }
+    state.juju.rebac = rebacState.build({
+      allowed: [],
+    });
+    const { result } = renderWrappedHook(() => useModelAccess("abc123"), {
+      state,
+      path,
+      url,
+    });
+    expect(result.current).toBeNull();
+  });
+});

--- a/src/hooks/useModelAccess.ts
+++ b/src/hooks/useModelAccess.ts
@@ -1,0 +1,69 @@
+import { useId } from "react";
+
+import { useCheckRelations } from "juju/api-hooks/permissions";
+import { JIMMRelation } from "juju/jimm/JIMMV4";
+import { getIsJuju, getControllerUserTag } from "store/general/selectors";
+import { getModelAccess, getReBACPermissions } from "store/juju/selectors";
+import type { ReBACAllowed } from "store/juju/types";
+import { useAppSelector } from "store/store";
+
+// A user can only have 'administrator', 'writer' or reader' entitlements to a model. See:
+// https://github.com/canonical/jimm/blob/197f97f212fa9b8eb9977dd33650b87d10492ca5/internal/jimmhttp/rebac_admin/entitlements.go#L63-L75
+const order = [
+  JIMMRelation.READER,
+  JIMMRelation.WRITER,
+  JIMMRelation.ADMINISTRATOR,
+];
+
+const getHighestAccess = (relations: ReBACAllowed[]) => {
+  if (!relations.length) {
+    return null;
+  }
+  return relations.reduce<JIMMRelation>(
+    (highest, { tuple }) =>
+      order.indexOf(tuple.relation) > order.indexOf(highest)
+        ? tuple.relation
+        : highest,
+    // Set the initial value to the first relation.
+    relations[0].tuple.relation,
+  );
+};
+
+const useModelAccess = (modelUUID?: string | null, cleanup?: boolean) => {
+  const isJuju = useAppSelector(getIsJuju);
+  const controllerUser = useAppSelector(getControllerUserTag);
+  const jujuAccess = useAppSelector((state) =>
+    getModelAccess(state, modelUUID),
+  );
+  const relations =
+    !isJuju && controllerUser && modelUUID
+      ? [
+          {
+            object: controllerUser,
+            relation: JIMMRelation.ADMINISTRATOR,
+            target_object: `model-${modelUUID}`,
+          },
+          {
+            object: controllerUser,
+            relation: JIMMRelation.WRITER,
+            target_object: `model-${modelUUID}`,
+          },
+          {
+            object: controllerUser,
+            relation: JIMMRelation.READER,
+            target_object: `model-${modelUUID}`,
+          },
+        ]
+      : null;
+  const permissions = useAppSelector((state) =>
+    getReBACPermissions(state, relations),
+  );
+  const requestId = useId();
+  useCheckRelations(requestId, relations, cleanup);
+  if (isJuju) {
+    return jujuAccess;
+  }
+  return getHighestAccess(permissions ?? []);
+};
+
+export default useModelAccess;

--- a/src/hooks/useModelAccess.ts
+++ b/src/hooks/useModelAccess.ts
@@ -2,7 +2,11 @@ import { useId } from "react";
 
 import { useCheckRelations } from "juju/api-hooks/permissions";
 import { JIMMRelation } from "juju/jimm/JIMMV4";
-import { getIsJuju, getControllerUserTag } from "store/general/selectors";
+import {
+  getIsJuju,
+  getControllerUserTag,
+  getIsJIMM,
+} from "store/general/selectors";
 import { getModelAccess, getReBACPermissions } from "store/juju/selectors";
 import type { ReBACAllowed } from "store/juju/types";
 import { useAppSelector } from "store/store";
@@ -31,12 +35,13 @@ const getHighestAccess = (relations: ReBACAllowed[]) => {
 
 const useModelAccess = (modelUUID?: string | null, cleanup?: boolean) => {
   const isJuju = useAppSelector(getIsJuju);
+  const isJIMM = useAppSelector(getIsJIMM);
   const controllerUser = useAppSelector(getControllerUserTag);
   const jujuAccess = useAppSelector((state) =>
     getModelAccess(state, modelUUID),
   );
   const relations =
-    !isJuju && controllerUser && modelUUID
+    isJIMM && controllerUser && modelUUID
       ? [
           {
             object: controllerUser,

--- a/src/pages/EntityDetails/Model/Model.tsx
+++ b/src/pages/EntityDetails/Model/Model.tsx
@@ -7,10 +7,10 @@ import EntityInfo from "components/EntityInfo";
 import InfoPanel from "components/InfoPanel";
 import type { EntityDetailsRoute } from "components/Routes";
 import useCanConfigureModel from "hooks/useCanConfigureModel";
+import useModelAccess from "hooks/useModelAccess";
 import useModelStatus from "hooks/useModelStatus";
 import { useQueryParams } from "hooks/useQueryParams";
 import {
-  getModelAccess,
   getModelApplications,
   getModelInfo,
   getModelMachines,
@@ -96,6 +96,7 @@ const Model = () => {
     getCanListSecrets(state, modelUUID),
   );
   const canConfigureModel = useCanConfigureModel();
+  const modelAccess = useModelAccess(modelUUID);
 
   const machinesTableRows = useMemo(() => {
     return modelName && userName
@@ -128,9 +129,6 @@ const Model = () => {
   const credential = useAppSelector((state) =>
     getModelCredential(state, modelUUID),
   );
-  const modelAccess = useAppSelector((state) =>
-    getModelAccess(state, modelUUID),
-  );
 
   return (
     <>
@@ -150,7 +148,7 @@ const Model = () => {
         {modelInfoData && (
           <EntityInfo
             data={{
-              access: modelAccess ?? "Unknown",
+              access: modelAccess || "Unknown",
               controller: modelInfoData.type,
               "Cloud/Region": generateCloudAndRegion(
                 modelInfoData["cloud"],

--- a/src/pages/EntityDetails/Model/Model.tsx
+++ b/src/pages/EntityDetails/Model/Model.tsx
@@ -148,7 +148,7 @@ const Model = () => {
         {modelInfoData && (
           <EntityInfo
             data={{
-              access: modelAccess || "Unknown",
+              access: modelAccess || "unknown",
               controller: modelInfoData.type,
               "Cloud/Region": generateCloudAndRegion(
                 modelInfoData["cloud"],

--- a/src/store/general/selectors.test.ts
+++ b/src/store/general/selectors.test.ts
@@ -32,6 +32,7 @@ import {
   isReBACEnabled,
   getControllerUserTag,
   getLoginLoading,
+  getIsJIMM,
 } from "./selectors";
 
 describe("selectors", () => {
@@ -55,6 +56,20 @@ describe("selectors", () => {
           general: generalStateFactory.build({
             config: configFactory.build({
               isJuju: true,
+            }),
+          }),
+        }),
+      ),
+    ).toStrictEqual(true);
+  });
+
+  it("getIsJIMM", () => {
+    expect(
+      getIsJIMM(
+        rootStateFactory.build({
+          general: generalStateFactory.build({
+            config: configFactory.build({
+              isJuju: false,
             }),
           }),
         }),

--- a/src/store/general/selectors.ts
+++ b/src/store/general/selectors.ts
@@ -28,6 +28,14 @@ export const getIsJuju = createSelector(
 );
 
 /**
+  Determines if JIMM is used based on config value from state.
+  @param state The application state.
+  @returns true if JIMM is used, false if JIMM isn't used or
+    undefined if config is undefined.
+ */
+export const getIsJIMM = createSelector([getIsJuju], (isJuju) => !isJuju);
+
+/**
   Determines if analytics is enabled based on config value from state.
   @param state The application state.
   @returns true if analytics is enabled, false if analytics isn't enabled,


### PR DESCRIPTION
## Done

- Fetch the user's relations to a model and use them to display their model access entitlement on the model details page.

## QA

- Connect to JIMM.
- Turn on ReBAC with `?enable-flag=rebac`.
- Go to a model and on the left hand side you should see your access.

## Details

https://warthogs.atlassian.net/browse/WD-19884
