### PR TITLE
feat(e2e): Add test suite for model access control

### DIFF
--- a/e2e/base/models.spec.ts
+++ b/e2e/base/models.spec.ts
@@ -34,7 +34,9 @@ test.describe("Models", () => {
     page,
     authHelpers,
   }) => {
+    // Skipping non-local auth tests: Only admin login supported for Candid/OIDC currently.
     test.skip(process.env.AUTH_MODE !== "local");
+
     await page.goto("/models/admin/foo");
     await authHelpers.login("John-Doe", "password2");
 

--- a/e2e/juju/model-access-control.spec.ts
+++ b/e2e/juju/model-access-control.spec.ts
@@ -1,0 +1,41 @@
+import { expect } from "@playwright/test";
+
+import { test } from "../fixtures/setup";
+
+test.describe("Model Access Control", () => {
+  test.beforeAll(async ({ jujuHelpers }) => {
+    await jujuHelpers.jujuLogin();
+    await jujuHelpers.addModel("foo");
+    await jujuHelpers.addUser("John-Doe");
+  });
+
+  test.afterAll(async ({ jujuHelpers }) => {
+    await jujuHelpers.cleanup();
+  });
+
+  test("Can change model permissions", async ({ page, authHelpers }) => {
+    // Skipping non-local auth tests: Only admin login supported for Candid/OIDC currently.
+    test.skip(process.env.AUTH_MODE !== "local");
+
+    await page.goto("/models");
+    await authHelpers.login();
+
+    await page.getByTestId("column-updated").last().hover();
+    await page.getByRole("button", { name: "Access" }).click();
+
+    await expect(page.getByTestId("share-panel")).toBeInViewport();
+
+    await page.getByRole("textbox", { name: "Username" }).fill("John-Doe");
+    await page.getByRole("button", { name: "Add user" }).click();
+
+    await expect(page.getByTestId("toast-card")).toContainText(
+      "John-Doe now has access to this model",
+    );
+
+    await page.goto("/models/admin/foo");
+    await authHelpers.login("John-Doe", "password2");
+    await expect(page.locator(".entity-info__grid-item").first()).toHaveText(
+      "accessread",
+    );
+  });
+});


### PR DESCRIPTION
## Done

- Added test suite to check that a user can change model permissions
- Also verifies that a user with permission can view another's model

## QA

- All tests should pass

## Details

https://warthogs.atlassian.net/browse/WD-20952
