### PR TITLE
feat(e2e): add basic auth tests for juju workflows

### DIFF
--- a/e2e/base/init.spec.ts
+++ b/e2e/base/init.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "@playwright/test";
 
-import { test } from "../fixtures/auth-setup";
+import { test } from "../fixtures/setup";
 
 test("Log in", async ({ page, authHelpers }) => {
   await authHelpers.login();

--- a/e2e/base/init.spec.ts
+++ b/e2e/base/init.spec.ts
@@ -1,6 +1,11 @@
-import { test, expect } from "@playwright/test";
+import { expect } from "@playwright/test";
 
-test("dashboard loads", async ({ page }) => {
-  await page.goto("/");
-  await expect(page).toHaveTitle(/Juju Dashboard/);
+import { test } from "../fixtures/auth-setup";
+
+test("Log in", async ({ page, authHelpers }) => {
+  await authHelpers.login();
+  await expect(page.getByRole("link", { name: "Models" })).toBeInViewport();
+  await expect(
+    page.getByRole("link", { name: "Controllers" }),
+  ).toBeInViewport();
 });

--- a/e2e/fixtures/auth-setup.ts
+++ b/e2e/fixtures/auth-setup.ts
@@ -1,0 +1,16 @@
+import { test as base } from "@playwright/test";
+
+import { AuthHelpers } from "../helpers/auth-helpers";
+
+type AuthFixtures = {
+  authHelpers: AuthHelpers;
+};
+
+export const test = base.extend<AuthFixtures>({
+  authHelpers: async ({ page }, use) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    await use(new AuthHelpers(page));
+  },
+});
+
+export default test;

--- a/e2e/fixtures/setup.ts
+++ b/e2e/fixtures/setup.ts
@@ -1,14 +1,14 @@
+/* eslint-disable react-hooks/rules-of-hooks */
 import { test as base } from "@playwright/test";
 
 import { AuthHelpers } from "../helpers/auth-helpers";
 
-type AuthFixtures = {
+type Fixtures = {
   authHelpers: AuthHelpers;
 };
 
-export const test = base.extend<AuthFixtures>({
+export const test = base.extend<Fixtures>({
   authHelpers: async ({ page }, use) => {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
     await use(new AuthHelpers(page));
   },
 });

--- a/e2e/helpers/auth-helpers.ts
+++ b/e2e/helpers/auth-helpers.ts
@@ -1,0 +1,40 @@
+import { type Page } from "@playwright/test";
+
+export class AuthHelpers {
+  readonly page: Page;
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  async loginLocal() {
+    await this.page.goto("/");
+    await this.page.getByRole("textbox", { name: "Username" }).fill("admin");
+    await this.page
+      .getByRole("textbox", { name: "Password" })
+      .fill("password1");
+    await this.page
+      .getByRole("button", { name: "Log in to the dashboard" })
+      .click();
+  }
+
+  async loginCandid() {
+    await this.page.goto("/");
+    const popupPromise = this.page.waitForEvent("popup");
+    await this.page
+      .getByRole("link", { name: "Log in to the dashboard" })
+      .click();
+    const popup = await popupPromise;
+    await popup.getByRole("link", { name: "static" }).click();
+    await popup.getByRole("textbox", { name: "Username" }).fill("user1");
+    await popup.getByRole("textbox", { name: "Password" }).fill("password1");
+    await popup.getByRole("button", { name: "Login" }).click();
+  }
+
+  async login() {
+    if (process.env.AUTH_MODE === "candid") {
+      await this.loginCandid();
+    } else {
+      await this.loginLocal();
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,6 @@
     "sourceMap": true,
     "types": ["vitest/globals"]
   },
-  "include": ["src"],
+  "include": ["src", "**/e2e"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
## Done

- Introduces basic authentication integration tests for all Juju workflows
- Verify the login functionality using username and password for Candid as well as Local Auth
- Implement helpers for authentication
- Inject the helpers as fixtures into the test

## QA

- The authentication tests should pass for all workflows
- Check the test results for all available End-to-End test workflows:
    1. https://github.com/canonical/juju-dashboard/actions/runs/14304424635/job/40085019396?pr=1926
    2. https://github.com/canonical/juju-dashboard/actions/runs/14304424635/job/40085019912?pr=1926
    3. https://github.com/canonical/juju-dashboard/actions/runs/14304424635/job/40085020348?pr=1926

## Details

https://warthogs.atlassian.net/browse/WD-20934
