### PR TITLE
feat: abstract authentication into `AuthMethod`

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     ]
   },
   "dependencies": {
-    "@canonical/jujulib": "7.0.0",
+    "@canonical/jujulib": "8.0.1",
     "@canonical/macaroon-bakery": "1.3.2",
     "@canonical/react-components": "2.2.0",
     "@canonical/rebac-admin": "0.0.1-alpha.12",

--- a/src/auth/Auth.test.ts
+++ b/src/auth/Auth.test.ts
@@ -1,0 +1,32 @@
+import { AuthMethod } from "store/general/types";
+
+import { Auth } from "./Auth";
+
+describe("Auth base class", () => {
+  beforeEach(() => {
+    // @ts-expect-error - Resetting singleton for each test run.
+    delete Auth.instance;
+  });
+
+  it("creates new singleton instance", () => {
+    expect(Auth.instance).not.toBeDefined();
+    const instance = new Auth(vi.fn(), AuthMethod.LOCAL);
+    expect(Auth.instance).to.equal(instance);
+  });
+
+  it("overrides singleton instance", () => {
+    const instance1 = new Auth(vi.fn(), AuthMethod.LOCAL);
+    const instance2 = new Auth(vi.fn(), AuthMethod.LOCAL);
+    expect(Auth.instance).not.to.equal(instance1);
+    expect(Auth.instance).to.equal(instance2);
+  });
+
+  it("continues controller connection by default", async () => {
+    const instance = new Auth(vi.fn(), AuthMethod.LOCAL);
+    await expect(
+      instance.beforeControllerConnect({
+        wsControllerURL: "wss://1.2.3.4/api",
+      }),
+    ).resolves.to.equal(true);
+  });
+});

--- a/src/auth/Auth.test.ts
+++ b/src/auth/Auth.test.ts
@@ -1,6 +1,4 @@
-import { AuthMethod } from "store/general/types";
-
-import { Auth } from "./Auth";
+import { Auth, AuthMethod } from ".";
 
 describe("Auth base class", () => {
   beforeEach(() => {

--- a/src/auth/Auth.ts
+++ b/src/auth/Auth.ts
@@ -4,9 +4,11 @@
 import type { ConnectOptions, Credentials } from "@canonical/jujulib";
 
 import type { ConnectionWithFacades } from "juju/types";
-import type { AuthMethod, Credential } from "store/general/types";
+import type { Credential } from "store/general/types";
 import type { AppDispatch } from "store/store";
 import { logger } from "utils/logger";
+
+import type { AuthMethod } from ".";
 
 export type ControllerData = {
   wsControllerURL: string;

--- a/src/auth/Auth.ts
+++ b/src/auth/Auth.ts
@@ -1,0 +1,104 @@
+/* eslint-disable @typescript-eslint/no-unused-vars -- This file contains a base class with a lot
+   of unused paramters. */
+
+import type { ConnectOptions, Credentials } from "@canonical/jujulib";
+
+import type { ConnectionWithFacades } from "juju/types";
+import type { AuthMethod, Credential } from "store/general/types";
+import type { AppDispatch } from "store/store";
+import { logger } from "utils/logger";
+
+export type ControllerData = {
+  wsControllerURL: string;
+  credentials?: Credential;
+};
+
+/**
+ * Base class for authentication providers. The stubbed lifecycle methods are called throughout the
+ * dashboard. Authentication implementations should extend this class and override the relevant
+ * methods.
+ *
+ * This class should be consumed as a singleton via the `instance` property (eg.
+ * `Auth.instance.logout()`). The singleton is set in the base class's constructor.
+ */
+export class Auth {
+  /**
+   * Singleton instance of the auth provider.
+   */
+  static instance: Auth;
+
+  /**
+   * Redux dispatch method for use within auth implementations.
+   */
+  protected dispatch: AppDispatch;
+
+  /**
+   * Identifier of the auth method.
+   */
+  public name: AuthMethod;
+
+  /**
+   * Create a new instance of the singleton using the provided store dispatch, and auth method
+   * name. This constructor should only be called once (including via extended classes), as it will
+   * override the previously instantiated singleton instance.
+   */
+  constructor(dispatch: AppDispatch, name: AuthMethod) {
+    if (Auth.instance) {
+      logger.warn(
+        "Singleton instance already exists, and is being re-constructed. Overriding previous instance with incoming.",
+      );
+    }
+
+    Auth.instance = this;
+    this.dispatch = dispatch;
+    this.name = name;
+  }
+
+  /**
+   * Executed at the conclusion of the dashboard's bootstrap method.
+   */
+  async bootstrap(): Promise<void> {}
+
+  /**
+   * Logout functionality for the authentication provider.
+   */
+  async logout(): Promise<void> {}
+
+  /**
+   * Executed after the controller list is fetched.
+   *
+   * @param conn - Controller connection.
+   */
+  async afterControllerListFetched(
+    conn: ConnectionWithFacades,
+  ): Promise<void> {}
+
+  /**
+   * Executed before a connection is initiated with a controller.
+   *
+   * @returns Whether to continue the connection attempt.
+   */
+  async beforeControllerConnect(
+    controllerData: ControllerData,
+  ): Promise<boolean> {
+    return true;
+  }
+
+  /**
+   * Produces `ConnectOptions` for jujulib.
+   *
+   * @returns Connection options to merge with existing jujulib connection options.
+   */
+  jujulibConnectOptions(): Partial<ConnectOptions> | undefined {
+    return undefined;
+  }
+
+  /**
+   * Produces login parameters to use with jujulib.
+   *
+   * @returns Credentials to provide to jujulib for connection.
+   */
+  determineCredentials(credential?: Credential): Credentials | undefined {
+    return undefined;
+  }
+}

--- a/src/auth/Auth.ts
+++ b/src/auth/Auth.ts
@@ -98,7 +98,9 @@ export class Auth {
    *
    * @returns Credentials to provide to jujulib for connection.
    */
-  determineCredentials(credential?: Credential): Credentials | undefined {
+  determineCredentials(
+    credential?: Credential | null,
+  ): Credentials | undefined {
     return undefined;
   }
 }

--- a/src/auth/CandidAuth.test.ts
+++ b/src/auth/CandidAuth.test.ts
@@ -1,0 +1,79 @@
+import type { Mock, MockInstance } from "vitest";
+
+import * as jujuApi from "juju/api";
+import type { ConnectionWithFacades } from "juju/types";
+import { thunks as appThunks } from "store/app";
+
+import { Auth } from "./Auth";
+import { CandidAuth } from "./CandidAuth";
+
+describe("CandidAuth", () => {
+  let dispatch: Mock;
+
+  beforeEach(() => {
+    dispatch = vi.fn();
+    new CandidAuth(dispatch);
+  });
+
+  afterEach(() => {
+    // @ts-expect-error - Resetting singleton for each test run.
+    delete Auth.instance;
+  });
+
+  describe("logout", () => {
+    let connectAndStartPollingMock: MockInstance;
+
+    beforeEach(() => {
+      connectAndStartPollingMock = vi.spyOn(
+        appThunks,
+        "connectAndStartPolling",
+      );
+    });
+
+    it("polling success", async () => {
+      dispatch.mockResolvedValue({ payload: {} });
+      await Auth.instance.logout();
+      expect(dispatch).toHaveBeenCalledOnce();
+      expect(connectAndStartPollingMock).toHaveBeenCalledOnce();
+    });
+
+    it("polling error", async () => {
+      dispatch.mockResolvedValue({
+        payload: null,
+        error: new Error("some error"),
+      });
+      await Auth.instance.logout();
+      expect(dispatch).toHaveBeenCalledOnce();
+      expect(connectAndStartPollingMock).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("afterControllerListFetched", () => {
+    let jujuDisableControllerUUIDMaskingMock: MockInstance;
+
+    beforeEach(() => {
+      jujuDisableControllerUUIDMaskingMock = vi.spyOn(
+        jujuApi,
+        "disableControllerUUIDMasking",
+      );
+    });
+
+    it("mask disable success", async () => {
+      jujuDisableControllerUUIDMaskingMock.mockReturnValue(Promise.resolve());
+      await Auth.instance.afterControllerListFetched(
+        {} as ConnectionWithFacades,
+      );
+      expect(jujuDisableControllerUUIDMaskingMock).toHaveBeenCalledOnce();
+    });
+
+    it("mask disable error", async () => {
+      jujuDisableControllerUUIDMaskingMock.mockRejectedValue(
+        new Error("some error"),
+      );
+      await Auth.instance.afterControllerListFetched(
+        {} as ConnectionWithFacades,
+      );
+      expect(jujuDisableControllerUUIDMaskingMock).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/src/auth/CandidAuth.ts
+++ b/src/auth/CandidAuth.ts
@@ -1,11 +1,12 @@
 import * as jujuApi from "juju/api";
 import type { ConnectionWithFacades } from "juju/types";
 import { thunks as appThunks } from "store/app";
-import { AuthMethod } from "store/general/types";
 import type { AppDispatch } from "store/store";
 
 import { Auth } from "./Auth";
 import { pollingMixin } from "./mixins";
+
+import { AuthMethod } from ".";
 
 export class CandidAuth extends pollingMixin(Auth) {
   constructor(dispatch: AppDispatch) {

--- a/src/auth/CandidAuth.ts
+++ b/src/auth/CandidAuth.ts
@@ -1,0 +1,34 @@
+import * as jujuApi from "juju/api";
+import type { ConnectionWithFacades } from "juju/types";
+import { thunks as appThunks } from "store/app";
+import { AuthMethod } from "store/general/types";
+import type { AppDispatch } from "store/store";
+
+import { Auth } from "./Auth";
+import { pollingMixin } from "./mixins";
+
+export class CandidAuth extends pollingMixin(Auth) {
+  constructor(dispatch: AppDispatch) {
+    super(dispatch, AuthMethod.CANDID);
+  }
+
+  override async logout(): Promise<void> {
+    // To enable users to log back in after logging out we have to re-connect
+    // to the controller to get another wait url and start polling on it
+    // again.
+    await this.dispatch(appThunks.connectAndStartPolling());
+  }
+
+  override async afterControllerListFetched(
+    conn: ConnectionWithFacades,
+  ): Promise<void> {
+    // This call will be a noop if the user isn't an administrator
+    // on the JIMM controller we're connected to.
+    try {
+      await jujuApi.disableControllerUUIDMasking(conn);
+    } catch (e) {
+      // Silently fail, if this doesn't work then the user isn't authorized
+      // to perform the action.
+    }
+  }
+}

--- a/src/auth/LocalAuth.test.ts
+++ b/src/auth/LocalAuth.test.ts
@@ -1,0 +1,36 @@
+import type { Mock } from "vitest";
+
+import { Auth } from "./Auth";
+import { LocalAuth } from "./LocalAuth";
+
+describe("LocalAuth", () => {
+  let dispatch: Mock;
+
+  beforeEach(() => {
+    dispatch = vi.fn();
+    new LocalAuth(dispatch);
+  });
+
+  afterEach(() => {
+    // @ts-expect-error - Resetting singleton for each test run.
+    delete Auth.instance;
+  });
+
+  describe("determineCredentials", () => {
+    it("no credential", () => {
+      expect(Auth.instance.determineCredentials()).toBeUndefined();
+    });
+
+    it("provided credentials", () => {
+      expect(
+        Auth.instance.determineCredentials({
+          user: "some-user",
+          password: "some-password",
+        }),
+      ).toEqual({
+        username: "some-user",
+        password: "some-password",
+      });
+    });
+  });
+});

--- a/src/auth/LocalAuth.ts
+++ b/src/auth/LocalAuth.ts
@@ -1,10 +1,11 @@
 import type { Credentials } from "@canonical/jujulib";
 
 import type { Credential } from "store/general/types";
-import { AuthMethod } from "store/general/types";
 import type { AppDispatch } from "store/store";
 
 import { Auth } from "./Auth";
+
+import { AuthMethod } from ".";
 
 export class LocalAuth extends Auth {
   constructor(dispatch: AppDispatch) {

--- a/src/auth/LocalAuth.ts
+++ b/src/auth/LocalAuth.ts
@@ -11,7 +11,9 @@ export class LocalAuth extends Auth {
     super(dispatch, AuthMethod.LOCAL);
   }
 
-  determineCredentials(credential?: Credential): Credentials | undefined {
+  determineCredentials(
+    credential?: Credential | null,
+  ): Credentials | undefined {
     if (!credential) {
       return;
     }

--- a/src/auth/LocalAuth.ts
+++ b/src/auth/LocalAuth.ts
@@ -1,0 +1,24 @@
+import type { Credentials } from "@canonical/jujulib";
+
+import type { Credential } from "store/general/types";
+import { AuthMethod } from "store/general/types";
+import type { AppDispatch } from "store/store";
+
+import { Auth } from "./Auth";
+
+export class LocalAuth extends Auth {
+  constructor(dispatch: AppDispatch) {
+    super(dispatch, AuthMethod.LOCAL);
+  }
+
+  determineCredentials(credential?: Credential): Credentials | undefined {
+    if (!credential) {
+      return;
+    }
+
+    return {
+      username: credential.user,
+      password: credential.password,
+    };
+  }
+}

--- a/src/auth/OIDCAuth.test.ts
+++ b/src/auth/OIDCAuth.test.ts
@@ -1,0 +1,110 @@
+import type { Mock } from "vitest";
+
+import * as jimmListeners from "juju/jimm/listeners";
+import * as jimmThunks from "juju/jimm/thunks";
+import { actions as generalActions } from "store/general";
+
+import { Auth } from "./Auth";
+import { OIDCAuth } from "./OIDCAuth";
+
+describe("OIDCAuth", () => {
+  let dispatch: Mock;
+
+  beforeEach(() => {
+    dispatch = vi.fn();
+    new OIDCAuth(dispatch);
+  });
+
+  afterEach(() => {
+    // @ts-expect-error - Resetting singleton for each test run.
+    delete Auth.instance;
+  });
+
+  it("bootstrap", async () => {
+    // Since `OIDCAuth` is created with a mixin, fetch the anonymous class's prototype to spy on.
+    const pollingAuthBootstrapMock = vi.spyOn(
+      Object.getPrototypeOf(OIDCAuth).prototype,
+      "bootstrap",
+    );
+    const addWhoamiListenerMock = vi.spyOn(jimmListeners, "addWhoamiListener");
+    await Auth.instance.bootstrap();
+    expect(addWhoamiListenerMock).toHaveBeenCalledOnce();
+    expect(pollingAuthBootstrapMock).toHaveBeenCalledOnce();
+  });
+
+  it("logout", async () => {
+    const logoutMock = vi.spyOn(jimmThunks, "logout");
+    await Auth.instance.logout();
+    expect(dispatch).toBeCalledTimes(2);
+    expect(dispatch).nthCalledWith(1, jimmListeners.pollWhoamiStop());
+    expect(logoutMock).toHaveBeenCalledOnce();
+  });
+
+  describe("beforeControllerConnect", () => {
+    it("with user", async () => {
+      const whoamiThunkMock = vi.spyOn(jimmThunks, "whoami");
+      const pollWhoamiStartMock = vi.spyOn(jimmListeners, "pollWhoamiStart");
+      const storeLoginErrorMock = vi.spyOn(generalActions, "storeLoginError");
+      dispatch
+        // Loading start
+        .mockResolvedValueOnce({})
+        // whoami
+        .mockResolvedValueOnce({ payload: {} });
+      const connectionContinue = await Auth.instance.beforeControllerConnect({
+        wsControllerURL: "wss://1.2.3.4/api",
+      });
+      expect(dispatch).toBeCalledTimes(3);
+      expect(whoamiThunkMock).toHaveBeenCalledOnce();
+      expect(pollWhoamiStartMock).toHaveBeenCalledOnce();
+      expect(connectionContinue).to.equal(true);
+      expect(storeLoginErrorMock).not.toHaveBeenCalledOnce();
+    });
+
+    it("without user", async () => {
+      const whoamiThunkMock = vi.spyOn(jimmThunks, "whoami");
+      const pollWhoamiStartMock = vi.spyOn(jimmListeners, "pollWhoamiStart");
+      const storeLoginErrorMock = vi.spyOn(generalActions, "storeLoginError");
+      dispatch
+        // Loading start
+        .mockResolvedValueOnce({})
+        // whoami
+        .mockResolvedValueOnce({ payload: null });
+      const connectionContinue = await Auth.instance.beforeControllerConnect({
+        wsControllerURL: "wss://1.2.3.4/api",
+      });
+      expect(dispatch).toBeCalledTimes(3);
+      expect(whoamiThunkMock).toHaveBeenCalledOnce();
+      expect(pollWhoamiStartMock).not.toHaveBeenCalled();
+      expect(connectionContinue).to.equal(false);
+      expect(storeLoginErrorMock).not.toHaveBeenCalledOnce();
+    });
+
+    it("with user error", async () => {
+      const whoamiThunkMock = vi.spyOn(jimmThunks, "whoami");
+      const pollWhoamiStartMock = vi.spyOn(jimmListeners, "pollWhoamiStart");
+      const storeLoginErrorMock = vi.spyOn(generalActions, "storeLoginError");
+      dispatch
+        // Loading start
+        .mockResolvedValueOnce({})
+        // whoami
+        .mockResolvedValueOnce({
+          payload: undefined,
+          error: new Error("some error"),
+        });
+      const connectionContinue = await Auth.instance.beforeControllerConnect({
+        wsControllerURL: "wss://1.2.3.4/api",
+      });
+      expect(dispatch).toBeCalledTimes(3);
+      expect(whoamiThunkMock).toHaveBeenCalledOnce();
+      expect(pollWhoamiStartMock).not.toHaveBeenCalled();
+      expect(connectionContinue).to.equal(false);
+      expect(storeLoginErrorMock).toHaveBeenCalledOnce();
+    });
+  });
+
+  it("jujulibConnectOptions", () => {
+    expect(Auth.instance.jujulibConnectOptions()).to.deep.equal({
+      oidcEnabled: true,
+    });
+  });
+});

--- a/src/auth/OIDCAuth.test.ts
+++ b/src/auth/OIDCAuth.test.ts
@@ -104,7 +104,7 @@ describe("OIDCAuth", () => {
 
   it("jujulibConnectOptions", () => {
     expect(Auth.instance.jujulibConnectOptions()).to.deep.equal({
-      oidcEnabled: true,
+      loginWithSessionCookie: true,
     });
   });
 });

--- a/src/auth/OIDCAuth.test.ts
+++ b/src/auth/OIDCAuth.test.ts
@@ -46,14 +46,12 @@ describe("OIDCAuth", () => {
       const pollWhoamiStartMock = vi.spyOn(jimmListeners, "pollWhoamiStart");
       const storeLoginErrorMock = vi.spyOn(generalActions, "storeLoginError");
       dispatch
-        // Loading start
-        .mockResolvedValueOnce({})
         // whoami
         .mockResolvedValueOnce({ payload: {} });
       const connectionContinue = await Auth.instance.beforeControllerConnect({
         wsControllerURL: "wss://1.2.3.4/api",
       });
-      expect(dispatch).toBeCalledTimes(3);
+      expect(dispatch).toBeCalledTimes(2);
       expect(whoamiThunkMock).toHaveBeenCalledOnce();
       expect(pollWhoamiStartMock).toHaveBeenCalledOnce();
       expect(connectionContinue).to.equal(true);
@@ -65,14 +63,12 @@ describe("OIDCAuth", () => {
       const pollWhoamiStartMock = vi.spyOn(jimmListeners, "pollWhoamiStart");
       const storeLoginErrorMock = vi.spyOn(generalActions, "storeLoginError");
       dispatch
-        // Loading start
-        .mockResolvedValueOnce({})
         // whoami
         .mockResolvedValueOnce({ payload: null });
       const connectionContinue = await Auth.instance.beforeControllerConnect({
         wsControllerURL: "wss://1.2.3.4/api",
       });
-      expect(dispatch).toBeCalledTimes(3);
+      expect(dispatch).toBeCalledTimes(1);
       expect(whoamiThunkMock).toHaveBeenCalledOnce();
       expect(pollWhoamiStartMock).not.toHaveBeenCalled();
       expect(connectionContinue).to.equal(false);
@@ -84,8 +80,6 @@ describe("OIDCAuth", () => {
       const pollWhoamiStartMock = vi.spyOn(jimmListeners, "pollWhoamiStart");
       const storeLoginErrorMock = vi.spyOn(generalActions, "storeLoginError");
       dispatch
-        // Loading start
-        .mockResolvedValueOnce({})
         // whoami
         .mockResolvedValueOnce({
           payload: undefined,
@@ -94,7 +88,7 @@ describe("OIDCAuth", () => {
       const connectionContinue = await Auth.instance.beforeControllerConnect({
         wsControllerURL: "wss://1.2.3.4/api",
       });
-      expect(dispatch).toBeCalledTimes(3);
+      expect(dispatch).toBeCalledTimes(2);
       expect(whoamiThunkMock).toHaveBeenCalledOnce();
       expect(pollWhoamiStartMock).not.toHaveBeenCalled();
       expect(connectionContinue).to.equal(false);

--- a/src/auth/OIDCAuth.ts
+++ b/src/auth/OIDCAuth.ts
@@ -1,0 +1,72 @@
+import type { ConnectOptions } from "@canonical/jujulib";
+import { unwrapResult } from "@reduxjs/toolkit";
+
+import * as jimmListeners from "juju/jimm/listeners";
+import * as jimmThunks from "juju/jimm/thunks";
+import { actions as generalActions } from "store/general";
+import { AuthMethod } from "store/general/types";
+import { listenerMiddleware } from "store/listenerMiddleware";
+import type { AppDispatch } from "store/store";
+
+import { Auth, type ControllerData } from "./Auth";
+import { pollingMixin } from "./mixins";
+
+export enum Label {
+  WHOAMI = "Unable to check authentication status. You can attempt to log in anyway.",
+}
+
+export class OIDCAuth extends pollingMixin(Auth) {
+  constructor(dispatch: AppDispatch) {
+    super(dispatch, AuthMethod.OIDC);
+  }
+
+  override async bootstrap(): Promise<void> {
+    jimmListeners.addWhoamiListener(listenerMiddleware.startListening);
+    await super.bootstrap();
+  }
+
+  override async logout(): Promise<void> {
+    this.dispatch(jimmListeners.pollWhoamiStop());
+    await this.dispatch(jimmThunks.logout());
+  }
+
+  override async beforeControllerConnect({
+    wsControllerURL,
+  }: ControllerData): Promise<boolean> {
+    try {
+      // TODO: (WD-20709) Hoist loading state into model-poller.
+      this.dispatch(generalActions.updateLoginLoading(true));
+      const whoamiResponse = await this.dispatch(jimmThunks.whoami());
+      const user = unwrapResult(whoamiResponse);
+      if (user) {
+        // Start polling the whoami endpoint to handle refresh tokens
+        // and revoked sessions.
+        this.dispatch(jimmListeners.pollWhoamiStart());
+      } else {
+        // If there's no response that means the user is not
+        // authenticated, so halt the connection attempt.
+        // TODO: (WD-20709) Hoist loading state into model-poller.
+        this.dispatch(generalActions.updateLoginLoading(false));
+        return false;
+      }
+    } catch (error) {
+      this.dispatch(
+        generalActions.storeLoginError({
+          wsControllerURL,
+          error: Label.WHOAMI,
+        }),
+      );
+      // Halt the connection attempt.
+      return false;
+    }
+
+    return true;
+  }
+
+  override jujulibConnectOptions(): Partial<ConnectOptions> {
+    return {
+      // TODO: (WD-20703) Replace with libjuju@8.0.1
+      oidcEnabled: true,
+    };
+  }
+}

--- a/src/auth/OIDCAuth.ts
+++ b/src/auth/OIDCAuth.ts
@@ -65,8 +65,7 @@ export class OIDCAuth extends pollingMixin(Auth) {
 
   override jujulibConnectOptions(): Partial<ConnectOptions> {
     return {
-      // TODO: (WD-20703) Replace with libjuju@8.0.1
-      oidcEnabled: true,
+      loginWithSessionCookie: true,
     };
   }
 }

--- a/src/auth/OIDCAuth.ts
+++ b/src/auth/OIDCAuth.ts
@@ -4,12 +4,13 @@ import { unwrapResult } from "@reduxjs/toolkit";
 import * as jimmListeners from "juju/jimm/listeners";
 import * as jimmThunks from "juju/jimm/thunks";
 import { actions as generalActions } from "store/general";
-import { AuthMethod } from "store/general/types";
 import { listenerMiddleware } from "store/listenerMiddleware";
 import type { AppDispatch } from "store/store";
 
 import { Auth, type ControllerData } from "./Auth";
 import { pollingMixin } from "./mixins";
+
+import { AuthMethod } from ".";
 
 export enum Label {
   WHOAMI = "Unable to check authentication status. You can attempt to log in anyway.",

--- a/src/auth/OIDCAuth.ts
+++ b/src/auth/OIDCAuth.ts
@@ -34,8 +34,6 @@ export class OIDCAuth extends pollingMixin(Auth) {
     wsControllerURL,
   }: ControllerData): Promise<boolean> {
     try {
-      // TODO: (WD-20709) Hoist loading state into model-poller.
-      this.dispatch(generalActions.updateLoginLoading(true));
       const whoamiResponse = await this.dispatch(jimmThunks.whoami());
       const user = unwrapResult(whoamiResponse);
       if (user) {
@@ -45,8 +43,6 @@ export class OIDCAuth extends pollingMixin(Auth) {
       } else {
         // If there's no response that means the user is not
         // authenticated, so halt the connection attempt.
-        // TODO: (WD-20709) Hoist loading state into model-poller.
-        this.dispatch(generalActions.updateLoginLoading(false));
         return false;
       }
     } catch (error) {

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,0 +1,1 @@
+export { Auth } from "./Auth";

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,1 +1,2 @@
 export { Auth } from "./Auth";
+export { OIDCAuth } from "./OIDCAuth";

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,4 +1,5 @@
 export { Auth } from "./Auth";
-export { OIDCAuth } from "./OIDCAuth";
-export { LocalAuth } from "./LocalAuth";
 export { CandidAuth } from "./CandidAuth";
+export { LocalAuth } from "./LocalAuth";
+export { OIDCAuth } from "./OIDCAuth";
+export { initialiseAuthFromConfig } from "./utils";

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,3 +1,4 @@
 export { Auth } from "./Auth";
 export { OIDCAuth } from "./OIDCAuth";
 export { LocalAuth } from "./LocalAuth";
+export { CandidAuth } from "./CandidAuth";

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -3,3 +3,4 @@ export { CandidAuth } from "./CandidAuth";
 export { LocalAuth } from "./LocalAuth";
 export { OIDCAuth } from "./OIDCAuth";
 export { initialiseAuthFromConfig } from "./utils";
+export { AuthMethod } from "./types";

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,2 +1,3 @@
 export { Auth } from "./Auth";
 export { OIDCAuth } from "./OIDCAuth";
+export { LocalAuth } from "./LocalAuth";

--- a/src/auth/mixins/index.ts
+++ b/src/auth/mixins/index.ts
@@ -1,0 +1,1 @@
+export { pollingMixin } from "./polling";

--- a/src/auth/mixins/polling.test.ts
+++ b/src/auth/mixins/polling.test.ts
@@ -1,9 +1,8 @@
 import type { Mock, MockInstance } from "vitest";
 
 import { thunks as appThunks } from "store/app";
-import { AuthMethod } from "store/general/types";
 
-import { Auth } from "../Auth";
+import { Auth, AuthMethod } from "..";
 
 import { pollingMixin } from "./polling";
 

--- a/src/auth/mixins/polling.test.ts
+++ b/src/auth/mixins/polling.test.ts
@@ -1,0 +1,42 @@
+import type { Mock, MockInstance } from "vitest";
+
+import { thunks as appThunks } from "store/app";
+import { AuthMethod } from "store/general/types";
+
+import { Auth } from "../Auth";
+
+import { pollingMixin } from "./polling";
+
+describe("PollingAuth", () => {
+  let dispatch: Mock;
+  let connectAndStartPollingMock: MockInstance;
+
+  beforeEach(() => {
+    dispatch = vi.fn();
+    const AuthClass = pollingMixin(Auth);
+    new AuthClass(dispatch, AuthMethod.OIDC);
+    connectAndStartPollingMock = vi.spyOn(appThunks, "connectAndStartPolling");
+  });
+
+  afterEach(() => {
+    // @ts-expect-error - Resetting singleton for each test run.
+    delete Auth.instance;
+  });
+
+  it("polling bootstrap success", async () => {
+    dispatch.mockResolvedValue({ payload: {} });
+    await Auth.instance.bootstrap();
+    expect(dispatch).toHaveBeenCalledOnce();
+    expect(connectAndStartPollingMock).toHaveBeenCalledOnce();
+  });
+
+  it("polling bootstrap failure", async () => {
+    dispatch.mockResolvedValue({
+      payload: null,
+      error: new Error("some error"),
+    });
+    await Auth.instance.bootstrap();
+    expect(dispatch).toHaveBeenCalledOnce();
+    expect(connectAndStartPollingMock).toHaveBeenCalledOnce();
+  });
+});

--- a/src/auth/mixins/polling.ts
+++ b/src/auth/mixins/polling.ts
@@ -1,0 +1,28 @@
+import { unwrapResult } from "@reduxjs/toolkit";
+
+import { thunks as appThunks } from "store/app";
+import { logger } from "utils/logger";
+
+import type { Auth } from "../Auth";
+
+export enum Label {
+  POLLING_ERROR = "Error while trying to connect and start polling.",
+}
+
+/**
+ * Class mixin which will override the `bootstrap` method so that it begins polling the controller.
+ *
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/extends#mix-ins}
+ */
+export function pollingMixin(Base: typeof Auth) {
+  return class extends Base {
+    override async bootstrap(): Promise<void> {
+      try {
+        // Try and connect automatically.
+        unwrapResult(await this.dispatch(appThunks.connectAndStartPolling()));
+      } catch (error) {
+        logger.error(Label.POLLING_ERROR, error);
+      }
+    }
+  };
+}

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -1,0 +1,5 @@
+export enum AuthMethod {
+  CANDID = "candid",
+  LOCAL = "local",
+  OIDC = "oidc",
+}

--- a/src/auth/utils.test.ts
+++ b/src/auth/utils.test.ts
@@ -1,0 +1,28 @@
+import { configFactory } from "testing/factories/general";
+
+import { initialiseAuthFromConfig } from "./utils";
+
+import { Auth, CandidAuth, OIDCAuth, LocalAuth } from ".";
+
+describe("initialiseAuthFromConfig", () => {
+  it("detects OIDC", () => {
+    const config = configFactory.build({ isJuju: false });
+    initialiseAuthFromConfig(config, vi.fn());
+    expect(Auth.instance).toBeInstanceOf(OIDCAuth);
+  });
+
+  it("detects candid", () => {
+    const config = configFactory.build({
+      isJuju: true,
+      identityProviderURL: "/candid",
+    });
+    initialiseAuthFromConfig(config, vi.fn());
+    expect(Auth.instance).toBeInstanceOf(CandidAuth);
+  });
+
+  it("detects local", () => {
+    const config = configFactory.build({ isJuju: true });
+    initialiseAuthFromConfig(config, vi.fn());
+    expect(Auth.instance).toBeInstanceOf(LocalAuth);
+  });
+});

--- a/src/auth/utils.ts
+++ b/src/auth/utils.ts
@@ -1,0 +1,23 @@
+import type { AppDispatch } from "store/store";
+import type { WindowConfig } from "types";
+
+import { CandidAuth, LocalAuth, OIDCAuth } from ".";
+
+/**
+ * From the provided config, initialise the `Auth` singleton instance with the correct auth
+ * implementation.
+ */
+export function initialiseAuthFromConfig(
+  config: WindowConfig,
+  dispatch: AppDispatch,
+) {
+  if (!config.isJuju) {
+    new OIDCAuth(dispatch);
+    return;
+  }
+  if (config.identityProviderURL) {
+    new CandidAuth(dispatch);
+    return;
+  }
+  new LocalAuth(dispatch);
+}

--- a/src/auth/utils.ts
+++ b/src/auth/utils.ts
@@ -1,5 +1,5 @@
+import type { Config } from "store/general/types";
 import type { AppDispatch } from "store/store";
-import type { WindowConfig } from "types";
 
 import { CandidAuth, LocalAuth, OIDCAuth } from ".";
 
@@ -8,7 +8,7 @@ import { CandidAuth, LocalAuth, OIDCAuth } from ".";
  * implementation.
  */
 export function initialiseAuthFromConfig(
-  config: WindowConfig,
+  config: Config,
   dispatch: AppDispatch,
 ) {
   if (!config.isJuju) {

--- a/src/components/LogIn/IdentityProviderForm/IdentityProviderForm.tsx
+++ b/src/components/LogIn/IdentityProviderForm/IdentityProviderForm.tsx
@@ -1,7 +1,8 @@
 import { Spinner } from "@canonical/react-components";
 
 import AuthenticationButton from "components/AuthenticationButton";
-import { useAppSelector } from "store/store";
+import { actions as generalActions } from "store/general";
+import { useAppDispatch, useAppSelector } from "store/store";
 
 import { Label } from "../types";
 
@@ -20,12 +21,14 @@ const IdentityProviderForm = ({ userIsLoggedIn }: Props) => {
       return state?.general?.visitURLs?.[0];
     }
   });
+  const dispatch = useAppDispatch();
 
   return visitURL ? (
     <AuthenticationButton
       appearance="positive"
       visitURL={visitURL}
       data-testid={TestId.CANDID_LOGIN}
+      onClick={() => dispatch(generalActions.updateLoginLoading(true))}
     >
       {Label.LOGIN_TO_DASHBOARD}
     </AuthenticationButton>

--- a/src/components/LogIn/LogIn.test.tsx
+++ b/src/components/LogIn/LogIn.test.tsx
@@ -2,7 +2,6 @@ import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
 
-import { AuthMethod } from "store/general/types";
 import { configFactory, generalStateFactory } from "testing/factories/general";
 import { rootStateFactory } from "testing/factories/root";
 import { renderComponent } from "testing/utils";
@@ -48,7 +47,8 @@ describe("LogIn", () => {
       general: generalStateFactory.withConfig().build({
         visitURLs: ["I am a url"],
         config: configFactory.build({
-          authMethod: AuthMethod.CANDID,
+          isJuju: true,
+          identityProviderURL: "/candid",
         }),
       }),
     });
@@ -64,9 +64,7 @@ describe("LogIn", () => {
   it("renders an OIDC login UI if the user is not logged in", () => {
     const state = rootStateFactory.build({
       general: generalStateFactory.withConfig().build({
-        config: configFactory.build({
-          authMethod: AuthMethod.OIDC,
-        }),
+        config: configFactory.build({ isJuju: false }),
       }),
     });
     renderComponent(<LogIn />, { state });
@@ -81,9 +79,7 @@ describe("LogIn", () => {
   it("renders a UserPass login UI if the user is not logged in", () => {
     const state = rootStateFactory.build({
       general: generalStateFactory.withConfig().build({
-        config: configFactory.build({
-          authMethod: AuthMethod.LOCAL,
-        }),
+        config: configFactory.build({ isJuju: true }),
       }),
     });
     renderComponent(<LogIn />, { state });
@@ -103,9 +99,6 @@ describe("LogIn", () => {
             "wss://controller.example.com": "Controller rejected request",
           },
         },
-        config: configFactory.build({
-          authMethod: AuthMethod.LOCAL,
-        }),
       }),
     });
     renderComponent(<LogIn />, { state });
@@ -120,9 +113,7 @@ describe("LogIn", () => {
         login: {
           errors: { "wss://controller.example.com": ErrorResponse.INVALID_TAG },
         },
-        config: configFactory.build({
-          authMethod: AuthMethod.LOCAL,
-        }),
+        config: configFactory.build(),
       }),
     });
     renderComponent(<LogIn />, { state });
@@ -137,9 +128,6 @@ describe("LogIn", () => {
             "wss://controller.example.com": ErrorResponse.INVALID_FIELD,
           },
         },
-        config: configFactory.build({
-          authMethod: AuthMethod.LOCAL,
-        }),
       }),
     });
     renderComponent(<LogIn />, { state });
@@ -149,9 +137,7 @@ describe("LogIn", () => {
   it("displays authentication request notifications", async () => {
     const state = rootStateFactory.build({
       general: generalStateFactory.withConfig().build({
-        config: configFactory.build({
-          authMethod: AuthMethod.CANDID,
-        }),
+        config: configFactory.build(),
         visitURLs: ["http://example.com/log-in"],
       }),
     });
@@ -170,7 +156,6 @@ describe("LogIn", () => {
       general: generalStateFactory.withConfig().build({
         config: configFactory.build({
           isJuju: true,
-          authMethod: AuthMethod.LOCAL,
         }),
         visitURLs: ["http://example.com/log-in"],
       }),

--- a/src/components/LogIn/LogIn.tsx
+++ b/src/components/LogIn/LogIn.tsx
@@ -1,3 +1,4 @@
+import { Spinner } from "@canonical/react-components";
 import type { ReactNode } from "react";
 import { useEffect, useRef } from "react";
 import reactHotToast from "react-hot-toast";
@@ -15,6 +16,7 @@ import {
   getWSControllerURL,
   isLoggedIn,
   getIsJuju,
+  getLoginLoading,
 } from "store/general/selectors";
 import { AuthMethod } from "store/general/types";
 import { useAppSelector } from "store/store";
@@ -36,6 +38,7 @@ export default function LogIn() {
     getLoginError(state, wsControllerURL),
   );
   const visitURLs = useAppSelector(getVisitURLs);
+  const loginLoading = useAppSelector(getLoginLoading);
 
   // This login component wraps all other views, so this useEffect will run each
   // time we get an authentication request.
@@ -71,16 +74,24 @@ export default function LogIn() {
   }, [visitURLs]);
 
   let form: ReactNode = null;
-  switch (config?.authMethod) {
-    case AuthMethod.CANDID:
-      form = <IdentityProviderForm userIsLoggedIn={userIsLoggedIn} />;
-      break;
-    case AuthMethod.OIDC:
-      form = <OIDCForm />;
-      break;
-    default:
-      form = <UserPassForm />;
-      break;
+  if (loginLoading) {
+    form = (
+      <button className="p-button--neutral" disabled>
+        <Spinner text="Connecting..." />
+      </button>
+    );
+  } else {
+    switch (config?.authMethod) {
+      case AuthMethod.CANDID:
+        form = <IdentityProviderForm userIsLoggedIn={userIsLoggedIn} />;
+        break;
+      case AuthMethod.OIDC:
+        form = <OIDCForm />;
+        break;
+      default:
+        form = <UserPassForm />;
+        break;
+    }
   }
 
   return (

--- a/src/components/LogIn/LogIn.tsx
+++ b/src/components/LogIn/LogIn.tsx
@@ -5,12 +5,12 @@ import reactHotToast from "react-hot-toast";
 import { Outlet } from "react-router";
 
 import FadeUpIn from "animations/FadeUpIn";
+import { Auth, AuthMethod } from "auth";
 import AuthenticationButton from "components/AuthenticationButton";
 import Logo from "components/Logo";
 import ToastCard from "components/ToastCard";
 import type { ToastInstance } from "components/ToastCard";
 import {
-  getConfig,
   getLoginError,
   getVisitURLs,
   getWSControllerURL,
@@ -18,7 +18,6 @@ import {
   getIsJuju,
   getLoginLoading,
 } from "store/general/selectors";
-import { AuthMethod } from "store/general/types";
 import { useAppSelector } from "store/store";
 
 import IdentityProviderForm from "./IdentityProviderForm";
@@ -28,7 +27,6 @@ import { ErrorResponse, Label, TestId } from "./types";
 
 export default function LogIn() {
   const viewedAuthRequests = useRef<string[]>([]);
-  const config = useAppSelector(getConfig);
   const isJuju = useAppSelector(getIsJuju);
   const wsControllerURL = useAppSelector(getWSControllerURL);
   const userIsLoggedIn = useAppSelector((state) =>
@@ -81,7 +79,7 @@ export default function LogIn() {
       </button>
     );
   } else {
-    switch (config?.authMethod) {
+    switch (Auth.instance.name) {
       case AuthMethod.CANDID:
         form = <IdentityProviderForm userIsLoggedIn={userIsLoggedIn} />;
         break;

--- a/src/components/LogIn/OIDCForm/OIDCForm.test.tsx
+++ b/src/components/LogIn/OIDCForm/OIDCForm.test.tsx
@@ -3,8 +3,6 @@ import userEvent from "@testing-library/user-event";
 
 import { endpoints } from "juju/jimm/api";
 import * as dashboardStore from "store/store";
-import { rootStateFactory } from "testing/factories";
-import { generalStateFactory } from "testing/factories/general";
 import { renderComponent } from "testing/utils";
 
 import { Label } from "../types";
@@ -17,21 +15,6 @@ describe("OIDCForm", () => {
     expect(
       screen.getByRole("link", { name: Label.LOGIN_TO_DASHBOARD }),
     ).toHaveAttribute("href", endpoints().login);
-  });
-
-  it("should render spinner after getting redirected", () => {
-    const state = rootStateFactory.build({
-      general: generalStateFactory.build({
-        login: {
-          errors: {},
-          loading: true,
-        },
-      }),
-    });
-    renderComponent(<OIDCForm />, { state });
-    expect(
-      screen.getByRole("button", { name: Label.LOADING }),
-    ).toBeInTheDocument();
   });
 
   it("should dispatch event to update loading state on click", async () => {

--- a/src/components/LogIn/OIDCForm/OIDCForm.tsx
+++ b/src/components/LogIn/OIDCForm/OIDCForm.tsx
@@ -1,9 +1,8 @@
-import { Button, Spinner } from "@canonical/react-components";
+import { Button } from "@canonical/react-components";
 
 import { endpoints } from "juju/jimm/api";
 import { actions as generalActions } from "store/general";
-import { getLoginLoading } from "store/general/selectors";
-import { useAppDispatch, useAppSelector } from "store/store";
+import { useAppDispatch } from "store/store";
 
 import { Label } from "../types";
 
@@ -11,13 +10,8 @@ import { TestId } from "./types";
 
 const OIDCForm = () => {
   const dispatch = useAppDispatch();
-  const loginLoading = useAppSelector(getLoginLoading);
 
-  return loginLoading ? (
-    <button className="p-button--neutral" disabled>
-      <Spinner text="Connecting..." />
-    </button>
-  ) : (
+  return (
     <Button
       appearance="positive"
       element="a"

--- a/src/components/LogIn/UserPassForm/UserPassForm.test.tsx
+++ b/src/components/LogIn/UserPassForm/UserPassForm.test.tsx
@@ -47,7 +47,10 @@ describe("UserPassForm", () => {
       type: "general/cleanupLoginErrors",
     });
     expect(mockUseAppDispatch.mock.calls[1][0]).toMatchObject(storeAction);
-    expect(mockUseAppDispatch.mock.calls[2][0]).toMatchObject({
+    expect(mockUseAppDispatch.mock.calls[2][0]).toMatchObject(
+      generalActions.updateLoginLoading(true),
+    );
+    expect(mockUseAppDispatch.mock.calls[3][0]).toMatchObject({
       type: "connectAndStartPolling",
     });
   });

--- a/src/components/LogIn/UserPassForm/UserPassForm.tsx
+++ b/src/components/LogIn/UserPassForm/UserPassForm.tsx
@@ -33,6 +33,7 @@ const UserPassForm = () => {
         credential: { user, password },
       }),
     );
+    dispatch(generalActions.updateLoginLoading(true));
     if (bakery) {
       dispatch(appThunks.connectAndStartPolling())
         .then(unwrapResult)

--- a/src/components/Routes/Routes.test.tsx
+++ b/src/components/Routes/Routes.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 
+import { LocalAuth } from "auth";
 import { AdvancedSearchTestId } from "pages/AdvancedSearch";
 import { ControllersIndexTestId } from "pages/ControllersIndex/index";
 import { EntityDetailsTestId } from "pages/EntityDetails";
@@ -37,6 +38,7 @@ describe("Routes", () => {
         },
       }),
     });
+    new LocalAuth(vi.fn());
   });
 
   it("handles models", async () => {

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -1,6 +1,7 @@
 import { screen, waitFor } from "@testing-library/dom";
 import { vi } from "vitest";
 
+import { Auth, LocalAuth } from "auth";
 import * as storeModule from "store";
 import { thunks as appThunks } from "store/app";
 import { actions as generalActions } from "store/general";
@@ -59,6 +60,8 @@ describe("renderApp", () => {
       document.body.removeChild(rootNode);
     }
     window.jujuDashboardConfig = undefined;
+    // @ts-expect-error - Resetting singleton for each test run.
+    delete Auth.instance;
     vi.useRealTimers();
   });
 
@@ -79,10 +82,15 @@ describe("renderApp", () => {
   });
 
   it("bootstraps if the config is found", async () => {
-    window.jujuDashboardConfig = configFactory.build();
+    const bootstrapSpy = vi.spyOn(LocalAuth.prototype, "bootstrap");
+    window.jujuDashboardConfig = configFactory.build({
+      controllerAPIEndpoint: "/api",
+      isJuju: true,
+    });
     renderApp();
     await waitFor(() => {
       expect(document.querySelector(`#${ROOT_ID}`)?.children).toHaveLength(1);
+      expect(bootstrapSpy).toHaveBeenCalledOnce();
     });
   });
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -155,7 +155,6 @@ function bootstrap() {
   reduxStore.dispatch(generalActions.storeVersion(appVersion));
 
   initialiseAuthFromConfig(config, reduxStore.dispatch);
-  console.log("bootstrapping", Auth.instance);
   void Auth.instance.bootstrap();
 
   getRoot()?.render(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,8 +10,6 @@ import { Auth, initialiseAuthFromConfig } from "auth";
 import App from "components/App";
 import reduxStore from "store";
 import { actions as generalActions } from "store/general";
-import { AuthMethod } from "store/general/types";
-import type { WindowConfig } from "types";
 import { logger } from "utils/logger";
 
 import packageJSON from "../package.json";
@@ -31,16 +29,6 @@ if (import.meta.env.PROD && window.jujuDashboardConfig?.analyticsEnabled) {
   });
   Sentry.setTag("dashboardVersion", appVersion);
 }
-
-const getAuthMethod = (config: WindowConfig) => {
-  if (!config.isJuju) {
-    return AuthMethod.OIDC;
-  }
-  if (config.identityProviderURL) {
-    return AuthMethod.CANDID;
-  }
-  return AuthMethod.LOCAL;
-};
 
 const addressRegex = new RegExp(/^ws[s]?:\/\/(\S+)\//);
 export const getControllerAPIEndpointErrors = (
@@ -93,13 +81,7 @@ export const renderApp = () => {
 renderApp();
 
 function bootstrap() {
-  const windowConfig = window.jujuDashboardConfig;
-  const config = windowConfig
-    ? {
-        ...windowConfig,
-        authMethod: getAuthMethod(windowConfig),
-      }
-    : null;
+  const config = window.jujuDashboardConfig;
   const isProduction = import.meta.env.PROD;
   const logLevel: LogLevelDesc = isProduction
     ? logger.levels.SILENT

--- a/src/juju/api-hooks/actions.test.tsx
+++ b/src/juju/api-hooks/actions.test.tsx
@@ -3,6 +3,7 @@ import * as jujuLib from "@canonical/jujulib";
 import { renderHook } from "@testing-library/react";
 import { vi } from "vitest";
 
+import { Auth, LocalAuth } from "auth";
 import type { RootState } from "store/store";
 import { rootStateFactory } from "testing/factories";
 import {
@@ -50,6 +51,12 @@ describe("actions", () => {
         },
       },
     });
+    new LocalAuth(vi.fn());
+  });
+
+  afterEach(() => {
+    // @ts-expect-error - Resetting singleton for each test run.
+    delete Auth.instance;
   });
 
   describe("useGetActionsForApplication", () => {

--- a/src/juju/api-hooks/application.test.tsx
+++ b/src/juju/api-hooks/application.test.tsx
@@ -3,6 +3,7 @@ import * as jujuLib from "@canonical/jujulib";
 import { renderHook } from "@testing-library/react";
 import { vi } from "vitest";
 
+import { Auth, LocalAuth } from "auth";
 import type { Config } from "panels/ConfigPanel/types";
 import type { RootState } from "store/store";
 import { rootStateFactory } from "testing/factories";
@@ -52,6 +53,12 @@ describe("application", () => {
         },
       },
     });
+    new LocalAuth(vi.fn());
+  });
+
+  afterEach(() => {
+    // @ts-expect-error - Resetting singleton for each test run.
+    delete Auth.instance;
   });
 
   describe("useGetApplicationConfig", () => {

--- a/src/juju/api-hooks/common.test.tsx
+++ b/src/juju/api-hooks/common.test.tsx
@@ -3,6 +3,7 @@ import type { Connection } from "@canonical/jujulib";
 import { renderHook, waitFor } from "@testing-library/react";
 import { vi } from "vitest";
 
+import { Auth, LocalAuth } from "auth";
 import type { RootState } from "store/store";
 import { rootStateFactory } from "testing/factories";
 import {
@@ -48,11 +49,14 @@ describe("useModelConnectionCallback", () => {
       },
     });
     vi.useFakeTimers();
+    new LocalAuth(vi.fn());
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
     vi.useRealTimers();
+    // @ts-expect-error - Resetting singleton for each test run.
+    delete Auth.instance;
   });
 
   it("can connect and log in", async () => {
@@ -257,6 +261,12 @@ describe("useCallWithConnectionPromise", () => {
         },
       },
     });
+    new LocalAuth(vi.fn());
+  });
+
+  afterEach(() => {
+    // @ts-expect-error - Resetting singleton for each test run.
+    delete Auth.instance;
   });
 
   it("calls the handler with args", async () => {
@@ -374,6 +384,12 @@ describe("useCallWithConnection", () => {
         },
       },
     });
+    new LocalAuth(vi.fn());
+  });
+
+  afterEach(() => {
+    // @ts-expect-error - Resetting singleton for each test run.
+    delete Auth.instance;
   });
 
   it("calls the handler with args", async () => {

--- a/src/juju/api-hooks/common.ts
+++ b/src/juju/api-hooks/common.ts
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 
 import { connectToModel } from "juju/api";
 import type { ConnectionWithFacades } from "juju/types";
-import { getConfig, getUserPass } from "store/general/selectors";
+import { getUserPass } from "store/general/selectors";
 import { getModelByUUID, getModelUUIDFromList } from "store/juju/selectors";
 import { useAppSelector } from "store/store";
 import { toErrorString } from "utils";
@@ -29,7 +29,6 @@ export const useModelConnectionCallback = (modelUUID?: string) => {
   const wsControllerURL = useAppSelector((state) =>
     getModelByUUID(state, modelUUID),
   )?.wsControllerURL;
-  const authMethod = useAppSelector(getConfig)?.authMethod;
   const credentials = useAppSelector((state) =>
     getUserPass(state, wsControllerURL),
   );
@@ -41,7 +40,7 @@ export const useModelConnectionCallback = (modelUUID?: string) => {
         // are available.
         return;
       }
-      connectToModel(modelUUID, wsControllerURL, credentials, authMethod)
+      connectToModel(modelUUID, wsControllerURL, credentials)
         .then((connection) => {
           if (!connection) {
             response({ error: Label.NO_CONNECTION_ERROR });
@@ -54,7 +53,7 @@ export const useModelConnectionCallback = (modelUUID?: string) => {
           response({ error: toErrorString(error) });
         });
     },
-    [credentials, authMethod, modelUUID, wsControllerURL],
+    [credentials, modelUUID, wsControllerURL],
   );
 };
 

--- a/src/juju/api-hooks/secrets.test.tsx
+++ b/src/juju/api-hooks/secrets.test.tsx
@@ -3,6 +3,7 @@ import type { Connection } from "@canonical/jujulib";
 import { renderHook, waitFor } from "@testing-library/react";
 import { vi } from "vitest";
 
+import { Auth, LocalAuth } from "auth";
 import { actions as jujuActions } from "store/juju";
 import type { RootState } from "store/store";
 import { rootStateFactory } from "testing/factories";
@@ -54,6 +55,12 @@ describe("useListSecrets", () => {
         },
       },
     });
+    new LocalAuth(vi.fn());
+  });
+
+  afterEach(() => {
+    // @ts-expect-error - Resetting singleton for each test run.
+    delete Auth.instance;
   });
 
   it("fetches secrets", async () => {
@@ -210,6 +217,12 @@ describe("useGetSecretContent", () => {
         },
       },
     });
+    new LocalAuth(vi.fn());
+  });
+
+  afterEach(() => {
+    // @ts-expect-error - Resetting singleton for each test run.
+    delete Auth.instance;
   });
 
   it("fetches secrets", async () => {
@@ -467,6 +480,12 @@ describe("useCreateSecrets", () => {
         },
       },
     });
+    new LocalAuth(vi.fn());
+  });
+
+  afterEach(() => {
+    // @ts-expect-error - Resetting singleton for each test run.
+    delete Auth.instance;
   });
 
   it("can create secrets", async () => {
@@ -571,6 +590,12 @@ describe("useUpdateSecrets", () => {
         },
       },
     });
+    new LocalAuth(vi.fn());
+  });
+
+  afterEach(() => {
+    // @ts-expect-error - Resetting singleton for each test run.
+    delete Auth.instance;
   });
 
   it("can update secrets", async () => {
@@ -679,6 +704,12 @@ describe("useRemoveSecrets", () => {
         },
       },
     });
+    new LocalAuth(vi.fn());
+  });
+
+  afterEach(() => {
+    // @ts-expect-error - Resetting singleton for each test run.
+    delete Auth.instance;
   });
 
   it("can remove secrets", async () => {
@@ -779,6 +810,12 @@ describe("useGrantSecret", () => {
         },
       },
     });
+    new LocalAuth(vi.fn());
+  });
+
+  afterEach(() => {
+    // @ts-expect-error - Resetting singleton for each test run.
+    delete Auth.instance;
   });
 
   it("can grant apps", async () => {
@@ -874,6 +911,12 @@ describe("useRevokeSecret", () => {
         },
       },
     });
+    new LocalAuth(vi.fn());
+  });
+
+  afterEach(() => {
+    // @ts-expect-error - Resetting singleton for each test run.
+    delete Auth.instance;
   });
 
   it("can revoke apps", async () => {

--- a/src/juju/api.test.ts
+++ b/src/juju/api.test.ts
@@ -6,7 +6,6 @@ import { vi } from "vitest";
 
 import { Auth, CandidAuth, LocalAuth, OIDCAuth } from "auth";
 import { actions as generalActions } from "store/general";
-import { AuthMethod } from "store/general/types";
 import { actions as jujuActions } from "store/juju";
 import type { RootState } from "store/store";
 import { rootStateFactory } from "testing/factories";
@@ -327,9 +326,6 @@ describe("Juju API", () => {
     });
 
     it("can log in with an external provider", async () => {
-      if (state.general.config) {
-        state.general.config.authMethod = AuthMethod.CANDID;
-      }
       const loginResponse = {
         conn: {
           facades: {

--- a/src/juju/api.test.ts
+++ b/src/juju/api.test.ts
@@ -154,7 +154,7 @@ describe("Juju API", () => {
         });
         expect(connectSpy).toHaveBeenCalledWith(
           "wss://example.com/api",
-          expect.objectContaining({ oidcEnabled: true }),
+          expect.objectContaining({ loginWithSessionCookie: true }),
         );
         expect(juju.login).toHaveBeenCalledWith(undefined, CLIENT_VERSION);
       });

--- a/src/juju/bakery.ts
+++ b/src/juju/bakery.ts
@@ -6,6 +6,7 @@ import reduxStore from "store/store";
 const bakery = new Bakery({
   visitPage: (resp) => {
     reduxStore.dispatch(generalActions.storeVisitURL(resp.Info.VisitURL));
+    reduxStore.dispatch(generalActions.updateLoginLoading(false));
   },
   storage: new BakeryStorage(localStorage, {}),
 });

--- a/src/juju/jimm/api.test.ts
+++ b/src/juju/jimm/api.test.ts
@@ -1,8 +1,8 @@
 import type { Connection } from "@canonical/jujulib";
 import { vi } from "vitest";
 
+import type { Config } from "store/general/types";
 import { relationshipTupleFactory } from "testing/factories/juju/juju";
-import type { WindowConfig } from "types";
 
 import {
   crossModelQuery,
@@ -20,7 +20,7 @@ describe("JIMM API", () => {
   it("generates correct endpoints", () => {
     window.jujuDashboardConfig = {
       controllerAPIEndpoint: "ws://example.com/api",
-    } as WindowConfig;
+    } as Config;
     const { login, logout, whoami } = endpoints();
     expect(login).toEqual("http://example.com/auth/login");
     expect(logout).toEqual("http://example.com/auth/logout");
@@ -30,7 +30,7 @@ describe("JIMM API", () => {
   it("generates correct endpoints for secure controller API", () => {
     window.jujuDashboardConfig = {
       controllerAPIEndpoint: "wss://example.com/api",
-    } as WindowConfig;
+    } as Config;
     const { login, logout, whoami } = endpoints();
     expect(login).toEqual("https://example.com/auth/login");
     expect(logout).toEqual("https://example.com/auth/logout");

--- a/src/juju/jimm/listeners.test.ts
+++ b/src/juju/jimm/listeners.test.ts
@@ -15,9 +15,9 @@ import { vi } from "vitest";
 
 import { thunks as appThunks } from "store/app";
 import { actions as generalActions } from "store/general";
+import type { Config } from "store/general/types";
 import type { RootState, AppDispatch } from "store/store";
 import { rootStateFactory } from "testing/factories";
-import type { WindowConfig } from "types";
 
 import { endpoints } from "./api";
 import {
@@ -58,7 +58,7 @@ describe("listeners", () => {
     fetchMock.resetMocks();
     window.jujuDashboardConfig = {
       controllerAPIEndpoint: "wss://controller.example.com",
-    } as WindowConfig;
+    } as Config;
     listenerMiddleware = createListenerMiddleware<RootState, AppDispatch>();
     const slice = createSlice({
       name: "root",

--- a/src/juju/jimm/thunks.test.ts
+++ b/src/juju/jimm/thunks.test.ts
@@ -1,7 +1,7 @@
 import { unwrapResult } from "@reduxjs/toolkit";
 import { vi } from "vitest";
 
-import type { WindowConfig } from "types";
+import type { Config } from "store/general/types";
 
 import { endpoints } from "./api";
 import { logout, whoami } from "./thunks";
@@ -11,7 +11,7 @@ describe("thunks", () => {
     fetchMock.resetMocks();
     window.jujuDashboardConfig = {
       controllerAPIEndpoint: "wss://example.com/api",
-    } as WindowConfig;
+    } as Config;
   });
 
   afterEach(() => {

--- a/src/store/app/actions.test.ts
+++ b/src/store/app/actions.test.ts
@@ -1,5 +1,3 @@
-import { AuthMethod } from "store/general/types";
-
 import type { ControllerArgs } from "./actions";
 import { updatePermissions, connectAndPollControllers } from "./actions";
 
@@ -23,7 +21,6 @@ describe("actions", () => {
     const controller: ControllerArgs = [
       "wss://example.com",
       { user: "eggman@external", password: "verysecure123" },
-      AuthMethod.LOCAL,
     ];
     const args = {
       controllers: [controller],

--- a/src/store/app/actions.ts
+++ b/src/store/app/actions.ts
@@ -1,6 +1,6 @@
 import { createAction } from "@reduxjs/toolkit";
 
-import type { AuthMethod, Credential } from "store/general/types";
+import type { Credential } from "store/general/types";
 
 export const updatePermissions = createAction<{
   action: string;
@@ -16,8 +16,6 @@ export type ControllerArgs = [
   string,
   // credentials
   Credential | undefined,
-  // authMethod
-  AuthMethod,
 ];
 
 export const connectAndPollControllers = createAction<{

--- a/src/store/app/thunks.test.ts
+++ b/src/store/app/thunks.test.ts
@@ -1,5 +1,6 @@
 import { vi } from "vitest";
 
+import { Auth, CandidAuth, OIDCAuth } from "auth";
 import { pollWhoamiStop } from "juju/jimm/listeners";
 import { actions as appActions } from "store/app";
 import { actions as generalActions } from "store/general";
@@ -59,6 +60,8 @@ describe("thunks", () => {
 
   afterEach(() => {
     delete window.jujuDashboardConfig;
+    // @ts-expect-error - Resetting singleton for each test run.
+    delete Auth.instance;
   });
 
   it("logOut", async () => {
@@ -71,6 +74,8 @@ describe("thunks", () => {
         }),
       }),
     );
+    const logoutSpy = vi.spyOn(CandidAuth.prototype, "logout");
+    new CandidAuth(dispatch);
     await action(dispatch, getState, null);
     expect(dispatch).toHaveBeenCalledWith(jujuActions.clearModelData());
     expect(dispatch).toHaveBeenCalledWith(jujuActions.clearControllerData());
@@ -81,6 +86,7 @@ describe("thunks", () => {
       null,
     );
     expect(dispatchedThunk.type).toBe("app/connectAndStartPolling/fulfilled");
+    expect(logoutSpy).toHaveBeenCalledOnce();
   });
 
   it("logOut from OIDC", async () => {
@@ -94,6 +100,8 @@ describe("thunks", () => {
         }),
       }),
     );
+    const logoutSpy = vi.spyOn(OIDCAuth.prototype, "logout");
+    new OIDCAuth(dispatch);
     await action(dispatch, getState, null);
     expect(dispatch).toHaveBeenCalledWith(jujuActions.clearModelData());
     expect(dispatch).toHaveBeenCalledWith(jujuActions.clearControllerData());
@@ -105,6 +113,7 @@ describe("thunks", () => {
       null,
     );
     expect(dispatchedThunk.type).toBe("jimm/logout/fulfilled");
+    expect(logoutSpy).toHaveBeenCalledOnce();
   });
 
   it("connectAndStartPolling", async () => {

--- a/src/store/app/thunks.test.ts
+++ b/src/store/app/thunks.test.ts
@@ -4,7 +4,7 @@ import { Auth, CandidAuth, OIDCAuth } from "auth";
 import { pollWhoamiStop } from "juju/jimm/listeners";
 import { actions as appActions } from "store/app";
 import { actions as generalActions } from "store/general";
-import { AuthMethod } from "store/general/types";
+import type { Config } from "store/general/types";
 import { actions as jujuActions } from "store/juju";
 import type { RootState } from "store/store";
 import { rootStateFactory } from "testing/factories";
@@ -17,7 +17,6 @@ import {
   controllerFactory,
   jujuStateFactory,
 } from "testing/factories/juju/juju";
-import type { WindowConfig } from "types";
 
 import { logOut, connectAndStartPolling } from "./thunks";
 
@@ -27,7 +26,7 @@ describe("thunks", () => {
   beforeEach(() => {
     window.jujuDashboardConfig = {
       controllerAPIEndpoint: "wss://example.com/api",
-    } as WindowConfig;
+    } as Config;
     fetchMock.resetMocks();
     state = rootStateFactory.build({
       general: generalStateFactory.build({
@@ -67,13 +66,7 @@ describe("thunks", () => {
   it("logOut", async () => {
     const action = logOut();
     const dispatch = vi.fn();
-    const getState = vi.fn(() =>
-      rootStateFactory.build({
-        general: generalStateFactory.build({
-          config: configFactory.build({ authMethod: AuthMethod.CANDID }),
-        }),
-      }),
-    );
+    const getState = vi.fn(() => rootStateFactory.build());
     const logoutSpy = vi.spyOn(CandidAuth.prototype, "logout");
     new CandidAuth(dispatch);
     await action(dispatch, getState, null);
@@ -93,13 +86,7 @@ describe("thunks", () => {
     fetchMock.mockResponseOnce(JSON.stringify({}), { status: 200 });
     const action = logOut();
     const dispatch = vi.fn();
-    const getState = vi.fn(() =>
-      rootStateFactory.build({
-        general: generalStateFactory.build({
-          config: configFactory.build({ authMethod: AuthMethod.OIDC }),
-        }),
-      }),
-    );
+    const getState = vi.fn(() => rootStateFactory.build());
     const logoutSpy = vi.spyOn(OIDCAuth.prototype, "logout");
     new OIDCAuth(dispatch);
     await action(dispatch, getState, null);

--- a/src/store/app/thunks.test.ts
+++ b/src/store/app/thunks.test.ts
@@ -123,9 +123,7 @@ describe("thunks", () => {
     await action(dispatch, getState, null);
     expect(dispatch).toHaveBeenCalledWith(
       appActions.connectAndPollControllers({
-        controllers: [
-          ["wss://controller.example.com", undefined, AuthMethod.LOCAL],
-        ],
+        controllers: [["wss://controller.example.com", undefined]],
         isJuju: true,
       }),
     );
@@ -145,9 +143,7 @@ describe("thunks", () => {
     await action(dispatch, getState, null);
     expect(dispatch).toHaveBeenCalledWith(
       appActions.connectAndPollControllers({
-        controllers: [
-          ["wss://controller.example.com", undefined, AuthMethod.LOCAL],
-        ],
+        controllers: [["wss://controller.example.com", undefined]],
         isJuju: true,
       }),
     );
@@ -172,9 +168,7 @@ describe("thunks", () => {
     await action(dispatch, getState, null);
     expect(dispatch).toHaveBeenCalledWith(
       appActions.connectAndPollControllers({
-        controllers: [
-          ["wss://controller.example.com", undefined, AuthMethod.LOCAL],
-        ],
+        controllers: [["wss://controller.example.com", undefined]],
         isJuju: true,
       }),
     );
@@ -199,9 +193,7 @@ describe("thunks", () => {
     await action(dispatch, getState, null);
     expect(dispatch).toHaveBeenCalledWith(
       appActions.connectAndPollControllers({
-        controllers: [
-          ["wss://controller.example.com", undefined, AuthMethod.LOCAL],
-        ],
+        controllers: [["wss://controller.example.com", undefined]],
         isJuju: true,
       }),
     );

--- a/src/store/app/thunks.ts
+++ b/src/store/app/thunks.ts
@@ -11,7 +11,6 @@ import {
   getUserPass,
   getWSControllerURL,
 } from "store/general/selectors";
-import { AuthMethod } from "store/general/types";
 import { actions as jujuActions } from "store/juju";
 import type { RootState } from "store/store";
 import { logger } from "utils/logger";
@@ -55,11 +54,7 @@ export const connectAndStartPolling = createAsyncThunk<
     const controllerConnections = getControllerConnections(storeState) || {};
     let controllerList: ControllerArgs[] = [];
     if (wsControllerURL) {
-      controllerList.push([
-        wsControllerURL,
-        credentials,
-        config?.authMethod ?? AuthMethod.LOCAL,
-      ]);
+      controllerList.push([wsControllerURL, credentials]);
     }
     const connectedControllers = Object.keys(controllerConnections);
     controllerList = controllerList.filter((controllerData) => {

--- a/src/store/general/types.ts
+++ b/src/store/general/types.ts
@@ -1,14 +1,7 @@
 import type { ConnectionInfo } from "@canonical/jujulib";
 
-export enum AuthMethod {
-  CANDID = "candid",
-  LOCAL = "local",
-  OIDC = "oidc",
-}
-
 export type Config = {
   analyticsEnabled: boolean;
-  authMethod: AuthMethod;
   baseAppURL: string;
   // Support for 2.9 configuration.
   baseControllerURL?: string | null;

--- a/src/store/middleware/model-poller.test.ts
+++ b/src/store/middleware/model-poller.test.ts
@@ -45,11 +45,7 @@ describe("model poller", () => {
   let next: Mock;
   const wsControllerURL = "wss://example.com";
   const controllers: ControllerArgs[] = [
-    [
-      wsControllerURL,
-      { user: "eggman@external", password: "test" },
-      AuthMethod.LOCAL,
-    ],
+    [wsControllerURL, { user: "eggman@external", password: "test" }],
   ];
   const models = [
     {
@@ -185,7 +181,7 @@ describe("model poller", () => {
       const loginWithBakerySpy = vi.spyOn(jujuModule, "loginWithBakery");
       await runMiddleware(
         appActions.connectAndPollControllers({
-          controllers: [[wsControllerURL, undefined, AuthMethod.OIDC]],
+          controllers: [[wsControllerURL, undefined]],
           isJuju: true,
           poll: 0,
         }),
@@ -207,7 +203,7 @@ describe("model poller", () => {
         }));
       await runMiddleware(
         appActions.connectAndPollControllers({
-          controllers: [[wsControllerURL, undefined, AuthMethod.OIDC]],
+          controllers: [[wsControllerURL, undefined]],
           isJuju: true,
           poll: 0,
         }),

--- a/src/store/middleware/model-poller.ts
+++ b/src/store/middleware/model-poller.ts
@@ -62,7 +62,7 @@ export const modelPollerMiddleware: Middleware<
       // first clean up any old auth requests:
       reduxStore.dispatch(generalActions.clearVisitURLs());
       for (const controllerData of action.payload.controllers) {
-        const [wsControllerURL, credentials, authMethod] = controllerData;
+        const [wsControllerURL, credentials] = controllerData;
         let conn: ConnectionWithFacades | undefined;
         let juju: Client | undefined;
         let error: unknown;
@@ -101,7 +101,7 @@ export const modelPollerMiddleware: Middleware<
           );
           return logger.log(LoginError.LOG, e, controllerData);
         } finally {
-          if (authMethod === AuthMethod.OIDC) {
+          if (Auth.instance.name === AuthMethod.OIDC) {
             reduxStore.dispatch(generalActions.updateLoginLoading(false));
           }
         }
@@ -127,7 +127,7 @@ export const modelPollerMiddleware: Middleware<
           { dashboardVersion, controllerVersion, isJuju },
           {
             category: "Authentication",
-            action: `User Login (${authMethod})`,
+            action: `User Login (${Auth.instance.name})`,
           },
         );
 

--- a/src/testing/factories/general.ts
+++ b/src/testing/factories/general.ts
@@ -7,11 +7,9 @@ import {
   type Credential,
   type GeneralState,
   type ControllerFeaturesState,
-  AuthMethod,
 } from "store/general/types";
 
 export const configFactory = Factory.define<Config>(() => ({
-  authMethod: AuthMethod.LOCAL,
   controllerAPIEndpoint: "wss://controller.example.com",
   baseAppURL: "/",
   identityProviderURL: "",

--- a/src/testing/utils.tsx
+++ b/src/testing/utils.tsx
@@ -23,7 +23,6 @@ import generalReducer from "store/general";
 import jujuReducer from "store/juju";
 import type { RootState } from "store/store";
 import { rootStateFactory } from "testing/factories";
-import type { WindowConfig } from "types";
 
 import { configFactory } from "./factories/general";
 import queries from "./queries";
@@ -80,8 +79,7 @@ export const wrapComponent = (
       ? options.store
       : createStore(options?.state ?? rootStateFactory.build());
   const config = store.getState().general.config || configFactory.build();
-  // TODO: (WD-20710) Remove `WindowConfig` cast once `authMethod` is removed from config.
-  initialiseAuthFromConfig(config as WindowConfig, store.dispatch);
+  initialiseAuthFromConfig(config, store.dispatch);
   const router = createMemoryRouter(
     [
       {

--- a/src/testing/utils.tsx
+++ b/src/testing/utils.tsx
@@ -18,11 +18,14 @@ import {
   createMemoryRouter,
 } from "react-router";
 
+import { initialiseAuthFromConfig } from "auth";
 import generalReducer from "store/general";
 import jujuReducer from "store/juju";
 import type { RootState } from "store/store";
 import { rootStateFactory } from "testing/factories";
+import type { WindowConfig } from "types";
 
+import { configFactory } from "./factories/general";
 import queries from "./queries";
 
 type Router = ReturnType<typeof createMemoryRouter>;
@@ -76,6 +79,9 @@ export const wrapComponent = (
     options && "store" in options
       ? options.store
       : createStore(options?.state ?? rootStateFactory.build());
+  const config = store.getState().general.config || configFactory.build();
+  // TODO: (WD-20710) Remove `WindowConfig` cast once `authMethod` is removed from config.
+  initialiseAuthFromConfig(config as WindowConfig, store.dispatch);
   const router = createMemoryRouter(
     [
       {

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,11 +4,9 @@ import { isAction } from "redux";
 
 import type { Config } from "store/general/types";
 
-export type WindowConfig = Omit<Config, "authMethod">;
-
 declare global {
   interface Window {
-    jujuDashboardConfig?: WindowConfig;
+    jujuDashboardConfig?: Config;
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -125,15 +125,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@canonical/jujulib@npm:7.0.0":
-  version: 7.0.0
-  resolution: "@canonical/jujulib@npm:7.0.0"
+"@canonical/jujulib@npm:8.0.1":
+  version: 8.0.1
+  resolution: "@canonical/jujulib@npm:8.0.1"
   dependencies:
     "@canonical/macaroon-bakery": "npm:1.3.2"
     btoa: "npm:1.2.1"
     websocket: "npm:1.0.34"
     xhr2: "npm:0.2.1"
-  checksum: 10c0/1ddfb5338ea6b4446ce3dd64b39a1d53bd5a736035f2478193879510c623f76faa225e6971b759ad5c9dc7e1412dc5f74aea0b16ef2a03869d1a48a4198c644d
+  checksum: 10c0/c39965f2156b743e11f61d4d0577cb6840fd835ce8d06ab40ad70b025449afb926e655294793eb7f42cc303f403120db021b0673dfddf4837a7af24d217b2ff9
   languageName: node
   linkType: hard
 
@@ -7740,7 +7740,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "juju-dashboard@workspace:."
   dependencies:
-    "@canonical/jujulib": "npm:7.0.0"
+    "@canonical/jujulib": "npm:8.0.1"
     "@canonical/macaroon-bakery": "npm:1.3.2"
     "@canonical/react-components": "npm:2.2.0"
     "@canonical/rebac-admin": "npm:0.0.1-alpha.12"


### PR DESCRIPTION
## Done

See composite PRs:

- #1905
- #1908
- #1911
- #1912
- #1915
- #1916
- #1918

## QA

### `LocalAuth`

- Ensure local juju multipass is running
- `yarn start`
- http://localhost:8036
- Login with local user account

### `OIDCAuth`

- Ensure access to JIMM instance
- `sudo yarn start-jaas --port 443`
- https://jimm-dashboard.k8s.dev.canonical.com
- Login with Google account

### `CandidAuth`

- Ensure access to [Juju controller with Candid](https://github.com/canonical/juju-dashboard/blob/main/HACKING.md#juju-controller-with-candid)
- `yarn start`
- http://localhost:8036
- Login with external account

## Details

- WD-20701
