### PR TITLE
fix(ci): use commit sha for pull request workflow

### DIFF
--- a/.github/actions/prepare-action/action.yml
+++ b/.github/actions/prepare-action/action.yml
@@ -33,7 +33,7 @@ runs:
       id: config
       shell: bash
       env:
-        PULL_REQUEST_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        PULL_REQUEST_HEAD_REF: ${{ github.event.pull_request.head.sha }}
         RELEASE_TARGET_COMMITISH: ${{ github.event.release.target_commitish }}
         INPUTS_DASHBOARD_CHARM_REF: ${{ github.event.inputs.dashboard-charm-ref }}
         INPUTS_JIMM_VERSION: ${{ github.event.inputs.jimm-version }}

--- a/.github/actions/prepare-action/action.yml
+++ b/.github/actions/prepare-action/action.yml
@@ -25,6 +25,9 @@ outputs:
   juju-channel:
     description: Version of Juju to use.
     value: ${{ steps.config.outputs.juju-channel }}
+  send-failure-notification:
+    description: Whether a failure notification should be triggered from this workflow.
+    value: ${{ steps.config.outputs.send-failure-notification }}
 
 runs:
   using: composite
@@ -50,6 +53,7 @@ runs:
         K8S_DASHBOARD_RESOURCE=""
         JIMM_VERSION="dev"
         JUJU_CHANNEL="3/stable"
+        SEND_FAILURE_NOTIFICATION=""
 
         case "${{ github.event_name }}" in
           "pull_request")
@@ -59,11 +63,13 @@ runs:
           "release")
             # Use release ref
             REPO_REF="$RELEASE_TARGET_COMMITISH"
+            SEND_FAILURE_NOTIFICATION="true"
             ;;
           "workflow_dispatch")
             DASHBOARD_CHARM_REF="$INPUTS_DASHBOARD_CHARM_REF"
             JIMM_VERSION="$INPUTS_JIMM_VERSION"
             JUJU_CHANNEL="$INPUTS_JUJU_CHANNEL"
+            SEND_FAILURE_NOTIFICATION="true"
 
             case "$INPUTS_DASHBOARD_SOURCE" in
               "bundled")
@@ -97,6 +103,7 @@ runs:
         echo "k8s-dashboard-resource=$K8S_DASHBOARD_RESOURCE" >> "$GITHUB_OUTPUT"
         echo "jimm-version=$JIMM_VERSION" >> "$GITHUB_OUTPUT"
         echo "juju-channel=$JUJU_CHANNEL" >> "$GITHUB_OUTPUT"
+        echo "send-failure-notification=$SEND_FAILURE_NOTIFICATION" >> "$GITHUB_OUTPUT"
     - name: Checkout Juju Dashboard repo
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/e2e-juju-k8s-charm-local-auth.yml
+++ b/.github/workflows/e2e-juju-k8s-charm-local-auth.yml
@@ -54,7 +54,7 @@ jobs:
           USERNAME: admin
           PASSWORD: ${{ inputs.admin-password }}
       - name: Send notification on failure
-        if: failure()
+        if: steps.config.outputs.send-failure-notification && failure()
         uses: ./.github/actions/send-notification
         with:
           webhook-url: ${{ secrets.WEBBOT_URL }}

--- a/.github/workflows/e2e-juju-machine-charm-candid-auth.yml
+++ b/.github/workflows/e2e-juju-machine-charm-candid-auth.yml
@@ -47,7 +47,7 @@ jobs:
           USERNAME: admin
           PASSWORD: ${{ inputs.admin-password }}
       - name: Send notification on failure
-        if: failure()
+        if: steps.config.outputs.send-failure-notification && failure()
         uses: ./.github/actions/send-notification
         with:
           webhook-url: ${{ secrets.WEBBOT_URL }}

--- a/.github/workflows/e2e-juju-machine-charm-local-auth.yml
+++ b/.github/workflows/e2e-juju-machine-charm-local-auth.yml
@@ -49,7 +49,7 @@ jobs:
           USERNAME: admin
           PASSWORD: ${{ inputs.admin-password }}
       - name: Send notification on failure
-        if: failure()
+        if: steps.config.outputs.send-failure-notification && failure()
         uses: ./.github/actions/send-notification
         with:
           webhook-url: ${{ secrets.WEBBOT_URL }}


### PR DESCRIPTION
## Done

- Use commit SHA instead of named ref for checking out source in action

## QA

- Actions pass


## Details

This seems to be a side effect of running the action across forks, rather than solely on branches within the repository. Branch names aren't shared across forks, so when `pull_request.head.ref` returns a branch name, the action isn't able to correctly determine how to resolve it. Using `pull_request.head.sha` appears to solve this.