### PR TITLE
chore(ci): add Juju, k8s and local auth e2e workflow

### DIFF
--- a/.github/actions/run-playwright/action.yml
+++ b/.github/actions/run-playwright/action.yml
@@ -18,11 +18,12 @@ runs:
       shell: bash
     - name: Get dashboard address
       id: dashboard
-      run: echo "address=http://$(juju show-unit dashboard/0 | yq '.dashboard/0.public-address'):8080" >> $GITHUB_OUTPUT
+      run: echo "address=http://$(address=$(juju show-unit dashboard/0 | yq '.dashboard/0.public-address'); if [ "$address" != "null" ]; then echo $address; else juju show-unit dashboard/0 | yq '.dashboard/0.address'; fi):8080" >> $GITHUB_OUTPUT
       shell: bash
     - name: Run Playwright tests
       run: |
         cd ${{ github.workspace }}
+        yarn install
         yarn playwright test
       shell: bash
       env: 

--- a/.github/actions/setup-candid/action.yaml
+++ b/.github/actions/setup-candid/action.yaml
@@ -15,15 +15,11 @@ runs:
   steps:
     - name: Install candid
       shell: bash
-      run: |
-        sudo snap install candid
-
-        while [ -n "$(snap changes candid 2>/dev/null | awk '/^[0-9]+/ {if ($2 != "Done") print $2 }')" ]; do
-          echo "Waiting for snap changes on candid to finish"
-          sleep 1
-        done
-
-        sleep 1
+      run: sudo snap install candid
+    - name: Wait for candid snap
+      uses: ./.github/actions/wait-for-snap
+      with:
+        snap: candid
     - name: Configure candid
       shell: bash
       run: |

--- a/.github/actions/setup-k8s-charm/action.yml
+++ b/.github/actions/setup-k8s-charm/action.yml
@@ -1,8 +1,11 @@
-name: Set up Juju Dashboard machine charm
-description: Set up the Juju Dashboard machine charm using the supplied versions.
+name: Set up Juju Dashboard k8s charm
+description: Set up the Juju Dashboard k8s charm using the supplied versions.
 inputs: 
   dashboard-version:
     description: When not called from a PR this can be set to the name of a Juju Dashboard release tag name or "latest".
+    required: false
+  dashboard-resource:
+    description: When not called from a PR this can be set to a dashboard-image revision or "latest" to use a docker image that has been published to Charmhub.
     required: false
   charm-channel:
     description: If set and this is not called from a PR this will run the e2e tests against a published charm. All other options will be ignored.
@@ -22,32 +25,33 @@ runs:
           echo "build_type=checkout" >> $GITHUB_ENV
         elif [ -n "${{ inputs.charm-channel }}" ]; then
           echo "build_type=charm-release" >> $GITHUB_ENV
+        elif [ -n "${{ inputs.dashboard-resource }}" ]; then
+          echo "build_type=dashboard-resource" >> $GITHUB_ENV
         else
           echo "build_type=dashboard-release" >> $GITHUB_ENV
         fi
       shell: bash
     - name: Check out Juju Dashboard charm
-      if: ${{ env.build_type == 'checkout' }}
+      if: ${{ env.build_type == 'checkout' || env.build_type == 'dashboard-release' }}
       uses: actions/checkout@v4
       with:
         repository: canonical/juju-dashboard-charm
         path: juju-dashboard-charm
     - name: Set up Juju Dashboard release
       if: ${{ env.build_type == 'dashboard-release' }}
-      run: |
-        cd ${{ github.workspace }}/juju-dashboard-charm/machine-charm
-        ./scripts/update-machine-charm-dashboard.sh ${{ inputs.dashboard-version }}
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.dashboard-version }}
+        path: juju-dashboard-release
+    - name: Build Juju Dashboard image
+      id: dashboard-image
+      if: ${{ env.build_type == 'checkout' || env.build_type == 'dashboard-release' }}
       shell: bash
-    - name: Set up Juju Dashboard release
-      if: ${{ env.build_type == 'checkout' }}
-      shell: bash
       run: |
