### PR TITLE
feat(e2e): Update test suite for models

### DIFF
--- a/e2e/base/models.spec.ts
+++ b/e2e/base/models.spec.ts
@@ -6,18 +6,21 @@ import { AddModel, GrantModelAccess } from "../helpers/actions";
 import type { User } from "../helpers/auth";
 import { ModelGrantPermission, type Model } from "../helpers/objects";
 
-const MODEL = "models-foo";
+const MODEL1 = "models-foo1";
+const MODEL2 = "models-foo2";
 const SHARED_MODEL = "models-bar";
 
 test.describe("Models", () => {
   // TODO: implement OIDC fixtures WD-21779.
-  test.skip(process.env.AUTH_MODE === "oidc");
+  // Skipping non-local auth tests: Only admin login supported for Candid/OIDC currently.
+  test.skip(process.env.AUTH_MODE !== "local");
 
   let actions: ActionStack;
   let user1: User;
   let user2: User;
-  let model: Model;
-  let sharedModel: Model;
+  let user1Model: Model;
+  let user1Model2: Model;
+  let user2Model: Model;
 
   test.beforeAll(async ({ jujuCLI }) => {
     actions = new ActionStack(jujuCLI);
@@ -26,10 +29,11 @@ test.describe("Models", () => {
       user1 = add(jujuCLI.createUser());
       user2 = add(jujuCLI.createUser());
 
-      model = add(new AddModel(user1, MODEL));
-      sharedModel = add(new AddModel(user2, SHARED_MODEL));
+      user1Model = add(new AddModel(user1, MODEL1));
+      user1Model2 = add(new AddModel(user1, MODEL2));
+      user2Model = add(new AddModel(user2, SHARED_MODEL));
 
-      add(new GrantModelAccess(sharedModel, user1, ModelGrantPermission.Read));
+      add(new GrantModelAccess(user1Model, user2, ModelGrantPermission.Read));
     });
   });
 
@@ -39,25 +43,22 @@ test.describe("Models", () => {
 
   test("List created and shared models", async ({ page }) => {
     await page.goto("/models");
-    await user1.dashboardLogin(page);
+    await user2.dashboardLogin(page);
 
     await expect(
       page
-        .locator("tr", { hasText: model.name })
+        .locator("tr", { hasText: user1Model.name })
         .and(page.locator("tr", { hasText: user1.dashboardUsername })),
     ).toBeInViewport();
     await expect(
       page
-        .locator("tr", { hasText: sharedModel.name })
+        .locator("tr", { hasText: user2Model.name })
         .and(page.locator("tr", { hasText: user2.dashboardUsername })),
     ).toBeInViewport();
   });
 
   test("Cannot access model without permission", async ({ page }) => {
-    // Skipping non-local auth tests: Only admin login supported for Candid/OIDC currently.
-    test.skip(process.env.AUTH_MODE !== "local");
-
-    await page.goto(`/models/${user1.dashboardUsername}/${model.name}`);
+    await page.goto(`/models/${user1.dashboardUsername}/${user1Model2.name}`);
     await user2.dashboardLogin(page);
 
     await expect(page.getByText("Model not found")).toBeVisible();

--- a/e2e/helpers/actions/addModel.ts
+++ b/e2e/helpers/actions/addModel.ts
@@ -8,13 +8,11 @@ import { Model } from "../objects";
  */
 export class AddModel implements Action<Model> {
   public model: Model;
+  private static nextModelId = 0;
 
-  constructor(
-    owner: User,
-    // TODO: Generate random name
-    modelName: string,
-  ) {
-    this.model = new Model(modelName, owner);
+  constructor(owner: User) {
+    const id = AddModel.nextModelId++;
+    this.model = new Model(`model${id}`, owner);
   }
 
   async run() {

--- a/e2e/helpers/auth/Users.ts
+++ b/e2e/helpers/auth/Users.ts
@@ -14,7 +14,7 @@ import type { AuthImplementation } from ".";
  * environment variable.
  */
 export class Users {
-  private nextUserId = 0;
+  private static nextUserId = 0;
   private CreateUser: AuthImplementation;
 
   constructor(browser: Browser) {
@@ -55,7 +55,7 @@ export class Users {
       return new this.CreateUser("test@example.com", "test");
     }
 
-    const id = this.nextUserId++;
+    const id = Users.nextUserId++;
     return new this.CreateUser(`user${id}`, `password${id}`);
   }
 }

--- a/e2e/juju/model-access-control.spec.ts
+++ b/e2e/juju/model-access-control.spec.ts
@@ -6,8 +6,6 @@ import { AddModel } from "../helpers/actions";
 import type { User } from "../helpers/auth";
 import type { Model } from "../helpers/objects";
 
-const MODEL = "model-access-control-foo";
-
 test.describe("Model Access Control", () => {
   let actions: ActionStack;
   let user1: User;
@@ -21,7 +19,7 @@ test.describe("Model Access Control", () => {
       user1 = add(jujuCLI.createUser());
       user2 = add(jujuCLI.createUser());
 
-      model = add(new AddModel(user2, MODEL));
+      model = add(new AddModel(user2));
     });
   });
 

--- a/e2e/juju/web-cli.spec.ts
+++ b/e2e/juju/web-cli.spec.ts
@@ -21,7 +21,7 @@ test.describe("Web CLI", () => {
 
     const { user, model } = await actions.prepare((add) => {
       const user = add(jujuCLI.createUser());
-      const model = add(new AddModel(user, "some-model-name"));
+      const model = add(new AddModel(user));
       return { user, model };
     });
 


### PR DESCRIPTION
## Done

- Updated the `models.spec.ts` test suite
- The test to verify list of created + shared models is now run from a secondary user's perspective that does not have superuser permissions
- Removed hard-coded model names and added incrementing model name.

## Details

https://warthogs.atlassian.net/browse/WD-21920
