### PR TITLE
chore(ci): add read-only tests

### DIFF
--- a/e2e/base/actions.spec.ts
+++ b/e2e/base/actions.spec.ts
@@ -1,5 +1,7 @@
 import { expect } from "@playwright/test";
 
+import { TestId as AppTestId } from "pages/EntityDetails/App/types";
+
 import { test } from "../fixtures/setup";
 import { ActionStack } from "../helpers/action";
 import {
@@ -89,7 +91,9 @@ test.describe("Actions", () => {
       page,
       `/models/${model.owner.dashboardUsername}/${model.name}/app/${application.name}?enable-flag=rebac`,
     );
-    await expect(page.getByRole("checkbox")).not.toBeVisible();
+    await expect(
+      page.getByTestId(AppTestId.UNITS_TABLE).getByRole("checkbox"),
+    ).not.toBeVisible();
     await expect(
       page.getByRole("button", { name: "Run action" }),
     ).not.toBeVisible();

--- a/e2e/base/models.spec.ts
+++ b/e2e/base/models.spec.ts
@@ -50,8 +50,31 @@ test.describe("Models", () => {
   test("Cannot access model without permission", async ({ page }) => {
     await user2.dashboardLogin(
       page,
-      `/models/${user1.dashboardUsername}/${user1Model.name}`,
+      `/models/${user1.cliUsername}/${user1Model.name}`,
     );
     await expect(page.getByText("Model not found")).toBeVisible();
+  });
+
+  test("model list does not display access button to non-admins", async ({
+    page,
+  }) => {
+    await user2.dashboardLogin(page, "/models?enable-flag=rebac");
+    // The access button only appears on hover.
+    await page.getByRole("link", { name: sharedModel.name }).hover();
+    await expect(
+      page.getByRole("button", { name: "Access" }),
+    ).not.toBeVisible();
+  });
+
+  test("model details does not display access button to non-admins", async ({
+    page,
+  }) => {
+    await user2.dashboardLogin(
+      page,
+      `/models/${user1.cliUsername}/${user1Model.name}?enable-flag=rebac`,
+    );
+    await expect(
+      page.getByRole("button", { name: "Manage access" }),
+    ).not.toBeVisible();
   });
 });

--- a/e2e/base/secrets.spec.ts
+++ b/e2e/base/secrets.spec.ts
@@ -1,0 +1,43 @@
+import { expect } from "@playwright/test";
+
+import { test } from "../fixtures/setup";
+import { ActionStack } from "../helpers/action";
+import { AddModel, GiveModelAccess } from "../helpers/actions";
+import type { User } from "../helpers/auth";
+import type { Model } from "../helpers/objects";
+import { ModelPermission } from "../helpers/objects";
+
+test.describe("secrets", () => {
+  let actions: ActionStack;
+  let user: User;
+  let nonAdmin: User;
+  let model: Model;
+
+  test.beforeAll(async ({ jujuCLI }) => {
+    test.setTimeout(300000);
+    actions = new ActionStack(jujuCLI);
+
+    await actions.prepare((add) => {
+      user = add(jujuCLI.createUser());
+      nonAdmin = add(jujuCLI.createUser());
+      model = add(new AddModel(user));
+      add(new GiveModelAccess(model, nonAdmin, ModelPermission.READ));
+    });
+  });
+
+  test.afterAll(async () => {
+    await actions.rollback();
+  });
+
+  test("secrets do not display controls", async ({ page }) => {
+    await nonAdmin.dashboardLogin(
+      page,
+      `/models/${model.owner.cliUsername}/${model.name}?activeView=secrets&enable-flag=rebac`,
+    );
+    // Go to the application inside the model:
+    await page.getByRole("link", { name: model.name }).hover();
+    await expect(
+      page.getByRole("button", { name: "Access" }),
+    ).not.toBeVisible();
+  });
+});

--- a/e2e/base/secrets.spec.ts
+++ b/e2e/base/secrets.spec.ts
@@ -14,7 +14,6 @@ test.describe("secrets", () => {
   let model: Model;
 
   test.beforeAll(async ({ jujuCLI }) => {
-    test.setTimeout(300000);
     actions = new ActionStack(jujuCLI);
 
     await actions.prepare((add) => {

--- a/e2e/helpers/actions/utils/give-access.ts
+++ b/e2e/helpers/actions/utils/give-access.ts
@@ -26,9 +26,11 @@ export class GiveAccess<Entity extends Model | Controller>
     jimmCommand: string,
   ) {
     if (jujuCLI.jujuEnv == JujuEnv.JUJU) {
+      const entityName =
+        this.tag === "controller" ? "" : `'${this.entityName}'`;
       await this.entity.owner.cliLogin();
       await exec(
-        `juju ${jujuCommand} '${this.user.cliUsername}' '${this.access}' '${this.entity.name}'`,
+        `juju ${jujuCommand} '${this.user.cliUsername}' '${this.access}' ${entityName}`,
       );
     } else {
       await jujuCLI.loginIdentityCLIAdmin();

--- a/e2e/helpers/actions/utils/give-access.ts
+++ b/e2e/helpers/actions/utils/give-access.ts
@@ -30,7 +30,7 @@ export class GiveAccess<Entity extends Model | Controller>
         this.tag === "controller" ? "" : `'${this.entityName}'`;
       await this.entity.owner.cliLogin();
       await exec(
-        `juju ${jujuCommand} '${this.user.cliUsername}' '${this.access}' ${entityName}`,
+        `juju ${jujuCommand} '${this.user.cliUsername}' '${this.access}' '${entityName}'`,
       );
     } else {
       await jujuCLI.loginIdentityCLIAdmin();

--- a/e2e/jimm/audit-logs.spec.ts
+++ b/e2e/jimm/audit-logs.spec.ts
@@ -1,5 +1,7 @@
 import { expect } from "@playwright/test";
 
+import { Label as PageNotFoundLabel } from "pages/PageNotFound/types";
+
 import { test } from "../fixtures/setup";
 import { ActionStack } from "../helpers/action";
 import {
@@ -82,7 +84,7 @@ test.describe("audit logs", () => {
     ).not.toBeVisible();
     await expect(
       page.getByRole("heading", {
-        name: "Hmm, we can't seem to find that page...",
+        name: PageNotFoundLabel.NOT_FOUND,
       }),
     ).toBeVisible();
   });

--- a/e2e/jimm/audit-logs.spec.ts
+++ b/e2e/jimm/audit-logs.spec.ts
@@ -2,20 +2,26 @@ import { expect } from "@playwright/test";
 
 import { test } from "../fixtures/setup";
 import { ActionStack } from "../helpers/action";
-import { GiveControllerAccess, AddModel } from "../helpers/actions";
+import {
+  GiveControllerAccess,
+  AddModel,
+  GiveModelAccess,
+} from "../helpers/actions";
 import type { User } from "../helpers/auth";
 import type { Model } from "../helpers/objects";
-import { ControllerPermission } from "../helpers/objects";
+import { ControllerPermission, ModelPermission } from "../helpers/objects";
 
 test.describe("audit logs", () => {
   let actions: ActionStack;
   let user: User;
+  let nonAdminUser: User;
   let model: Model;
 
   test.beforeAll(async ({ jujuCLI }) => {
     actions = new ActionStack(jujuCLI);
     await actions.prepare((add) => {
       user = add(jujuCLI.createUser());
+      nonAdminUser = add(jujuCLI.createUser());
       model = add(new AddModel(user));
       add(
         new GiveControllerAccess(
@@ -24,6 +30,7 @@ test.describe("audit logs", () => {
           ControllerPermission.SUPERUSER,
         ),
       );
+      add(new GiveModelAccess(model, nonAdminUser, ModelPermission.READ));
     });
   });
 
@@ -59,5 +66,41 @@ test.describe("audit logs", () => {
         .filter({ hasText: "less than a minute ago" })
         .first(),
     ).toBeVisible();
+  });
+
+  test("all logs link is not displayed for non-admins", async ({ page }) => {
+    await nonAdminUser.dashboardLogin(page, "/models?enable-flag=rebac");
+    await expect(
+      page.getByRole("banner").getByRole("link", { name: "Logs" }),
+    ).not.toBeVisible();
+  });
+
+  test("all logs page can't be accessed by non-admins", async ({ page }) => {
+    await nonAdminUser.dashboardLogin(page, "/logs?enable-flag=rebac");
+    await expect(
+      page.getByRole("heading", { name: "Audit logs" }),
+    ).not.toBeVisible();
+    await expect(
+      page.getByRole("heading", {
+        name: "Hmm, we can't seem to find that page...",
+      }),
+    ).toBeVisible();
+  });
+
+  test("model logs link is not displayed for non-admins", async ({ page }) => {
+    await nonAdminUser.dashboardLogin(page, "/models?enable-flag=rebac");
+    await expect(
+      page.getByRole("banner").getByRole("link", { name: "Logs" }),
+    ).not.toBeVisible();
+  });
+
+  test("model logs tab can't be accessed by non-admins", async ({ page }) => {
+    await nonAdminUser.dashboardLogin(
+      page,
+      `/models/${model.owner.dashboardUsername}/${model.name}?activeView=logs&tableView=audit-logs&enable-flag=rebac`,
+    );
+    await expect(
+      page.getByRole("tab", { name: "Audit logs" }),
+    ).not.toBeVisible();
   });
 });

--- a/e2e/jimm/rebac.spec.ts
+++ b/e2e/jimm/rebac.spec.ts
@@ -3,13 +3,18 @@ import { expect } from "@playwright/test";
 import { test } from "../fixtures/setup";
 import { ActionStack } from "../helpers/action";
 import { GiveControllerAccess } from "../helpers/actions";
+import type { User } from "../helpers/auth";
 import { ControllerPermission } from "../helpers/objects";
 
 test.describe("ReBAC Admin", () => {
   let actions: ActionStack;
+  let nonAdminUser: User;
 
-  test.beforeAll(({ jujuCLI }) => {
+  test.beforeAll(async ({ jujuCLI }) => {
     actions = new ActionStack(jujuCLI);
+    await actions.prepare((add) => {
+      nonAdminUser = add(jujuCLI.createUser());
+    });
   });
 
   test.afterAll(async () => {
@@ -34,5 +39,27 @@ test.describe("ReBAC Admin", () => {
     await expect(
       page.locator("td", { hasText: jujuCLI.identityAdmin.dashboardUsername }),
     ).toBeVisible();
+  });
+
+  test("link is not displayed for non-admins", async ({ page }) => {
+    await nonAdminUser.dashboardLogin(page, "/models?enable-flag=rebac");
+    await expect(
+      page.getByRole("banner").getByRole("link", { name: "Permissions" }),
+    ).not.toBeVisible();
+  });
+
+  test("can't be accessed by non-admins", async ({ page }) => {
+    await nonAdminUser.dashboardLogin(
+      page,
+      "/permissions/users?enable-flag=rebac",
+    );
+    await expect(
+      page.getByRole("heading", {
+        name: "Hmm, we can't seem to find that page...",
+      }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Users" }),
+    ).not.toBeVisible();
   });
 });


### PR DESCRIPTION
## Done

Add tests that controls aren't displayed for read-only permissions.

## Details

https://warthogs.atlassian.net/browse/WD-20949

Passing run:
https://github.com/canonical/juju-dashboard/actions/runs/15010802849/job/42179029947?pr=1967