-        cd ${{ github.workspace }}
-        yarn install
-        yarn build
-        cd ${{ github.workspace }}/juju-dashboard-charm/machine-charm
-        rm -rf src/dist/*
-        cp -r ${{ github.workspace }}/build/* src/dist
+        cd ${{ github.workspace }}${{ env.build_type == 'dashboard-release' && '/juju-dashboard-release' || '' }}
+        DOCKER_BUILDKIT=1 docker build -t juju-dashboard .
+        docker image save juju-dashboard | sudo microk8s ctr image import -
+        echo "id=$(docker image inspect juju-dashboard --format '{{.ID}}')" >> $GITHUB_OUTPUT
     - name: Install charmcraft
       if: ${{ env.build_type != 'charm-release' }}
       run: sudo snap install charmcraft --classic
@@ -60,7 +64,7 @@ runs:
     - name: Build the charm
       if: ${{ env.build_type != 'charm-release' }}
       run: |
-        cd ${{ github.workspace }}/juju-dashboard-charm/machine-charm
+        cd ${{ github.workspace }}/juju-dashboard-charm/k8s-charm
         charmcraft pack
       shell: bash
     - name: Switch to controller
@@ -72,7 +76,7 @@ runs:
       shell: bash
     - name: Deploy built charm
       if: ${{ env.build_type != 'charm-release' }}
-      run: juju deploy ${{ github.workspace }}/juju-dashboard-charm/machine-charm/juju-dashboard*.charm dashboard
+      run: juju deploy ${{ github.workspace }}/juju-dashboard-charm/k8s-charm/juju-dashboard*.charm dashboard --resource 'dashboard-image=${{ env.build_type == 'dashboard-release' && 'canonicalwebteam/juju-dashboard:${{ inputs.dashboard-release }}' || steps.dashboard-image.outputs.id }}'
       shell: bash
     - name: Integrate charm
       run: juju integrate controller dashboard

--- a/.github/actions/wait-for-snap/action.yml
+++ b/.github/actions/wait-for-snap/action.yml
@@ -1,0 +1,18 @@
+name: Wait for snap changes
+description: Wait for a snap to finish changes.
+inputs: 
+  snap:
+    description: The name of the snap to wait for.
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Wait for snap
+      shell: bash
+      run: |
+        while [ -n "$(snap changes ${{ inputs.snap }} 2>/dev/null | awk '/^[0-9]+/ {if ($2 != "Done") print $2 }')" ]; do
+          echo "Waiting for snap changes on ${{ inputs.snap }} to finish"
+          sleep 1
+        done
+        sleep 1

--- a/.github/workflows/e2e-juju-k8s-charm-local-auth.yml
+++ b/.github/workflows/e2e-juju-k8s-charm-local-auth.yml
@@ -1,0 +1,43 @@
+name: "E2E tests: Juju, k8s charm and local auth"
+
+on:
+  workflow_call:
+    inputs:
+      admin-password:
+        required: false
+        type: string
+        description: The password to use when logging in as the admin user.
+        default: password1
+
+jobs:
+  test:
+    name: Run tests
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        node-version: [22.x]
+    steps:
+      - name: Checkout Juju Dashboard repo
+        uses: actions/checkout@v4
+      - name: Setup Juju controller on k8s
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: "microk8s"
+          channel: 1.28-strict/stable
+          juju-channel: 3.6/stable
+          microk8s-group: snap_microk8s
+      - name: Save microk8s controller name
+        id: microk8s-controller
+        run: echo "name=$CONTROLLER_NAME" >> $GITHUB_OUTPUT
+        shell: bash
+      - name: Set up access
+        run: echo ${{ inputs.admin-password }} | juju change-user-password --no-prompt
+      - name: Set up Juju Dashboard k8s charm
+        uses: ./.github/actions/setup-k8s-charm
+      - name: Run tests
+        uses: ./.github/actions/run-playwright
+        with:
+          test-identifier: e2e-juju-k8s-charm-local-auth
+        env:
+          AUTH_MODE: local
+          JUJU_ENV: juju

--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -10,3 +10,6 @@ jobs:
   juju-machine-candid:
     name: Test Juju, machine-charm and candid-auth
     uses: ./.github/workflows/e2e-juju-machine-charm-candid-auth.yml
+  juju-k8s-local:
+    name: Test Juju, k8s-charm and local-auth
+    uses: ./.github/workflows/e2e-juju-k8s-charm-local-auth.yml


### PR DESCRIPTION
## Done

Add a workflow for testing the dashboard with Juju, local auth and the k8s charm.

## QA

Check that the workflow completes successfully:

https://github.com/canonical/juju-dashboard/actions/runs/14299184682/job/40070634428?pr=1921

Check the uploaded artefact:

https://github.com/canonical/juju-dashboard/actions/runs/14299184682?pr=1921

## Details

https://warthogs.atlassian.net/browse/WD-20939