### PR TITLE
feat: utilise `Auth` methods in place of `AuthMethod`

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     ]
   },
   "dependencies": {
-    "@canonical/jujulib": "7.0.0",
+    "@canonical/jujulib": "8.0.1",
     "@canonical/macaroon-bakery": "1.3.2",
     "@canonical/react-components": "2.2.0",
     "@canonical/rebac-admin": "0.0.1-alpha.12",

--- a/src/auth/Auth.ts
+++ b/src/auth/Auth.ts
@@ -98,7 +98,9 @@ export class Auth {
    *
    * @returns Credentials to provide to jujulib for connection.
    */
-  determineCredentials(credential?: Credential): Credentials | undefined {
+  determineCredentials(
+    credential?: Credential | null,
+  ): Credentials | undefined {
     return undefined;
   }
 }

--- a/src/auth/LocalAuth.ts
+++ b/src/auth/LocalAuth.ts
@@ -11,7 +11,9 @@ export class LocalAuth extends Auth {
     super(dispatch, AuthMethod.LOCAL);
   }
 
-  determineCredentials(credential?: Credential): Credentials | undefined {
+  determineCredentials(
+    credential?: Credential | null,
+  ): Credentials | undefined {
     if (!credential) {
       return;
     }

--- a/src/auth/OIDCAuth.test.ts
+++ b/src/auth/OIDCAuth.test.ts
@@ -104,7 +104,7 @@ describe("OIDCAuth", () => {
 
   it("jujulibConnectOptions", () => {
     expect(Auth.instance.jujulibConnectOptions()).to.deep.equal({
-      oidcEnabled: true,
+      loginWithSessionCookie: true,
     });
   });
 });

--- a/src/auth/OIDCAuth.ts
+++ b/src/auth/OIDCAuth.ts
@@ -65,8 +65,7 @@ export class OIDCAuth extends pollingMixin(Auth) {
 
   override jujulibConnectOptions(): Partial<ConnectOptions> {
     return {
-      // TODO: (WD-20703) Replace with libjuju@8.0.1
-      oidcEnabled: true,
+      loginWithSessionCookie: true,
     };
   }
 }

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,4 +1,5 @@
 export { Auth } from "./Auth";
-export { OIDCAuth } from "./OIDCAuth";
-export { LocalAuth } from "./LocalAuth";
 export { CandidAuth } from "./CandidAuth";
+export { LocalAuth } from "./LocalAuth";
+export { OIDCAuth } from "./OIDCAuth";
+export { initialiseAuthFromConfig } from "./utils";

--- a/src/auth/utils.test.ts
+++ b/src/auth/utils.test.ts
@@ -1,0 +1,28 @@
+import { configFactory } from "testing/factories/general";
+
+import { initialiseAuthFromConfig } from "./utils";
+
+import { Auth, CandidAuth, OIDCAuth, LocalAuth } from ".";
+
+describe("initialiseAuthFromConfig", () => {
+  it("detects OIDC", () => {
+    const config = configFactory.build({ isJuju: false });
+    initialiseAuthFromConfig(config, vi.fn());
+    expect(Auth.instance).toBeInstanceOf(OIDCAuth);
+  });
+
+  it("detects candid", () => {
+    const config = configFactory.build({
+      isJuju: true,
+      identityProviderURL: "/candid",
+    });
+    initialiseAuthFromConfig(config, vi.fn());
+    expect(Auth.instance).toBeInstanceOf(CandidAuth);
+  });
+
+  it("detects local", () => {
+    const config = configFactory.build({ isJuju: true });
+    initialiseAuthFromConfig(config, vi.fn());
+    expect(Auth.instance).toBeInstanceOf(LocalAuth);
+  });
+});

--- a/src/auth/utils.ts
+++ b/src/auth/utils.ts
@@ -1,0 +1,23 @@
+import type { AppDispatch } from "store/store";
+import type { WindowConfig } from "types";
+
+import { CandidAuth, LocalAuth, OIDCAuth } from ".";
+
+/**
+ * From the provided config, initialise the `Auth` singleton instance with the correct auth
+ * implementation.
+ */
+export function initialiseAuthFromConfig(
+  config: WindowConfig,
+  dispatch: AppDispatch,
+) {
+  if (!config.isJuju) {
+    new OIDCAuth(dispatch);
+    return;
+  }
+  if (config.identityProviderURL) {
+    new CandidAuth(dispatch);
+    return;
+  }
+  new LocalAuth(dispatch);
+}

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -1,6 +1,7 @@
 import { screen, waitFor } from "@testing-library/dom";
 import { vi } from "vitest";
 
+import { Auth, LocalAuth } from "auth";
 import * as storeModule from "store";
 import { thunks as appThunks } from "store/app";
 import { actions as generalActions } from "store/general";
@@ -59,6 +60,8 @@ describe("renderApp", () => {
       document.body.removeChild(rootNode);
     }
     window.jujuDashboardConfig = undefined;
+    // @ts-expect-error - Resetting singleton for each test run.
+    delete Auth.instance;
     vi.useRealTimers();
   });
 
@@ -79,10 +82,15 @@ describe("renderApp", () => {
   });
 
   it("bootstraps if the config is found", async () => {
-    window.jujuDashboardConfig = configFactory.build();
+    const bootstrapSpy = vi.spyOn(LocalAuth.prototype, "bootstrap");
+    window.jujuDashboardConfig = configFactory.build({
+      controllerAPIEndpoint: "/api",
+      isJuju: true,
+    });
     renderApp();
     await waitFor(() => {
       expect(document.querySelector(`#${ROOT_ID}`)?.children).toHaveLength(1);
+      expect(bootstrapSpy).toHaveBeenCalledOnce();
     });
   });
 

--- a/src/juju/api-hooks/actions.test.tsx
+++ b/src/juju/api-hooks/actions.test.tsx
@@ -3,6 +3,7 @@ import * as jujuLib from "@canonical/jujulib";
 import { renderHook } from "@testing-library/react";
 import { vi } from "vitest";
 
+import { Auth, LocalAuth } from "auth";
 import type { RootState } from "store/store";
 import { rootStateFactory } from "testing/factories";
 import {
@@ -50,6 +51,12 @@ describe("actions", () => {
         },
       },
     });
+    new LocalAuth(vi.fn());
+  });
+
+  afterEach(() => {
+    // @ts-expect-error - Resetting singleton for each test run.
+    delete Auth.instance;
   });
 
   describe("useGetActionsForApplication", () => {

--- a/src/juju/api-hooks/application.test.tsx
+++ b/src/juju/api-hooks/application.test.tsx
@@ -3,6 +3,7 @@ import * as jujuLib from "@canonical/jujulib";
 import { renderHook } from "@testing-library/react";
 import { vi } from "vitest";
 
+import { Auth, LocalAuth } from "auth";
 import type { Config } from "panels/ConfigPanel/types";
 import type { RootState } from "store/store";
 import { rootStateFactory } from "testing/factories";
@@ -52,6 +53,12 @@ describe("application", () => {
         },
       },
     });
