### PR TITLE
feat: create webhook notification action

### DIFF
--- a/.github/actions/send-notification/action.yml
+++ b/.github/actions/send-notification/action.yml
@@ -1,0 +1,18 @@
+name: Send Mattermost notification
+description: Sends the provided content to a Mattermost channel.
+inputs:
+  channel:
+    description: Mattermost channel to send message to.
+    required: false
+    default: juju-dashboard-webhook-testing
+  webhook-url:
+    description: Webhook URL to send use.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Send notification
+      shell: bash
+      run: |
+        curl -X POST -F "workflow=${{ github.workflow }}" -F "repo_name=${{ github.repository }}" -F "action_id=${{ github.run_id }}" ${{ inputs.webhook-url }}?room=${{ inputs.channel }}

--- a/.github/workflows/e2e-juju-k8s-charm-local-auth.yml
+++ b/.github/workflows/e2e-juju-k8s-charm-local-auth.yml
@@ -41,3 +41,8 @@ jobs:
         env:
           AUTH_MODE: local
           JUJU_ENV: juju
+      - name: Send notification on failure
+        if: failure()
+        uses: ./.github/actions/send-notification
+        with:
+          webhook-url: ${{ secrets.WEBBOT_URL }}

--- a/.github/workflows/e2e-juju-machine-charm-candid-auth.yml
+++ b/.github/workflows/e2e-juju-machine-charm-candid-auth.yml
@@ -30,3 +30,8 @@ jobs:
         env:
           AUTH_MODE: candid
           JUJU_ENV: juju
+      - name: Send notification on failure
+        if: failure()
+        uses: ./.github/actions/send-notification
+        with:
+          webhook-url: ${{ secrets.WEBBOT_URL }}

--- a/.github/workflows/e2e-juju-machine-charm-local-auth.yml
+++ b/.github/workflows/e2e-juju-machine-charm-local-auth.yml
@@ -35,3 +35,8 @@ jobs:
         env:
           AUTH_MODE: local
           JUJU_ENV: juju
+      - name: Send notification on failure
+        if: failure()
+        uses: ./.github/actions/send-notification
+        with:
+          webhook-url: ${{ secrets.WEBBOT_URL }}

--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -7,9 +7,12 @@ jobs:
   juju-machine-local:
     name: Test Juju, machine-charm and local-auth
     uses: ./.github/workflows/e2e-juju-machine-charm-local-auth.yml
+    secrets: inherit
   juju-machine-candid:
     name: Test Juju, machine-charm and candid-auth
     uses: ./.github/workflows/e2e-juju-machine-charm-candid-auth.yml
+    secrets: inherit
   juju-k8s-local:
     name: Test Juju, k8s-charm and local-auth
     uses: ./.github/workflows/e2e-juju-k8s-charm-local-auth.yml
+    secrets: inherit


### PR DESCRIPTION
## Done

- Use [`secrets: inherit`](https://docs.github.com/en/actions/sharing-automations/reusing-workflows#passing-inputs-and-secrets-to-a-reusable-workflow) for re-usable workflows

- Create `send-notification` action

## QA

- https://github.com/canonical/juju-dashboard/actions/runs/14326157448/job/40151897274#step:3:1

## Details

WD-20958

## Screenshots

<img width="473" alt="image" src="https://github.com/user-attachments/assets/26c705cb-5ca8-4746-95f2-a685d8bc7f98" />
