### PR TITLE
chore(docs): add instructions for charm access and port forwarding

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -356,7 +356,7 @@ Get the dashboard machine's instance id:
 juju status
 ```
 
-Then port forward to the dashboard instance so that the dashboard can be access
+Then port forward to the dashboard instance so that the dashboard can be accessed
 from outside the Multipass container:
 
 ```shell

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -239,7 +239,9 @@ cd juju-dashboard-charm
 
 [Build and
 deploy](https://github.com/canonical/juju-dashboard-charm#building-and-testing-the-k8s-charm)
-the Kubernetes charm and follow the [QA steps](#qa-steps) to confirm it is working.
+the Kubernetes charm (using the [build from
+source](https://github.com/canonical/juju-dashboard-charm?tab=readme-ov-file#building-from-source)
+steps to build a new Docker image with the latest dashboard code) and follow the [QA steps](#qa-steps) to confirm it is working.
 
 If you've deployed inside a Multipass container you will need access to the
 dashboard from outside the container. To do this, inside the multipass container

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -172,6 +172,12 @@ Finally, publish the release.
 Juju Dashboard can be deployed using a machine charm or a Kubernetes charm which both
 need updating and releasing.
 
+If you don't have access to publish the charm, ask someone on the Juju Dashboard
+team to be added as a collaborator to both charms:
+
+https://charmhub.io/juju-dashboard/collaboration
+https://charmhub.io/juju-dashboard-k8s/collaboration
+
 ### Machine charm
 
 Fork and clone the [juju-dashboard-charm
@@ -191,6 +197,19 @@ Update the dashboard to the latest release:
 [Build and
 deploy](https://github.com/canonical/juju-dashboard-charm#building-and-testing-the-machine-charm)
 the machine charm and follow the [QA steps](#qa-steps) to confirm it is working.
+
+If you've deployed inside a Multipass container you will need access to the
+dashboard from outside the container. To do this first get the dashboard machine's instance id:
+
+```shell
+juju status
+```
+
+Then, inside the multipass container add a port forward to the dashboard instance:
+
+```shell
+lxc config device add [inst-id] portforward8080 proxy listen=tcp:0.0.0.0:8080 connect=tcp:127.0.0.1:8080
+```
 
 Now create a PR to land the update dashboard package.
 
@@ -221,6 +240,14 @@ cd juju-dashboard-charm
 [Build and
 deploy](https://github.com/canonical/juju-dashboard-charm#building-and-testing-the-k8s-charm)
 the Kubernetes charm and follow the [QA steps](#qa-steps) to confirm it is working.
+
+If you've deployed inside a Multipass container you will need access to the
+dashboard from outside the container. To do this, inside the multipass container
+add a port forward to the dashboard instance:
+
+```shell
+microk8s.kubectl port-forward dashboard-0 8080:8080 --namespace=controller-micro --address=0.0.0.0
+```
 
 The K8s charm does not need to commit any changes to the repo as a
 Docker image is published to Charmhub instead.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -142,16 +142,17 @@ Set the title to the same version number.
 
 Attach the release tarball that you created earlier.
 
-Get the changes since the last release. You can get the changes using GitHub at `https://github.com/canonical/juju-dashboard/compare/<last-version-number>...main`
-or run the following command inside the repo:
-
-```shell
-git log $(git describe --tags --abbrev=0)..HEAD  --oneline
-```
+Click the 'Generate release notes' button to show changes since the last release
+and create a full changelog link, but rewrite the changes to help them make
+sense to consumers of the library.
 
 Create the release notes using the following template:
 
 ```markdown
+## Breaking changes:
+
+-
+
 ## New features:
 
 -

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -226,8 +226,6 @@ steps](https://github.com/canonical/juju-dashboard-charm#machine-charm) again to
 publish the charm to either the beta or stable channel depending on whether this
 release is ready for general use.
 
-https://github.com/canonical/juju-dashboard-charm#building-and-testing-the-k8s-charm
-
 ### Kubernetes charm
 
 Fork and clone the [juju-dashboard-charm


### PR DESCRIPTION
## Done

[List of work items including drive-bys]

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- [Add additional steps]

## Details

[List of links to issues/bugs and cards if needed]

## Screenshots

[if relevant, include a screenshot]
