### PR TITLE
fix: actions panel reopen

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "dompurify": "3.2.4",
     "fast-deep-equal": "3.1.3",
     "formik": "2.4.6",
-    "framer-motion": "12.4.2",
+    "framer-motion": "12.5.0",
     "fuse.js": "7.1.0",
     "lodash.mergewith": "4.6.2",
     "loglevel": "1.9.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5586,12 +5586,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"framer-motion@npm:12.4.2":
-  version: 12.4.2
-  resolution: "framer-motion@npm:12.4.2"
+"framer-motion@npm:12.5.0":
+  version: 12.5.0
+  resolution: "framer-motion@npm:12.5.0"
   dependencies:
-    motion-dom: "npm:^12.0.0"
-    motion-utils: "npm:^12.0.0"
+    motion-dom: "npm:^12.5.0"
+    motion-utils: "npm:^12.5.0"
     tslib: "npm:^2.4.0"
   peerDependencies:
     "@emotion/is-prop-valid": "*"
@@ -5604,7 +5604,7 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: 10c0/31d1a5360278de19ccf8e3e79cf442e15b5c04980130914f8cdcd3becc99fbd47088041b9b92fc9c06af7dc4030dc3b6e2da2c9c3d25cce9e36dc35d1bf6ac51
+  checksum: 10c0/ac632ea3a452e473abf9adad1d6777522b1dd2ed8cf567078a9997f07a388d7b9e68a3e9c102b1807e1e88af3d83eb2eb0d9476032059f4803a0c32bded9bf74
   languageName: node
   linkType: hard
 
@@ -7516,7 +7516,7 @@ __metadata:
     fast-deep-equal: "npm:3.1.3"
     fishery: "npm:2.2.3"
     formik: "npm:2.4.6"
-    framer-motion: "npm:12.4.2"
+    framer-motion: "npm:12.5.0"
     fuse.js: "npm:7.1.0"
     happy-dom: "npm:17.1.0"
     jest-websocket-mock: "npm:2.5.0"
@@ -8135,19 +8135,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"motion-dom@npm:^12.0.0":
-  version: 12.0.0
-  resolution: "motion-dom@npm:12.0.0"
+"motion-dom@npm:^12.5.0":
+  version: 12.5.0
+  resolution: "motion-dom@npm:12.5.0"
   dependencies:
-    motion-utils: "npm:^12.0.0"
-  checksum: 10c0/d67209bc217f16b9a0305afa4bfc366997d02df76eea9ab29062f98beeff5fdfc60ae1b422ab397f525ae775c640ac9ba061c9f45aacd6cd71a23dce06661384
+    motion-utils: "npm:^12.5.0"
+  checksum: 10c0/32e6029a14c23a82392253ecd5349f3d7c603edac6e214357c6657560c90dff42163b40d7a9d93cd31c6eaded39765e115a1abf137496baec27942803f4bc56e
   languageName: node
   linkType: hard
 
-"motion-utils@npm:^12.0.0":
-  version: 12.0.0
-  resolution: "motion-utils@npm:12.0.0"
-  checksum: 10c0/ca6cc7542d00afab011130fcd940e5f5a412b21a4eaeb17c0a497dcb86de311dda90741eeca7de1276cc8c1dff7ac1e6a8df1e8cebb1191a2c43bfe8368dc70b
+"motion-utils@npm:^12.5.0":
+  version: 12.5.0
+  resolution: "motion-utils@npm:12.5.0"
+  checksum: 10c0/f556240efda96a4bb86b13bb0e6cad689b2665ca688b2616585a7c7db182e3b8d93377ff1fb3782ca0088a4a8aa6dd5e47e81fda5c19ab334f01812eade639ef
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Done

Updated framer-motion to fix an issue where reopening actions panel didn't reset it as `AnimatePresence` wasn't removing the panel from the DOM when closing it.

## QA

- Go to a model with multiple apps.
- Search and tick multiple apps.
- Click "Run action".
- Choose one of the apps and click 'Next'.
- Close the panel and click "Run action" again.
- See that you don't get to choose an app and you get taken straight to the action options.

## Details

Fixes #1888.
https://warthogs.atlassian.net/browse/WD-20173
