### PR TITLE
chore(ci): add e2e tests for accessing audit logs

### DIFF
--- a/e2e/helpers/juju-cli.ts
+++ b/e2e/helpers/juju-cli.ts
@@ -10,6 +10,7 @@ import type { Action } from "./action";
 import type { User } from "./auth";
 import { Users } from "./auth";
 import { LocalUser } from "./auth/backends/Local";
+import { Controller } from "./objects";
 
 /**
  * Credentials for the local superuser.
@@ -29,6 +30,7 @@ export class JujuCLI {
   private users: Users;
   private localAdmin: User;
   public identityAdmin: User;
+  public controllerInstance: Controller;
 
   constructor(
     public jujuEnv: JujuEnv,
@@ -43,6 +45,11 @@ export class JujuCLI {
     // Create an identity instance for the admin user. When using local auth
     // this will be identical to this.localAdmin.
     this.identityAdmin = this.users.createUserInstance(username, password);
+    this.controllerInstance = new Controller(
+      // In JIMM the controller name given to Juju is "jimm".
+      this.jujuEnv === JujuEnv.JIMM ? "jimm" : this.controller,
+      this.identityAdmin,
+    );
   }
 
   /**

--- a/e2e/jimm/audit-logs.spec.ts
+++ b/e2e/jimm/audit-logs.spec.ts
@@ -1,0 +1,63 @@
+import { expect } from "@playwright/test";
+
+import { test } from "../fixtures/setup";
+import { ActionStack } from "../helpers/action";
+import { GiveControllerAccess, AddModel } from "../helpers/actions";
+import type { User } from "../helpers/auth";
+import type { Model } from "../helpers/objects";
+import { ControllerPermission } from "../helpers/objects";
+
+test.describe("audit logs", () => {
+  let actions: ActionStack;
+  let user: User;
+  let model: Model;
+
+  test.beforeAll(async ({ jujuCLI }) => {
+    actions = new ActionStack(jujuCLI);
+    await actions.prepare((add) => {
+      user = add(jujuCLI.createUser());
+      model = add(new AddModel(user));
+      add(
+        new GiveControllerAccess(
+          jujuCLI.controllerInstance,
+          user,
+          ControllerPermission.SUPERUSER,
+        ),
+      );
+    });
+  });
+
+  test.afterAll(async () => {
+    await actions.rollback();
+  });
+
+  test("all logs page", async ({ page }) => {
+    await user.dashboardLogin(page, "/logs?enable-flag=rebac");
+    await expect(
+      page.getByRole("heading", { name: "Audit logs" }),
+    ).toBeVisible();
+    await expect(
+      page.locator("td", { hasText: user.displayName }).first(),
+    ).toBeVisible();
+    await expect(
+      page.locator("td", { hasText: "less than a minute ago" }).first(),
+    ).toBeVisible();
+  });
+
+  test("model logs tab", async ({ page }) => {
+    await user.dashboardLogin(
+      page,
+      `/models/${model.owner.dashboardUsername}/${model.name}?activeView=logs&tableView=audit-logs&enable-flag=rebac`,
+    );
+    await expect(page.getByRole("tab", { name: "Audit logs" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    await expect(
+      page.locator("td", { hasText: user.dashboardUsername }).first(),
+    ).toBeVisible();
+    await expect(
+      page.locator("td", { hasText: "less than a minute ago" }).first(),
+    ).toBeVisible();
+  });
+});

--- a/e2e/jimm/audit-logs.spec.ts
+++ b/e2e/jimm/audit-logs.spec.ts
@@ -37,10 +37,9 @@ test.describe("audit logs", () => {
       page.getByRole("heading", { name: "Audit logs" }),
     ).toBeVisible();
     await expect(
-      page.locator("td", { hasText: user.displayName }).first(),
-    ).toBeVisible();
-    await expect(
-      page.locator("td", { hasText: "less than a minute ago" }).first(),
+      page
+        .locator("td", { hasText: user.displayName })
+        .and(page.locator("td", { hasText: "less than a minute ago" })),
     ).toBeVisible();
   });
 
@@ -54,10 +53,9 @@ test.describe("audit logs", () => {
       "true",
     );
     await expect(
-      page.locator("td", { hasText: user.dashboardUsername }).first(),
-    ).toBeVisible();
-    await expect(
-      page.locator("td", { hasText: "less than a minute ago" }).first(),
+      page
+        .locator("td", { hasText: user.displayName })
+        .and(page.locator("td", { hasText: "less than a minute ago" })),
     ).toBeVisible();
   });
 });

--- a/e2e/jimm/audit-logs.spec.ts
+++ b/e2e/jimm/audit-logs.spec.ts
@@ -39,7 +39,8 @@ test.describe("audit logs", () => {
     await expect(
       page
         .locator("tr", { hasText: user.displayName })
-        .and(page.locator("tr", { hasText: "less than a minute ago" })),
+        .filter({ hasText: "less than a minute ago" })
+        .first(),
     ).toBeVisible();
   });
 
@@ -55,7 +56,8 @@ test.describe("audit logs", () => {
     await expect(
       page
         .locator("tr", { hasText: user.displayName })
-        .and(page.locator("tr", { hasText: "less than a minute ago" })),
+        .filter({ hasText: "less than a minute ago" })
+        .first(),
     ).toBeVisible();
   });
 });

--- a/e2e/jimm/audit-logs.spec.ts
+++ b/e2e/jimm/audit-logs.spec.ts
@@ -38,8 +38,8 @@ test.describe("audit logs", () => {
     ).toBeVisible();
     await expect(
       page
-        .locator("td", { hasText: user.displayName })
-        .and(page.locator("td", { hasText: "less than a minute ago" })),
+        .locator("tr", { hasText: user.displayName })
+        .and(page.locator("tr", { hasText: "less than a minute ago" })),
     ).toBeVisible();
   });
 
@@ -54,8 +54,8 @@ test.describe("audit logs", () => {
     );
     await expect(
       page
-        .locator("td", { hasText: user.displayName })
-        .and(page.locator("td", { hasText: "less than a minute ago" })),
+        .locator("tr", { hasText: user.displayName })
+        .and(page.locator("tr", { hasText: "less than a minute ago" })),
     ).toBeVisible();
   });
 });

--- a/e2e/jimm/rebac.spec.ts
+++ b/e2e/jimm/rebac.spec.ts
@@ -3,7 +3,7 @@ import { expect } from "@playwright/test";
 import { test } from "../fixtures/setup";
 import { ActionStack } from "../helpers/action";
 import { GiveControllerAccess } from "../helpers/actions";
-import { Controller, ControllerPermission } from "../helpers/objects";
+import { ControllerPermission } from "../helpers/objects";
 
 test.describe("ReBAC Admin", () => {
   let actions: ActionStack;
@@ -18,11 +18,10 @@ test.describe("ReBAC Admin", () => {
 
   test("can be accessed", async ({ jujuCLI, page }) => {
     const user = await actions.prepare((add) => {
-      const controller = new Controller("jimm", jujuCLI.identityAdmin);
       const user = add(jujuCLI.createUser());
       add(
         new GiveControllerAccess(
-          controller,
+          jujuCLI.controllerInstance,
           user,
           ControllerPermission.SUPERUSER,
         ),


### PR DESCRIPTION
## Done

- Test that audit logs can be viewed on the top level page and in model details.

## Details

https://warthogs.atlassian.net/browse/WD-20955
