### PR TITLE
feat: hoist login state

### DIFF
--- a/src/auth/OIDCAuth.test.ts
+++ b/src/auth/OIDCAuth.test.ts
@@ -46,14 +46,12 @@ describe("OIDCAuth", () => {
       const pollWhoamiStartMock = vi.spyOn(jimmListeners, "pollWhoamiStart");
       const storeLoginErrorMock = vi.spyOn(generalActions, "storeLoginError");
       dispatch
-        // Loading start
-        .mockResolvedValueOnce({})
         // whoami
         .mockResolvedValueOnce({ payload: {} });
       const connectionContinue = await Auth.instance.beforeControllerConnect({
         wsControllerURL: "wss://1.2.3.4/api",
       });
-      expect(dispatch).toBeCalledTimes(3);
+      expect(dispatch).toBeCalledTimes(2);
       expect(whoamiThunkMock).toHaveBeenCalledOnce();
       expect(pollWhoamiStartMock).toHaveBeenCalledOnce();
       expect(connectionContinue).to.equal(true);
@@ -65,14 +63,12 @@ describe("OIDCAuth", () => {
       const pollWhoamiStartMock = vi.spyOn(jimmListeners, "pollWhoamiStart");
       const storeLoginErrorMock = vi.spyOn(generalActions, "storeLoginError");
       dispatch
-        // Loading start
-        .mockResolvedValueOnce({})
         // whoami
         .mockResolvedValueOnce({ payload: null });
       const connectionContinue = await Auth.instance.beforeControllerConnect({
         wsControllerURL: "wss://1.2.3.4/api",
       });
-      expect(dispatch).toBeCalledTimes(3);
+      expect(dispatch).toBeCalledTimes(1);
       expect(whoamiThunkMock).toHaveBeenCalledOnce();
       expect(pollWhoamiStartMock).not.toHaveBeenCalled();
       expect(connectionContinue).to.equal(false);
@@ -84,8 +80,6 @@ describe("OIDCAuth", () => {
       const pollWhoamiStartMock = vi.spyOn(jimmListeners, "pollWhoamiStart");
       const storeLoginErrorMock = vi.spyOn(generalActions, "storeLoginError");
       dispatch
-        // Loading start
-        .mockResolvedValueOnce({})
         // whoami
         .mockResolvedValueOnce({
           payload: undefined,
@@ -94,7 +88,7 @@ describe("OIDCAuth", () => {
       const connectionContinue = await Auth.instance.beforeControllerConnect({
         wsControllerURL: "wss://1.2.3.4/api",
       });
-      expect(dispatch).toBeCalledTimes(3);
+      expect(dispatch).toBeCalledTimes(2);
       expect(whoamiThunkMock).toHaveBeenCalledOnce();
       expect(pollWhoamiStartMock).not.toHaveBeenCalled();
       expect(connectionContinue).to.equal(false);

--- a/src/auth/OIDCAuth.ts
+++ b/src/auth/OIDCAuth.ts
@@ -34,8 +34,6 @@ export class OIDCAuth extends pollingMixin(Auth) {
     wsControllerURL,
   }: ControllerData): Promise<boolean> {
     try {
-      // TODO: (WD-20709) Hoist loading state into model-poller.
-      this.dispatch(generalActions.updateLoginLoading(true));
       const whoamiResponse = await this.dispatch(jimmThunks.whoami());
       const user = unwrapResult(whoamiResponse);
       if (user) {
@@ -45,8 +43,6 @@ export class OIDCAuth extends pollingMixin(Auth) {
       } else {
         // If there's no response that means the user is not
         // authenticated, so halt the connection attempt.
-        // TODO: (WD-20709) Hoist loading state into model-poller.
-        this.dispatch(generalActions.updateLoginLoading(false));
         return false;
       }
     } catch (error) {

--- a/src/components/LogIn/IdentityProviderForm/IdentityProviderForm.tsx
+++ b/src/components/LogIn/IdentityProviderForm/IdentityProviderForm.tsx
@@ -1,7 +1,8 @@
 import { Spinner } from "@canonical/react-components";
 
 import AuthenticationButton from "components/AuthenticationButton";
-import { useAppSelector } from "store/store";
+import { actions as generalActions } from "store/general";
+import { useAppDispatch, useAppSelector } from "store/store";
 
 import { Label } from "../types";
 
@@ -20,12 +21,14 @@ const IdentityProviderForm = ({ userIsLoggedIn }: Props) => {
       return state?.general?.visitURLs?.[0];
     }
   });
+  const dispatch = useAppDispatch();
 
   return visitURL ? (
     <AuthenticationButton
       appearance="positive"
       visitURL={visitURL}
       data-testid={TestId.CANDID_LOGIN}
+      onClick={() => dispatch(generalActions.updateLoginLoading(true))}
     >
       {Label.LOGIN_TO_DASHBOARD}
     </AuthenticationButton>

--- a/src/components/LogIn/LogIn.tsx
+++ b/src/components/LogIn/LogIn.tsx
@@ -1,3 +1,4 @@
+import { Spinner } from "@canonical/react-components";
 import type { ReactNode } from "react";
 import { useEffect, useRef } from "react";
 import reactHotToast from "react-hot-toast";
@@ -15,6 +16,7 @@ import {
   getWSControllerURL,
   isLoggedIn,
   getIsJuju,
+  getLoginLoading,
 } from "store/general/selectors";
 import { AuthMethod } from "store/general/types";
 import { useAppSelector } from "store/store";
@@ -36,6 +38,7 @@ export default function LogIn() {
     getLoginError(state, wsControllerURL),
   );
   const visitURLs = useAppSelector(getVisitURLs);
+  const loginLoading = useAppSelector(getLoginLoading);
 
   // This login component wraps all other views, so this useEffect will run each
   // time we get an authentication request.
@@ -71,16 +74,24 @@ export default function LogIn() {
   }, [visitURLs]);
 
   let form: ReactNode = null;
-  switch (config?.authMethod) {
-    case AuthMethod.CANDID:
-      form = <IdentityProviderForm userIsLoggedIn={userIsLoggedIn} />;
-      break;
-    case AuthMethod.OIDC:
-      form = <OIDCForm />;
-      break;
-    default:
-      form = <UserPassForm />;
-      break;
+  if (loginLoading) {
+    form = (
+      <button className="p-button--neutral" disabled>
+        <Spinner text="Connecting..." />
+      </button>
+    );
+  } else {
+    switch (config?.authMethod) {
+      case AuthMethod.CANDID:
+        form = <IdentityProviderForm userIsLoggedIn={userIsLoggedIn} />;
+        break;
+      case AuthMethod.OIDC:
+        form = <OIDCForm />;
+        break;
+      default:
+        form = <UserPassForm />;
+        break;
+    }
   }
 
   return (

--- a/src/components/LogIn/OIDCForm/OIDCForm.test.tsx
+++ b/src/components/LogIn/OIDCForm/OIDCForm.test.tsx
@@ -3,8 +3,6 @@ import userEvent from "@testing-library/user-event";
 
 import { endpoints } from "juju/jimm/api";
 import * as dashboardStore from "store/store";
-import { rootStateFactory } from "testing/factories";
-import { generalStateFactory } from "testing/factories/general";
 import { renderComponent } from "testing/utils";
 
 import { Label } from "../types";
@@ -17,21 +15,6 @@ describe("OIDCForm", () => {
     expect(
       screen.getByRole("link", { name: Label.LOGIN_TO_DASHBOARD }),
     ).toHaveAttribute("href", endpoints().login);
-  });
-
-  it("should render spinner after getting redirected", () => {
-    const state = rootStateFactory.build({
-      general: generalStateFactory.build({
-        login: {
-          errors: {},
-          loading: true,
-        },
-      }),
-    });
-    renderComponent(<OIDCForm />, { state });
-    expect(
-      screen.getByRole("button", { name: Label.LOADING }),
-    ).toBeInTheDocument();
   });
 
   it("should dispatch event to update loading state on click", async () => {

--- a/src/components/LogIn/OIDCForm/OIDCForm.tsx
+++ b/src/components/LogIn/OIDCForm/OIDCForm.tsx
@@ -1,9 +1,8 @@
-import { Button, Spinner } from "@canonical/react-components";
+import { Button } from "@canonical/react-components";
 
 import { endpoints } from "juju/jimm/api";
 import { actions as generalActions } from "store/general";
-import { getLoginLoading } from "store/general/selectors";
-import { useAppDispatch, useAppSelector } from "store/store";
+import { useAppDispatch } from "store/store";
 
 import { Label } from "../types";
 
@@ -11,13 +10,8 @@ import { TestId } from "./types";
 
 const OIDCForm = () => {
   const dispatch = useAppDispatch();
-  const loginLoading = useAppSelector(getLoginLoading);
 
-  return loginLoading ? (
-    <button className="p-button--neutral" disabled>
-      <Spinner text="Connecting..." />
-    </button>
-  ) : (
+  return (
     <Button
       appearance="positive"
       element="a"

--- a/src/components/LogIn/UserPassForm/UserPassForm.test.tsx
+++ b/src/components/LogIn/UserPassForm/UserPassForm.test.tsx
@@ -47,7 +47,10 @@ describe("UserPassForm", () => {
       type: "general/cleanupLoginErrors",
     });
     expect(mockUseAppDispatch.mock.calls[1][0]).toMatchObject(storeAction);
-    expect(mockUseAppDispatch.mock.calls[2][0]).toMatchObject({
+    expect(mockUseAppDispatch.mock.calls[2][0]).toMatchObject(
+      generalActions.updateLoginLoading(true),
+    );
+    expect(mockUseAppDispatch.mock.calls[3][0]).toMatchObject({
       type: "connectAndStartPolling",
     });
   });

--- a/src/components/LogIn/UserPassForm/UserPassForm.tsx
+++ b/src/components/LogIn/UserPassForm/UserPassForm.tsx
@@ -33,6 +33,7 @@ const UserPassForm = () => {
         credential: { user, password },
       }),
     );
+    dispatch(generalActions.updateLoginLoading(true));
     if (bakery) {
       dispatch(appThunks.connectAndStartPolling())
         .then(unwrapResult)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -155,7 +155,6 @@ function bootstrap() {
   reduxStore.dispatch(generalActions.storeVersion(appVersion));
 
   initialiseAuthFromConfig(config, reduxStore.dispatch);
-  console.log("bootstrapping", Auth.instance);
   void Auth.instance.bootstrap();
 
   getRoot()?.render(

--- a/src/juju/bakery.ts
+++ b/src/juju/bakery.ts
@@ -6,6 +6,7 @@ import reduxStore from "store/store";
 const bakery = new Bakery({
   visitPage: (resp) => {
     reduxStore.dispatch(generalActions.storeVisitURL(resp.Info.VisitURL));
+    reduxStore.dispatch(generalActions.updateLoginLoading(false));
   },
   storage: new BakeryStorage(localStorage, {}),
 });


### PR DESCRIPTION
WD-20709

## Done

- Move spinner logic out of `OIDCForm` to `LogIn`

## QA

### `LocalAuth`

- Ensure local juju multipass is running
- `yarn start`
- http://localhost:8036
- Login with local user account

### `OIDCAuth`

- Ensure access to JIMM instance
- `sudo yarn start-jaas --port 443`
- https://jimm-dashboard.k8s.dev.canonical.com
- Login with Google account

### `CandidAuth`

- Ensure access to [Juju controller with Candid](https://github.com/canonical/juju-dashboard/blob/main/HACKING.md#juju-controller-with-candid)
- `yarn start`
- http://localhost:8036
- Login with external account
