### PR TITLE
fix: don't trigger e2e from other labels

### DIFF
--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -54,19 +54,31 @@ jobs:
     name: Test Juju, machine-charm and local-auth
     uses: ./.github/workflows/e2e-juju-machine-charm-local-auth.yml
     secrets: inherit
-    if:  github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'e2e')
+    if: |
+      github.event_name != 'pull_request' || (
+        (github.event.action == 'labeled' && github.event.label.name == 'e2e') ||
+        (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'e2e')))
   juju-machine-candid:
     name: Test Juju, machine-charm and candid-auth
     uses: ./.github/workflows/e2e-juju-machine-charm-candid-auth.yml
     secrets: inherit
-    if:  github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'e2e')
+    if: |
+      github.event_name != 'pull_request' || (
+        (github.event.action == 'labeled' && github.event.label.name == 'e2e') ||
+        (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'e2e')))
   juju-k8s-local:
     name: Test Juju, k8s-charm and local-auth
     uses: ./.github/workflows/e2e-juju-k8s-charm-local-auth.yml
     secrets: inherit
-    if:  github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'e2e')
+    if: |
+      github.event_name != 'pull_request' || (
+        (github.event.action == 'labeled' && github.event.label.name == 'e2e') ||
+        (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'e2e')))
   jimm-k8s-oidc:
     name: Test JIMM, k8s-charm and oidc-auth
     uses: ./.github/workflows/e2e-jimm-k8s-charm-oidc-auth.yml
     secrets: inherit
-    if:  github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'e2e')
+    if: |
+      github.event_name != 'pull_request' || (
+        (github.event.action == 'labeled' && github.event.label.name == 'e2e') ||
+        (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'e2e')))


### PR DESCRIPTION
## Done

- Fix an issue where changing an unrelated label would trigger the e2e workflows if the PR already had the `e2e` label applied.

## Details

https://warthogs.atlassian.net/browse/WD-21780

