### PR TITLE
fix: flash of charm actions on load

### DIFF
--- a/src/components/RadioInputBox/_radio-input-box.scss
+++ b/src/components/RadioInputBox/_radio-input-box.scss
@@ -1,9 +1,28 @@
 .radio-input-box {
-  border: 1px solid $color-mid-light;
+  $border-width: 1px;
+  $v-padding: 0.5rem;
+
+  // This is the default for `label` in Vanilla.
+  $line-height: 1.5rem;
+
+  // Calculate the vertical spacing on this item, which will comprise of the border width, plus the
+  // vertical padding.
+  $v-spacing: #{calc(2 * ($v-padding + $border-width))};
+
+  border: $border-width solid $color-mid-light;
   border-radius: 2px;
   margin-bottom: 0.5rem;
   overflow: hidden;
-  padding: 0.5rem 1rem 0.5rem 0.5rem;
+  padding: $v-padding 1rem $v-padding 0.5rem;
+
+  // 'Export' variables so they can be used in the animation from JS.
+  --v-spacing: #{$v-spacing};
+  --initial-height: #{calc($line-height + $v-spacing)};
+
+  // Set the collapsed height of the item when it's not expanded.
+  &:not([aria-expanded="true"]) {
+    height: var(--initial-height);
+  }
 
   @include vf-animation(#{border, background-color}, sleepy, linear);
 


### PR DESCRIPTION
## Done

Since the charm action item height was set in JS, there was a moment of time where the default item height was displayed before React kicked in and set it to the correct value.

This fix includes a few changes:

- No more magic values: animation points are pulled out of CSS variables, rather than hard coded pixel values

- Height enforced via CSS: JS is only used for triggering animations, there are no manual overrides of `el.style.height` in JS

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Select an application, and click 'Run Action'

## Details

- Close #1557
- WD-20172

## Screenshots

I've slowed down the recording for some of these which have caused some frames to go weird. This doesn't seem to be the case when actually using it (see the last video).

### Previous

https://github.com/user-attachments/assets/bd2bcd4f-54a4-436c-82bb-6bebce50f90d

### Fixed

https://github.com/user-attachments/assets/3e3ac127-9927-481e-9069-26a1245882ce

### Real-time

https://github.com/user-attachments/assets/014be8d2-b914-40e6-bbd7-b4c31977489e