+    new LocalAuth(vi.fn());
+  });
+
+  afterEach(() => {
+    // @ts-expect-error - Resetting singleton for each test run.
+    delete Auth.instance;
   });
 
   describe("useGetApplicationConfig", () => {

--- a/src/juju/api-hooks/common.test.tsx
+++ b/src/juju/api-hooks/common.test.tsx
@@ -3,6 +3,7 @@ import type { Connection } from "@canonical/jujulib";
 import { renderHook, waitFor } from "@testing-library/react";
 import { vi } from "vitest";
 
+import { Auth, LocalAuth } from "auth";
 import type { RootState } from "store/store";
 import { rootStateFactory } from "testing/factories";
 import {
@@ -48,11 +49,14 @@ describe("useModelConnectionCallback", () => {
       },
     });
     vi.useFakeTimers();
+    new LocalAuth(vi.fn());
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
     vi.useRealTimers();
+    // @ts-expect-error - Resetting singleton for each test run.
+    delete Auth.instance;
   });
 
   it("can connect and log in", async () => {
@@ -257,6 +261,12 @@ describe("useCallWithConnectionPromise", () => {
         },
       },
     });
+    new LocalAuth(vi.fn());
+  });
+
+  afterEach(() => {
+    // @ts-expect-error - Resetting singleton for each test run.
+    delete Auth.instance;
   });
 
   it("calls the handler with args", async () => {
@@ -374,6 +384,12 @@ describe("useCallWithConnection", () => {
         },
       },
     });
