### PR TITLE
feat: implement base `Auth` class

### DIFF
--- a/src/auth/Auth.test.ts
+++ b/src/auth/Auth.test.ts
@@ -1,0 +1,32 @@
+import { AuthMethod } from "store/general/types";
+
+import { Auth } from "./Auth";
+
+describe("Auth base class", () => {
+  beforeEach(() => {
+    // @ts-expect-error - Resetting singleton for each test run.
+    delete Auth.instance;
+  });
+
+  it("creates new singleton instance", () => {
+    expect(Auth.instance).not.toBeDefined();
+    const instance = new Auth(vi.fn(), AuthMethod.LOCAL);
+    expect(Auth.instance).to.equal(instance);
+  });
+
+  it("overrides singleton instance", () => {
+    const instance1 = new Auth(vi.fn(), AuthMethod.LOCAL);
+    const instance2 = new Auth(vi.fn(), AuthMethod.LOCAL);
+    expect(Auth.instance).not.to.equal(instance1);
+    expect(Auth.instance).to.equal(instance2);
+  });
+
+  it("continues controller connection by default", async () => {
+    const instance = new Auth(vi.fn(), AuthMethod.LOCAL);
+    await expect(
+      instance.beforeControllerConnect({
+        wsControllerURL: "wss://1.2.3.4/api",
+      }),
+    ).resolves.to.equal(true);
+  });
+});

--- a/src/auth/Auth.ts
+++ b/src/auth/Auth.ts
@@ -1,0 +1,104 @@
+/* eslint-disable @typescript-eslint/no-unused-vars -- This file contains a base class with a lot
+   of unused paramters. */
+
+import type { ConnectOptions, Credentials } from "@canonical/jujulib";
+
+import type { ConnectionWithFacades } from "juju/types";
+import type { AuthMethod, Credential } from "store/general/types";
+import type { AppDispatch } from "store/store";
+import { logger } from "utils/logger";
+
+export type ControllerData = {
+  wsControllerURL: string;
+  credentials?: Credential;
+};
+
+/**
+ * Base class for authentication providers. The stubbed lifecycle methods are called throughout the
+ * dashboard. Authentication implementations should extend this class and override the relevant
+ * methods.
+ *
+ * This class should be consumed as a singleton via the `instance` property (eg.
+ * `Auth.instance.logout()`). The singleton is set in the base class's constructor.
+ */
+export class Auth {
+  /**
+   * Singleton instance of the auth provider.
+   */
+  static instance: Auth;
+
+  /**
+   * Redux dispatch method for use within auth implementations.
+   */
+  protected dispatch: AppDispatch;
+
+  /**
+   * Identifier of the auth method.
+   */
+  public name: AuthMethod;
+
+  /**
+   * Create a new instance of the singleton using the provided store dispatch, and auth method
+   * name. This constructor should only be called once (including via extended classes), as it will
+   * override the previously instantiated singleton instance.
+   */
+  constructor(dispatch: AppDispatch, name: AuthMethod) {
+    if (Auth.instance) {
+      logger.warn(
+        "Singleton instance already exists, and is being re-constructed. Overriding previous instance with incoming.",
+      );
+    }
+
+    Auth.instance = this;
+    this.dispatch = dispatch;
+    this.name = name;
+  }
+
+  /**
+   * Executed at the conclusion of the dashboard's bootstrap method.
+   */
+  async bootstrap(): Promise<void> {}
+
+  /**
+   * Logout functionality for the authentication provider.
+   */
+  async logout(): Promise<void> {}
+
+  /**
+   * Executed after the controller list is fetched.
+   *
+   * @param conn - Controller connection.
+   */
+  async afterControllerListFetched(
+    conn: ConnectionWithFacades,
+  ): Promise<void> {}
+
+  /**
+   * Executed before a connection is initiated with a controller.
+   *
+   * @returns Whether to continue the connection attempt.
+   */
+  async beforeControllerConnect(
+    controllerData: ControllerData,
+  ): Promise<boolean> {
+    return true;
+  }
+
+  /**
+   * Produces `ConnectOptions` for jujulib.
+   *
+   * @returns Connection options to merge with existing jujulib connection options.
+   */
+  jujulibConnectOptions(): Partial<ConnectOptions> | undefined {
+    return undefined;
+  }
+
+  /**
+   * Produces login parameters to use with jujulib.
+   *
+   * @returns Credentials to provide to jujulib for connection.
+   */
+  determineCredentials(credential?: Credential): Credentials | undefined {
+    return undefined;
+  }
+}

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,0 +1,1 @@
+export { Auth } from "./Auth";


### PR DESCRIPTION
## Done

- Create `Auth` base class
- WD-20704

## Details

- `constructor(dispatch: AppDispatch)`
  - Checks if singleton has already been initialised, and will emit a warning if it has been
  - Should the constructor also be passed `getState` to thunk-ify it?
- `bootstrap(): Promise<void>`
  - Replaces: https://github.com/canonical/juju-dashboard/blob/93c1d3fbf7fd037a27e598f7b499f0917187c62d/src/index.tsx#L161-L172
- `logout(): Promise<void>`
  - Replaces: https://github.com/canonical/juju-dashboard/blob/93c1d3fbf7fd037a27e598f7b499f0917187c62d/src/store/app/thunks.ts#L39-L47
- `onControllerListFetched(conn: ConnectionWithFacades): Promise<void>`
  - Candid implementation requires `conn` in order to call `disableControllerUUIDMasking`
  - Could be renamed to `afterControllerListFetched` to make it clear where in the lifecycle it's executed?
  - Replaces: https://github.com/canonical/juju-dashboard/blob/93c1d3fbf7fd037a27e598f7b499f0917187c62d/src/store/middleware/model-poller.ts#L203-L212
- `beforeControllerConnect(): Promise<boolean>`
  - Current implementation allows controller connection to be aborted (with or without an error), so a boolean is returned to indicate whether the caller should continue.
  - Replaces: https://github.com/canonical/juju-dashboard/blob/93c1d3fbf7fd037a27e598f7b499f0917187c62d/src/store/middleware/model-poller.ts#L73-L98
- `jujulibOptions(): Partial<ConnectOptions>`
  - Could be renamed to `jujulibConnectOptions`
  - Result to be merged with: https://github.com/canonical/juju-dashboard/blob/93c1d3fbf7fd037a27e598f7b499f0917187c62d/src/juju/api.ts#L99-L106
- `determineLoginParams(credential?: Credential): Credentials | undefined`
  - Could be renamed to `determineCredentials`?
  - `credential` originates from redux state, would it be better allow the auth implementation to pull it out of the store?
  - Replaces: https://github.com/canonical/juju-dashboard/blob/93c1d3fbf7fd037a27e598f7b499f0917187c62d/src/juju/api.ts#L109-L119
