### PR TITLE
chore(ci): add e2e test for configuring an application

### DIFF
--- a/e2e/base/configure.spec.ts
+++ b/e2e/base/configure.spec.ts
@@ -1,0 +1,63 @@
+import { expect } from "@playwright/test";
+
+import { test } from "../fixtures/setup";
+import { ActionStack } from "../helpers/action";
+import { AddModel, DeployApplication } from "../helpers/actions";
+import type { User } from "../helpers/auth";
+import type { Model, Application } from "../helpers/objects";
+
+test.describe("configure application", () => {
+  let actions: ActionStack;
+  let user: User;
+  let model: Model;
+  let application: Application;
+
+  test.beforeAll(async ({ jujuCLI, testOptions }) => {
+    test.setTimeout(300000);
+    actions = new ActionStack(jujuCLI);
+
+    await actions.prepare((add) => {
+      user = add(jujuCLI.createUser());
+      model = add(new AddModel(user));
+      application = add(new DeployApplication(model, testOptions.provider));
+    });
+  });
+
+  test.afterAll(async () => {
+    await actions.rollback();
+  });
+
+  test("application can be configured", async ({ page }) => {
+    await user.dashboardLogin(page, "/models?enable-flag=rebac");
+    // Go to the application inside the model:
+    await page.getByRole("link", { name: model.name }).click();
+    await page.getByRole("link", { name: application.name }).click();
+    // Open the configure panel for the corresponding application:
+    await page.getByRole("button", { name: "Configure" }).click();
+    const configPanel = page.getByTestId("config-panel");
+    await expect(configPanel).toBeInViewport();
+    // Set the config:
+    const textbox = page.getByTestId(application.config).getByRole("textbox");
+    const changed = "new value";
+    await textbox.clear();
+    await textbox.fill(changed);
+    await configPanel.getByRole("button", { name: "Save and apply" }).click();
+    // Confirm the change:
+    await expect(
+      page.getByRole("heading", {
+        name: "Are you sure you wish to apply these changes?",
+      }),
+    ).toBeInViewport();
+    await page.getByRole("button", { name: "Yes, apply changes" }).click();
+    // The panel should now close:
+    await expect(configPanel).not.toBeInViewport();
+    await user.reloadDashboard(page);
+    // Open the configure panel again:
+    await page.getByRole("button", { name: "Configure" }).click();
+    await expect(page.getByTestId("config-panel")).toBeInViewport();
+    // Check that the config persisted:
+    await expect(
+      page.getByTestId(application.config).getByRole("textbox"),
+    ).toHaveValue(changed);
+  });
+});

--- a/e2e/helpers/auth/Users.ts
+++ b/e2e/helpers/auth/Users.ts
@@ -64,6 +64,11 @@ export abstract class User {
   ): Promise<void>;
 
   /**
+   * Use this user to log into the dashboard.
+   */
+  abstract reloadDashboard(page: Page): Promise<void>;
+
+  /**
    * Use this user to authenticate with the Juju CLI.
    */
   abstract cliLogin(): Promise<void>;

--- a/e2e/helpers/auth/backends/Candid.ts
+++ b/e2e/helpers/auth/backends/Candid.ts
@@ -95,6 +95,10 @@ export class CandidUser extends LocalUser {
     await this.candidUiLogin(popup);
   }
 
+  override async reloadDashboard(page: Page) {
+    await page.reload();
+  }
+
   override async cliLogin() {
     await exec("juju logout");
 

--- a/e2e/helpers/auth/backends/Local.ts
+++ b/e2e/helpers/auth/backends/Local.ts
@@ -46,11 +46,20 @@ export class LocalUser implements User {
     public password: string,
   ) {}
 
-  async dashboardLogin(page: Page, url: string) {
-    await page.goto(url);
+  private async enterCredentials(page: Page) {
     await page.getByRole("textbox", { name: "Username" }).fill(this.username);
     await page.getByRole("textbox", { name: "Password" }).fill(this.password);
     await page.getByRole("button", { name: "Log in to the dashboard" }).click();
+  }
+
+  async dashboardLogin(page: Page, url: string) {
+    await page.goto(url);
+    await this.enterCredentials(page);
+  }
+
+  async reloadDashboard(page: Page) {
+    await page.reload();
+    await this.enterCredentials(page);
   }
 
   async cliLogin() {

--- a/e2e/helpers/auth/backends/OIDC.ts
+++ b/e2e/helpers/auth/backends/OIDC.ts
@@ -80,6 +80,10 @@ export class OIDCUser extends LocalUser {
     );
   }
 
+  override async reloadDashboard(page: Page) {
+    await page.reload();
+  }
+
   override async cliLogin() {
     let retry = 3;
     // This login is retried as sometimes the login fails if it is too slow and an error is displayed:

--- a/e2e/helpers/objects/application.ts
+++ b/e2e/helpers/objects/application.ts
@@ -1,25 +1,35 @@
 /**
  * Charm to deploy based on provider.
  */
-export const CharmName = {
-  localhost: "anbox-cloud-dashboard",
-  microk8s: "hello-kubecon",
-};
+export enum CharmName {
+  localhost = "anbox-cloud-dashboard",
+  microk8s = "hello-kubecon",
+}
 
 /**
  * Action to run.
  */
-export const ActionName = {
-  "anbox-cloud-dashboard": "backup",
-  "hello-kubecon": "pull-site",
-};
+export enum ActionName {
+  "anbox-cloud-dashboard" = "backup",
+  "hello-kubecon" = "pull-site",
+}
+
+/**
+ * Config property to change.
+ */
+export enum ConfigName {
+  "anbox-cloud-dashboard" = "location",
+  "hello-kubecon" = "redirect-map",
+}
 
 export class Application {
   public action: string;
+  public config: string;
   constructor(
     public name: string,
-    public charm: string,
+    public charm: CharmName,
   ) {
-    this.action = ActionName[charm as keyof typeof ActionName];
+    this.action = ActionName[charm];
+    this.config = ConfigName[charm];
   }
 }


### PR DESCRIPTION
## Done

- Add support for reloading the dashboard and logging back in.
- Added configure application test.

Passing run:
https://github.com/canonical/juju-dashboard/actions/runs/14986276376?pr=1966

## Details

https://warthogs.atlassian.net/browse/WD-20945