+    new LocalAuth(vi.fn());
+  });
+
+  afterEach(() => {
+    // @ts-expect-error - Resetting singleton for each test run.
+    delete Auth.instance;
   });
 
   it("calls the handler with args", async () => {

--- a/src/juju/api-hooks/common.ts
+++ b/src/juju/api-hooks/common.ts
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 
 import { connectToModel } from "juju/api";
 import type { ConnectionWithFacades } from "juju/types";
-import { getConfig, getUserPass } from "store/general/selectors";
+import { getUserPass } from "store/general/selectors";
 import { getModelByUUID, getModelUUIDFromList } from "store/juju/selectors";
 import { useAppSelector } from "store/store";
 import { toErrorString } from "utils";
@@ -29,7 +29,6 @@ export const useModelConnectionCallback = (modelUUID?: string) => {
   const wsControllerURL = useAppSelector((state) =>
     getModelByUUID(state, modelUUID),
   )?.wsControllerURL;
-  const authMethod = useAppSelector(getConfig)?.authMethod;
   const credentials = useAppSelector((state) =>
     getUserPass(state, wsControllerURL),
   );
@@ -41,7 +40,7 @@ export const useModelConnectionCallback = (modelUUID?: string) => {
         // are available.
         return;
       }
-      connectToModel(modelUUID, wsControllerURL, credentials, authMethod)
+      connectToModel(modelUUID, wsControllerURL, credentials)
         .then((connection) => {
           if (!connection) {
             response({ error: Label.NO_CONNECTION_ERROR });
@@ -54,7 +53,7 @@ export const useModelConnectionCallback = (modelUUID?: string) => {
           response({ error: toErrorString(error) });
         });
     },
-    [credentials, authMethod, modelUUID, wsControllerURL],
+    [credentials, modelUUID, wsControllerURL],
   );
 };
 

--- a/src/juju/api-hooks/secrets.test.tsx
+++ b/src/juju/api-hooks/secrets.test.tsx
@@ -3,6 +3,7 @@ import type { Connection } from "@canonical/jujulib";
 import { renderHook, waitFor } from "@testing-library/react";
 import { vi } from "vitest";
 
+import { Auth, LocalAuth } from "auth";
 import { actions as jujuActions } from "store/juju";
 import type { RootState } from "store/store";
 import { rootStateFactory } from "testing/factories";
@@ -54,6 +55,12 @@ describe("useListSecrets", () => {
         },
       },
     });
+    new LocalAuth(vi.fn());
+  });
+
+  afterEach(() => {
+    // @ts-expect-error - Resetting singleton for each test run.
+    delete Auth.instance;
   });
 
   it("fetches secrets", async () => {
@@ -210,6 +217,12 @@ describe("useGetSecretContent", () => {
         },
       },
     });
+    new LocalAuth(vi.fn());
+  });
+
+  afterEach(() => {
+    // @ts-expect-error - Resetting singleton for each test run.
+    delete Auth.instance;
   });
 
   it("fetches secrets", async () => {
@@ -467,6 +480,12 @@ describe("useCreateSecrets", () => {
         },
       },
     });
+    new LocalAuth(vi.fn());
+  });
+
+  afterEach(() => {
+    // @ts-expect-error - Resetting singleton for each test run.
+    delete Auth.instance;
   });
 
   it("can create secrets", async () => {
@@ -571,6 +590,12 @@ describe("useUpdateSecrets", () => {
         },
       },
     });
+    new LocalAuth(vi.fn());
+  });
+
+  afterEach(() => {
+    // @ts-expect-error - Resetting singleton for each test run.
+    delete Auth.instance;
   });
 
   it("can update secrets", async () => {
@@ -679,6 +704,12 @@ describe("useRemoveSecrets", () => {
         },
       },
     });
+    new LocalAuth(vi.fn());
+  });
+
+  afterEach(() => {
+    // @ts-expect-error - Resetting singleton for each test run.
+    delete Auth.instance;
   });
 
   it("can remove secrets", async () => {
@@ -779,6 +810,12 @@ describe("useGrantSecret", () => {
         },
       },
     });
+    new LocalAuth(vi.fn());
+  });
+
+  afterEach(() => {
+    // @ts-expect-error - Resetting singleton for each test run.
+    delete Auth.instance;
   });
 
   it("can grant apps", async () => {
@@ -874,6 +911,12 @@ describe("useRevokeSecret", () => {
         },
       },
     });
