### PR TITLE
Update model access test to support Candid

### DIFF
--- a/e2e/helpers/auth/backends/OIDC.ts
+++ b/e2e/helpers/auth/backends/OIDC.ts
@@ -104,7 +104,7 @@ export class OIDCUser extends LocalUser {
   }
 
   override get dashboardUsername(): string {
-    return `${this.username}@example.com`;
+    return this.cliUsername;
   }
 
   public get displayName(): string {


### PR DESCRIPTION
## Done

- Update the test for changing model access to support Candid users. This was failing because refreshing the page in Candid logs you in as the previous user.

Passing run:
https://github.com/canonical/juju-dashboard/actions/runs/14960599944?pr=1963

## Details

https://warthogs.atlassian.net/browse/WD-22015
