### PR TITLE
fix: improve regex for generating charm icons

### DIFF
--- a/src/store/juju/utils/models.ts
+++ b/src/store/juju/utils/models.ts
@@ -280,12 +280,16 @@ export const generateIconPath = (charmId: string) => {
   }
   if (charmId.indexOf("ch:") === 0) {
     // Regex explanation:
-    // "ch:amd64/xenial/content-cache-425".match(/\/(.+)\/(.+)-\d+/)
-    // Array(3) [ "/xenial/content-cache-425", "xenial", "content-cache" ]
-    const charmName = charmId.match(/\/(.+)\/(.+)-\d+/)?.[2];
-    return `https://charmhub.io/${charmName}/icon`;
+    // "ch:amd64/xenial/content-cache-425".match(/\/(?:(?<release>.+)\/)?(?<charmName>.+)-\d+/).groups
+    // Object { release: "xenial", charmName: "content-cache" }
+    const charmName = charmId.match(
+      /\/(?:(?<release>.+)\/)?(?<charmName>.+)-\d+/,
+    )?.groups?.["charmName"];
+    if (charmName) {
+      return `https://charmhub.io/${charmName}/icon`;
+    }
   }
-  return "";
+  return defaultCharmIcon;
 };
 
 export const extractRelationEndpoints = (relation: {


### PR DESCRIPTION
## Done

- improve regex for pulling out charm icons

## QA

- View a model, and see all of the charm icons

## Details

This caused two minor issues:

- no icons throughout the dashboard
- unnecessary requests to `https://charmhub.io/undefined/icon`

Has the nice side-effect that the correct URL hits a CDN so the icons appear _much_ quicker than the previous fallback icon after it attempted loading the incorrect URL.

## Screenshots

### Before

![image](https://github.com/user-attachments/assets/1dc5a8ae-a7a9-4e3a-bd25-ad4cec0188e2)

### After

![image](https://github.com/user-attachments/assets/545c1baf-aaf9-4b06-bdcf-1e4c5509bc75)