+    new LocalAuth(vi.fn());
+  });
+
+  afterEach(() => {
+    // @ts-expect-error - Resetting singleton for each test run.
+    delete Auth.instance;
   });
 
   it("can revoke apps", async () => {

--- a/src/juju/api.test.ts
+++ b/src/juju/api.test.ts
@@ -154,7 +154,7 @@ describe("Juju API", () => {
         });
         expect(connectSpy).toHaveBeenCalledWith(
           "wss://example.com/api",
-          expect.objectContaining({ oidcEnabled: true }),
+          expect.objectContaining({ loginWithSessionCookie: true }),
         );
         expect(juju.login).toHaveBeenCalledWith(undefined, CLIENT_VERSION);
       });

--- a/src/store/app/actions.test.ts
+++ b/src/store/app/actions.test.ts
@@ -1,5 +1,3 @@
-import { AuthMethod } from "store/general/types";
-
 import type { ControllerArgs } from "./actions";
 import { updatePermissions, connectAndPollControllers } from "./actions";
 
@@ -23,7 +21,6 @@ describe("actions", () => {
     const controller: ControllerArgs = [
       "wss://example.com",
       { user: "eggman@external", password: "verysecure123" },
-      AuthMethod.LOCAL,
     ];
     const args = {
       controllers: [controller],

--- a/src/store/app/actions.ts
+++ b/src/store/app/actions.ts
@@ -1,6 +1,6 @@
 import { createAction } from "@reduxjs/toolkit";
 
-import type { AuthMethod, Credential } from "store/general/types";
+import type { Credential } from "store/general/types";
 
 export const updatePermissions = createAction<{
   action: string;
@@ -16,8 +16,6 @@ export type ControllerArgs = [
   string,
   // credentials
   Credential | undefined,
-  // authMethod
-  AuthMethod,
 ];
 
 export const connectAndPollControllers = createAction<{

--- a/src/store/app/thunks.test.ts
+++ b/src/store/app/thunks.test.ts
@@ -1,5 +1,6 @@
 import { vi } from "vitest";
 
+import { Auth, CandidAuth, OIDCAuth } from "auth";
 import { pollWhoamiStop } from "juju/jimm/listeners";
 import { actions as appActions } from "store/app";
 import { actions as generalActions } from "store/general";
@@ -59,6 +60,8 @@ describe("thunks", () => {
 
   afterEach(() => {
     delete window.jujuDashboardConfig;
+    // @ts-expect-error - Resetting singleton for each test run.
+    delete Auth.instance;
   });
 
   it("logOut", async () => {
@@ -71,6 +74,8 @@ describe("thunks", () => {
         }),
       }),
     );
+    const logoutSpy = vi.spyOn(CandidAuth.prototype, "logout");
+    new CandidAuth(dispatch);
     await action(dispatch, getState, null);
     expect(dispatch).toHaveBeenCalledWith(jujuActions.clearModelData());
     expect(dispatch).toHaveBeenCalledWith(jujuActions.clearControllerData());
@@ -81,6 +86,7 @@ describe("thunks", () => {
       null,
     );
     expect(dispatchedThunk.type).toBe("app/connectAndStartPolling/fulfilled");
+    expect(logoutSpy).toHaveBeenCalledOnce();
   });
 
   it("logOut from OIDC", async () => {
@@ -94,6 +100,8 @@ describe("thunks", () => {
         }),
       }),
     );
+    const logoutSpy = vi.spyOn(OIDCAuth.prototype, "logout");
+    new OIDCAuth(dispatch);
     await action(dispatch, getState, null);
     expect(dispatch).toHaveBeenCalledWith(jujuActions.clearModelData());
     expect(dispatch).toHaveBeenCalledWith(jujuActions.clearControllerData());
@@ -105,6 +113,7 @@ describe("thunks", () => {
       null,
     );
     expect(dispatchedThunk.type).toBe("jimm/logout/fulfilled");
+    expect(logoutSpy).toHaveBeenCalledOnce();
   });
 
   it("connectAndStartPolling", async () => {

--- a/src/store/app/thunks.test.ts
+++ b/src/store/app/thunks.test.ts
@@ -123,9 +123,7 @@ describe("thunks", () => {
     await action(dispatch, getState, null);
     expect(dispatch).toHaveBeenCalledWith(
       appActions.connectAndPollControllers({
-        controllers: [
-          ["wss://controller.example.com", undefined, AuthMethod.LOCAL],
-        ],
+        controllers: [["wss://controller.example.com", undefined]],
         isJuju: true,
       }),
     );
@@ -145,9 +143,7 @@ describe("thunks", () => {
     await action(dispatch, getState, null);
     expect(dispatch).toHaveBeenCalledWith(
       appActions.connectAndPollControllers({
-        controllers: [
-          ["wss://controller.example.com", undefined, AuthMethod.LOCAL],
-        ],
+        controllers: [["wss://controller.example.com", undefined]],
         isJuju: true,
       }),
     );
@@ -172,9 +168,7 @@ describe("thunks", () => {
     await action(dispatch, getState, null);
     expect(dispatch).toHaveBeenCalledWith(
       appActions.connectAndPollControllers({
-        controllers: [
-          ["wss://controller.example.com", undefined, AuthMethod.LOCAL],
-        ],
+        controllers: [["wss://controller.example.com", undefined]],
         isJuju: true,
       }),
     );
@@ -199,9 +193,7 @@ describe("thunks", () => {
     await action(dispatch, getState, null);
     expect(dispatch).toHaveBeenCalledWith(
       appActions.connectAndPollControllers({
-        controllers: [
-          ["wss://controller.example.com", undefined, AuthMethod.LOCAL],
-        ],
+        controllers: [["wss://controller.example.com", undefined]],
         isJuju: true,
       }),
     );

--- a/src/store/app/thunks.ts
+++ b/src/store/app/thunks.ts
@@ -11,7 +11,6 @@ import {
   getUserPass,
   getWSControllerURL,
 } from "store/general/selectors";
-import { AuthMethod } from "store/general/types";
 import { actions as jujuActions } from "store/juju";
 import type { RootState } from "store/store";
 import { logger } from "utils/logger";
@@ -55,11 +54,7 @@ export const connectAndStartPolling = createAsyncThunk<
     const controllerConnections = getControllerConnections(storeState) || {};
     let controllerList: ControllerArgs[] = [];
     if (wsControllerURL) {
-      controllerList.push([
-        wsControllerURL,
-        credentials,
-        config?.authMethod ?? AuthMethod.LOCAL,
-      ]);
+      controllerList.push([wsControllerURL, credentials]);
     }
     const connectedControllers = Object.keys(controllerConnections);
     controllerList = controllerList.filter((controllerData) => {

--- a/src/store/middleware/model-poller.test.ts
+++ b/src/store/middleware/model-poller.test.ts
@@ -45,11 +45,7 @@ describe("model poller", () => {
   let next: Mock;
   const wsControllerURL = "wss://example.com";
   const controllers: ControllerArgs[] = [
-    [
-      wsControllerURL,
-      { user: "eggman@external", password: "test" },
-      AuthMethod.LOCAL,
-    ],
+    [wsControllerURL, { user: "eggman@external", password: "test" }],
   ];
   const models = [
     {
@@ -185,7 +181,7 @@ describe("model poller", () => {
       const loginWithBakerySpy = vi.spyOn(jujuModule, "loginWithBakery");
       await runMiddleware(
         appActions.connectAndPollControllers({
-          controllers: [[wsControllerURL, undefined, AuthMethod.OIDC]],
+          controllers: [[wsControllerURL, undefined]],
           isJuju: true,
           poll: 0,
         }),
@@ -207,7 +203,7 @@ describe("model poller", () => {
         }));
       await runMiddleware(
         appActions.connectAndPollControllers({
-          controllers: [[wsControllerURL, undefined, AuthMethod.OIDC]],
+          controllers: [[wsControllerURL, undefined]],
           isJuju: true,
           poll: 0,
         }),

--- a/src/store/middleware/model-poller.ts
+++ b/src/store/middleware/model-poller.ts
@@ -62,7 +62,7 @@ export const modelPollerMiddleware: Middleware<
       // first clean up any old auth requests:
       reduxStore.dispatch(generalActions.clearVisitURLs());
       for (const controllerData of action.payload.controllers) {
-        const [wsControllerURL, credentials, authMethod] = controllerData;
+        const [wsControllerURL, credentials] = controllerData;
         let conn: ConnectionWithFacades | undefined;
         let juju: Client | undefined;
         let error: unknown;
@@ -101,7 +101,7 @@ export const modelPollerMiddleware: Middleware<
           );
           return logger.log(LoginError.LOG, e, controllerData);
         } finally {
-          if (authMethod === AuthMethod.OIDC) {
+          if (Auth.instance.name === AuthMethod.OIDC) {
             reduxStore.dispatch(generalActions.updateLoginLoading(false));
           }
         }
@@ -127,7 +127,7 @@ export const modelPollerMiddleware: Middleware<
           { dashboardVersion, controllerVersion, isJuju },
           {
             category: "Authentication",
-            action: `User Login (${authMethod})`,
+            action: `User Login (${Auth.instance.name})`,
           },
         );
 

--- a/src/testing/utils.tsx
+++ b/src/testing/utils.tsx
@@ -18,11 +18,14 @@ import {
   createMemoryRouter,
 } from "react-router";
 
+import { initialiseAuthFromConfig } from "auth";
 import generalReducer from "store/general";
 import jujuReducer from "store/juju";
 import type { RootState } from "store/store";
 import { rootStateFactory } from "testing/factories";
+import type { WindowConfig } from "types";
 
+import { configFactory } from "./factories/general";
 import queries from "./queries";
 
 type Router = ReturnType<typeof createMemoryRouter>;
@@ -76,6 +79,9 @@ export const wrapComponent = (
     options && "store" in options
       ? options.store
       : createStore(options?.state ?? rootStateFactory.build());
+  const config = store.getState().general.config || configFactory.build();
+  // TODO: (WD-20710) Remove `WindowConfig` cast once `authMethod` is removed from config.
+  initialiseAuthFromConfig(config as WindowConfig, store.dispatch);
   const router = createMemoryRouter(
     [
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -125,15 +125,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@canonical/jujulib@npm:7.0.0":
-  version: 7.0.0
-  resolution: "@canonical/jujulib@npm:7.0.0"
+"@canonical/jujulib@npm:8.0.1":
+  version: 8.0.1
+  resolution: "@canonical/jujulib@npm:8.0.1"
   dependencies:
     "@canonical/macaroon-bakery": "npm:1.3.2"
     btoa: "npm:1.2.1"
     websocket: "npm:1.0.34"
     xhr2: "npm:0.2.1"
-  checksum: 10c0/1ddfb5338ea6b4446ce3dd64b39a1d53bd5a736035f2478193879510c623f76faa225e6971b759ad5c9dc7e1412dc5f74aea0b16ef2a03869d1a48a4198c644d
+  checksum: 10c0/c39965f2156b743e11f61d4d0577cb6840fd835ce8d06ab40ad70b025449afb926e655294793eb7f42cc303f403120db021b0673dfddf4837a7af24d217b2ff9
   languageName: node
   linkType: hard
 
@@ -7740,7 +7740,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "juju-dashboard@workspace:."
   dependencies:
-    "@canonical/jujulib": "npm:7.0.0"
+    "@canonical/jujulib": "npm:8.0.1"
     "@canonical/macaroon-bakery": "npm:1.3.2"
     "@canonical/react-components": "npm:2.2.0"
     "@canonical/rebac-admin": "npm:0.0.1-alpha.12"


### PR DESCRIPTION
## Done

- Utilise `Auth` methods (WD-20708)
- Update `js-libjuju` to `8.0.1`

## QA

### `LocalAuth`

- Ensure local juju multipass is running
- `yarn start`
- http://localhost:8036
- Login with local user account
- Verify dashboard functionality
- Logout of user in bottom left corner

### `OIDCAuth`

- Ensure access to JIMM instance
- `sudo yarn start-jaas --port 443`
- https://jimm-dashboard.k8s.dev.canonical.com
- Login with Google account
- Verify dashboard functionality
- Logout of user in bottom left corner

### `CandidAuth`

- Ensure access to [Juju controller with Candid](https://github.com/canonical/juju-dashboard/blob/main/HACKING.md#juju-controller-with-candid)
- `yarn start`
- http://localhost:8036
- Login with external account
- Verify dashboard functionality
- Logout of user in bottom left corner

## Details

Unfortunately this is a bit of a messy PR as it touches a lot of things.

The majority of the changes relate to tests, as it is now required that _an_ instance of `Auth` is initialised in the singleton for (many) of the tests to run. To deal with this, in some `beforeEach` hooks a specific instance of `Auth` is created based on the requirements of the test (OIDC/Candid/etc). Initialising the `Auth` instance in `setup.ts` seemed to cause a variety of errors across a large selection of tests.