### PR TITLE
fix: trigger e2e tests on PR creation if label is present

### DIFF
--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -20,10 +20,10 @@ on:
         required: true
         type: choice
         options:
-        - branch
-        - release
-        - charm
-        - bundled
+          - branch
+          - release
+          - charm
+          - bundled
       source-identifier:
         description: |
           Identifier for the dashboard source:
@@ -57,6 +57,7 @@ jobs:
     if: |
       github.event_name != 'pull_request' || (
         (github.event.action == 'labeled' && github.event.label.name == 'e2e') ||
+        (github.event.action == 'opened' && contains(github.event.pull_request.labels.*.name, 'e2e')) ||
         (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'e2e')))
   juju-machine-candid:
     name: Test Juju, machine-charm and candid-auth
@@ -65,6 +66,7 @@ jobs:
     if: |
       github.event_name != 'pull_request' || (
         (github.event.action == 'labeled' && github.event.label.name == 'e2e') ||
+        (github.event.action == 'opened' && contains(github.event.pull_request.labels.*.name, 'e2e')) ||
         (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'e2e')))
   juju-k8s-local:
     name: Test Juju, k8s-charm and local-auth
@@ -73,6 +75,7 @@ jobs:
     if: |
       github.event_name != 'pull_request' || (
         (github.event.action == 'labeled' && github.event.label.name == 'e2e') ||
+        (github.event.action == 'opened' && contains(github.event.pull_request.labels.*.name, 'e2e')) ||
         (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'e2e')))
   jimm-k8s-oidc:
     name: Test JIMM, k8s-charm and oidc-auth
@@ -81,4 +84,5 @@ jobs:
     if: |
       github.event_name != 'pull_request' || (
         (github.event.action == 'labeled' && github.event.label.name == 'e2e') ||
+        (github.event.action == 'opened' && contains(github.event.pull_request.labels.*.name, 'e2e')) ||
         (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'e2e')))


### PR DESCRIPTION
## Done

- Updated the e2e workflow to trigger when a PR is initially created and it already has the 'e2e' label applied.
