### PR TITLE
chore(ci): use urls definition and automatically add feature flags

### DIFF
--- a/e2e/base/actions.spec.ts
+++ b/e2e/base/actions.spec.ts
@@ -7,6 +7,7 @@ import {
 import { Label as ConfirmationDialogLabel } from "panels/ActionsPanel/ConfirmationDialog/types";
 import { TestId as ActionsPanelTestId } from "panels/ActionsPanel/types";
 import { ModelTab } from "urls";
+import urls from "urls";
 
 import { test } from "../fixtures/setup";
 import { ActionStack } from "../helpers/action";
@@ -41,7 +42,7 @@ test.describe("Actions", () => {
   });
 
   test("Run charm actions", async ({ page }) => {
-    await user.dashboardLogin(page, "/models?enable-flag=rebac");
+    await user.dashboardLogin(page, urls.models.index);
 
     // Go to the application inside the model
     await page.getByRole("link", { name: model.name }).click();

--- a/e2e/base/actions.spec.ts
+++ b/e2e/base/actions.spec.ts
@@ -96,10 +96,7 @@ test.describe("Actions", () => {
       const nonAdmin = add(jujuCLI.createUser());
       add(new GiveModelAccess(model, nonAdmin, ModelPermission.READ));
     });
-    await user.dashboardLogin(
-      page,
-      `/models/${model.owner.dashboardUsername}/${model.name}/app/${application.name}?enable-flag=rebac`,
-    );
+    await user.dashboardLogin(page, application.url);
     await expect(
       page.getByTestId(AppTestId.UNITS_TABLE).getByRole("checkbox"),
     ).not.toBeVisible();

--- a/e2e/base/auth-validation.spec.ts
+++ b/e2e/base/auth-validation.spec.ts
@@ -3,6 +3,7 @@ import { expect } from "@playwright/test";
 import { OIDCAuthLabel } from "auth/types";
 import { Label as LogInLabel } from "components/LogIn/types";
 import { Label as APILabel } from "juju/types";
+import urls from "urls";
 
 import { test } from "../fixtures/setup";
 import { ActionStack } from "../helpers/action";
@@ -19,10 +20,10 @@ test.describe("Authentication Validation", () => {
   });
 
   test("Can't bypass authentication", async ({ page }) => {
-    await page.goto("/models");
+    await page.goto(urls.models.index);
     await expect(page.getByText(LogInLabel.LOGIN_TO_DASHBOARD)).toBeVisible();
 
-    await page.goto("/controllers");
+    await page.goto(urls.controllers);
     await expect(page.getByText(LogInLabel.LOGIN_TO_DASHBOARD)).toBeVisible();
   });
 

--- a/e2e/base/configure.spec.ts
+++ b/e2e/base/configure.spec.ts
@@ -83,10 +83,7 @@ test.describe("configure application", () => {
   });
 
   test("application does not display configure button", async ({ page }) => {
-    await user.dashboardLogin(
-      page,
-      `/models/${model.owner.dashboardUsername}/${model.name}/app/${application.name}?enable-flag=rebac`,
-    );
+    await user.dashboardLogin(page, application.url);
     await expect(
       page.getByRole("button", { name: AppLabel.CONFIGURE }),
     ).not.toBeVisible();

--- a/e2e/base/models.spec.ts
+++ b/e2e/base/models.spec.ts
@@ -60,7 +60,7 @@ test.describe("Models", () => {
   test("model list does not display access button to non-admins", async ({
     page,
   }) => {
-    await user2.dashboardLogin(page, "/models?enable-flag=rebac");
+    await user2.dashboardLogin(page, urls.models.index);
     // The access button only appears on hover.
     await page.getByRole("link", { name: sharedModel.name }).hover();
     await expect(
@@ -71,10 +71,7 @@ test.describe("Models", () => {
   test("model details does not display access button to non-admins", async ({
     page,
   }) => {
-    await user2.dashboardLogin(
-      page,
-      `/models/${user1.cliUsername}/${user1Model.name}?enable-flag=rebac`,
-    );
+    await user2.dashboardLogin(page, user1Model.url);
     await expect(
       page.getByRole("button", { name: ModelLabel.ACCESS_BUTTON }),
     ).not.toBeVisible();

--- a/e2e/base/models.spec.ts
+++ b/e2e/base/models.spec.ts
@@ -3,6 +3,7 @@ import { expect } from "@playwright/test";
 import { Label as AccessButtonLabel } from "components/ModelTableList/AccessButton/types";
 import { Label as ModelLabel } from "pages/EntityDetails/Model/types";
 import { Label as EntityDetailsLabel } from "pages/EntityDetails/types";
+import urls from "urls";
 
 import { test } from "../fixtures/setup";
 import { ActionStack } from "../helpers/action";
@@ -38,7 +39,7 @@ test.describe("Models", () => {
   });
 
   test("List created and shared models", async ({ page }) => {
-    await user2.dashboardLogin(page, "/models");
+    await user2.dashboardLogin(page, urls.models.index);
     await expect(
       page
         .locator("tr", { hasText: sharedModel.name })
@@ -52,10 +53,7 @@ test.describe("Models", () => {
   });
 
   test("Cannot access model without permission", async ({ page }) => {
-    await user2.dashboardLogin(
-      page,
-      `/models/${user1.cliUsername}/${user1Model.name}`,
-    );
+    await user2.dashboardLogin(page, user1Model.url);
     await expect(page.getByText(EntityDetailsLabel.NOT_FOUND)).toBeVisible();
   });
 

--- a/e2e/base/secrets.spec.ts
+++ b/e2e/base/secrets.spec.ts
@@ -1,5 +1,7 @@
 import { expect } from "@playwright/test";
 
+import { ModelTab } from "urls";
+
 import { test } from "../fixtures/setup";
 import { ActionStack } from "../helpers/action";
 import { AddModel, GiveModelAccess } from "../helpers/actions";
@@ -29,10 +31,7 @@ test.describe("secrets", () => {
   });
 
   test("secrets do not display controls", async ({ page }) => {
-    await nonAdmin.dashboardLogin(
-      page,
-      `/models/${model.owner.cliUsername}/${model.name}?activeView=secrets&enable-flag=rebac`,
-    );
+    await nonAdmin.dashboardLogin(page, model.tab(ModelTab.SECRETS));
     // Go to the application inside the model:
     await page.getByRole("link", { name: model.name }).hover();
     await expect(

--- a/e2e/helpers/actions/deployApplication.ts
+++ b/e2e/helpers/actions/deployApplication.ts
@@ -15,7 +15,7 @@ export class DeployApplication implements Action<Application> {
   ) {
     const charm = CharmName[provider];
     const name = generateRandomName(charm);
-    this.application = new Application(name, charm);
+    this.application = new Application(name, charm, model);
   }
 
   async run() {

--- a/e2e/helpers/auth/backends/Candid.ts
+++ b/e2e/helpers/auth/backends/Candid.ts
@@ -1,6 +1,7 @@
 import type { Browser } from "@playwright/test";
 import { type Page } from "@playwright/test";
 
+import { addFeatureFlags } from "../../../utils";
 import { exec } from "../../../utils/exec";
 import { findLine } from "../../../utils/findLine";
 import type { Action } from "../../action";
@@ -87,7 +88,7 @@ export class CandidUser extends LocalUser {
   }
 
   override async dashboardLogin(page: Page, url: string) {
-    await page.goto(url);
+    await page.goto(addFeatureFlags(url));
     const popupPromise = page.waitForEvent("popup");
     await page.getByRole("link", { name: "Log in to the dashboard" }).click();
 

--- a/e2e/helpers/auth/backends/Local.ts
+++ b/e2e/helpers/auth/backends/Local.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import type { Page } from "@playwright/test";
 
 import type { User } from "..";
-import { juju } from "../../../utils";
+import { addFeatureFlags, juju } from "../../../utils";
 import { exec } from "../../../utils/exec";
 import type { Action } from "../../action";
 import type { JujuCLI } from "../../juju-cli";
@@ -53,7 +53,7 @@ export class LocalUser implements User {
   }
 
   async dashboardLogin(page: Page, url: string) {
-    await page.goto(url);
+    await page.goto(addFeatureFlags(url));
     await this.enterCredentials(page);
   }
 

--- a/e2e/helpers/auth/backends/OIDC.ts
+++ b/e2e/helpers/auth/backends/OIDC.ts
@@ -2,7 +2,7 @@ import type { Page } from "@playwright/test";
 import { expect } from "@playwright/test";
 import { chromium } from "playwright";
 
-import { getEnv, exec, findLine } from "../../../utils";
+import { getEnv, exec, findLine, addFeatureFlags } from "../../../utils";
 import type { Action } from "../../action";
 import type { JujuCLI } from "../../juju-cli";
 
@@ -170,7 +170,7 @@ export class OIDC {
     url: string,
     expectError?: boolean,
   ) {
-    await page.goto(url);
+    await page.goto(addFeatureFlags(url));
     await page.getByRole("link", { name: "Log in to the dashboard" }).click();
     await page.getByRole("textbox", { name: "Email" }).fill(user.username);
     await page.getByRole("textbox", { name: "Password" }).fill(user.password);
@@ -181,7 +181,7 @@ export class OIDC {
       await page.waitForURL("**/models");
       // The OIDC flow always redirects back to /models so now we need to visit
       // the expected URL:
-      await page.goto(url);
+      await page.goto(addFeatureFlags(url));
     }
   }
 }

--- a/e2e/helpers/objects/application.ts
+++ b/e2e/helpers/objects/application.ts
@@ -1,3 +1,6 @@
+import urls from "urls";
+
+import type { Model } from "../objects";
 /**
  * Charm to deploy based on provider.
  */
@@ -28,8 +31,17 @@ export class Application {
   constructor(
     public name: string,
     public charm: CharmName,
+    public model: Model,
   ) {
     this.action = ActionName[charm];
     this.config = ConfigName[charm];
+  }
+
+  public get url(): string {
+    return urls.model.app.index({
+      userName: this.model.owner.dashboardUsername,
+      modelName: this.model.name,
+      appName: this.name,
+    });
   }
 }

--- a/e2e/helpers/objects/model.ts
+++ b/e2e/helpers/objects/model.ts
@@ -1,3 +1,6 @@
+import type { ModelTab } from "urls";
+import urls from "urls";
+
 import type { User } from "../auth";
 
 /**
@@ -14,4 +17,19 @@ export class Model {
     public name: string,
     public owner: User,
   ) {}
+
+  public get url(): string {
+    return urls.model.index({
+      userName: this.owner.cliUsername,
+      modelName: this.name,
+    });
+  }
+
+  public tab(tab: ModelTab): string {
+    return urls.model.tab({
+      userName: this.owner.cliUsername,
+      modelName: this.name,
+      tab,
+    });
+  }
 }

--- a/e2e/jimm/audit-logs.spec.ts
+++ b/e2e/jimm/audit-logs.spec.ts
@@ -74,7 +74,7 @@ test.describe("audit logs", () => {
   });
 
   test("all logs link is not displayed for non-admins", async ({ page }) => {
-    await nonAdminUser.dashboardLogin(page, "/models?enable-flag=rebac");
+    await nonAdminUser.dashboardLogin(page, urls.models.index);
     await expect(
       page
         .getByRole("banner")
@@ -83,7 +83,7 @@ test.describe("audit logs", () => {
   });
 
   test("all logs page can't be accessed by non-admins", async ({ page }) => {
-    await nonAdminUser.dashboardLogin(page, "/logs?enable-flag=rebac");
+    await nonAdminUser.dashboardLogin(page, urls.logs);
     await expect(
       page.getByRole("heading", { name: LogsPageLabel.TITLE }),
     ).not.toBeVisible();
@@ -95,7 +95,7 @@ test.describe("audit logs", () => {
   });
 
   test("model logs link is not displayed for non-admins", async ({ page }) => {
-    await nonAdminUser.dashboardLogin(page, "/models?enable-flag=rebac");
+    await nonAdminUser.dashboardLogin(page, urls.models.index);
     await expect(
       page
         .getByRole("banner")
@@ -106,7 +106,7 @@ test.describe("audit logs", () => {
   test("model logs tab can't be accessed by non-admins", async ({ page }) => {
     await nonAdminUser.dashboardLogin(
       page,
-      `/models/${model.owner.dashboardUsername}/${model.name}?activeView=logs&tableView=audit-logs&enable-flag=rebac`,
+      `${model.tab(ModelTab.LOGS)}&tableView=audit-logs`,
     );
     await expect(
       page.getByRole("tab", { name: LogsPageLabel.TITLE }),

--- a/e2e/jimm/audit-logs.spec.ts
+++ b/e2e/jimm/audit-logs.spec.ts
@@ -4,6 +4,7 @@ import { Label as PrimaryNavLabel } from "components/PrimaryNav/types";
 import { Label as LogsLabel } from "pages/EntityDetails/Model/Logs/types";
 import { Label as LogsPageLabel } from "pages/Logs/types";
 import { Label as PageNotFoundLabel } from "pages/PageNotFound/types";
+import urls, { ModelTab } from "urls";
 
 import { test } from "../fixtures/setup";
 import { ActionStack } from "../helpers/action";
@@ -44,7 +45,7 @@ test.describe("audit logs", () => {
   });
 
   test("all logs page", async ({ page }) => {
-    await user.dashboardLogin(page, "/logs?enable-flag=rebac");
+    await user.dashboardLogin(page, urls.logs);
     await expect(
       page.getByRole("heading", { name: LogsPageLabel.TITLE }),
     ).toBeVisible();
@@ -59,7 +60,7 @@ test.describe("audit logs", () => {
   test("model logs tab", async ({ page }) => {
     await user.dashboardLogin(
       page,
-      `/models/${model.owner.dashboardUsername}/${model.name}?activeView=logs&tableView=audit-logs&enable-flag=rebac`,
+      `${model.tab(ModelTab.LOGS)}&tableView=audit-logs`,
     );
     await expect(
       page.getByRole("tab", { name: LogsLabel.AUDIT_LOGS }),

--- a/e2e/jimm/rebac.spec.ts
+++ b/e2e/jimm/rebac.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from "@playwright/test";
 
 import { Label as PrimaryNavLabel } from "components/PrimaryNav/types";
+import { rebacURLS } from "urls";
 
 import { test } from "../fixtures/setup";
 import { ActionStack } from "../helpers/action";
@@ -35,7 +36,7 @@ test.describe("ReBAC Admin", () => {
       );
       return user;
     });
-    await user.dashboardLogin(page, "/permissions/users?enable-flag=rebac");
+    await user.dashboardLogin(page, rebacURLS.users.index);
     await expect(
       page.getByRole("link", { name: PrimaryNavLabel.PERMISSIONS }),
     ).toBeVisible();

--- a/e2e/jimm/rebac.spec.ts
+++ b/e2e/jimm/rebac.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from "@playwright/test";
 
 import { Label as PrimaryNavLabel } from "components/PrimaryNav/types";
-import { rebacURLS } from "urls";
+import urls, { rebacURLS } from "urls";
 
 import { test } from "../fixtures/setup";
 import { ActionStack } from "../helpers/action";
@@ -47,7 +47,7 @@ test.describe("ReBAC Admin", () => {
   });
 
   test("link is not displayed for non-admins", async ({ page }) => {
-    await nonAdminUser.dashboardLogin(page, "/models?enable-flag=rebac");
+    await nonAdminUser.dashboardLogin(page, urls.models.index);
     await expect(
       page
         .getByRole("banner")
@@ -56,10 +56,7 @@ test.describe("ReBAC Admin", () => {
   });
 
   test("can't be accessed by non-admins", async ({ page }) => {
-    await nonAdminUser.dashboardLogin(
-      page,
-      "/permissions/users?enable-flag=rebac",
-    );
+    await nonAdminUser.dashboardLogin(page, rebacURLS.users.index);
     await expect(
       page.getByRole("heading", {
         name: "Hmm, we can't seem to find that page...",

--- a/e2e/juju/model-access-control.spec.ts
+++ b/e2e/juju/model-access-control.spec.ts
@@ -7,6 +7,7 @@ import {
   TestId as ShareModelTestId,
 } from "panels/ShareModelPanel/types";
 import { Label as ShareModelPanelLabel } from "panels/ShareModelPanel/types";
+import urls from "urls";
 
 import { test } from "../fixtures/setup";
 import { ActionStack } from "../helpers/action";
@@ -36,7 +37,7 @@ test.describe("Model Access Control", () => {
   });
 
   test("Can change model permissions", async ({ browser, page }) => {
-    await user2.dashboardLogin(page, "/models");
+    await user2.dashboardLogin(page, urls.models.index);
     const row = page.getByRole("row", { name: model.name });
     await row.getByTestId(StatusGroupTestId.COLUMN_UPDATED).hover();
     await page
@@ -60,10 +61,7 @@ test.describe("Model Access Control", () => {
     const context = await browser.newContext();
     // Create a new page inside context.
     const page2 = await context.newPage();
-    await user1.dashboardLogin(
-      page2,
-      `/models/${user2.cliUsername}/${model.name}`,
-    );
+    await user1.dashboardLogin(page2, model.url);
     await expect(page2.locator(".entity-info__grid-item").first()).toHaveText(
       "accessread",
     );

--- a/e2e/juju/web-cli.spec.ts
+++ b/e2e/juju/web-cli.spec.ts
@@ -27,10 +27,7 @@ test.describe("Web CLI", () => {
       const model = add(new AddModel(user));
       return { user, model };
     });
-    await user.dashboardLogin(
-      page,
-      `/models/${user.dashboardUsername}/${model.name}`,
-    );
+    await user.dashboardLogin(page, model.url);
     await page
       .getByRole("textbox", { name: WebCLIFields.COMMAND })
       .fill("help");

--- a/e2e/utils/addFeatureFlags.ts
+++ b/e2e/utils/addFeatureFlags.ts
@@ -1,0 +1,5 @@
+/**
+ * Add required feature flags to a URL.
+ */
+export const addFeatureFlags = (url: string): string =>
+  [url, "enable-flag=rebac"].join(url.includes("?") ? "&" : "?");

--- a/e2e/utils/addFeatureFlags.ts
+++ b/e2e/utils/addFeatureFlags.ts
@@ -1,5 +1,11 @@
+const flags = [["enable-flag", "rebac"]];
+
 /**
  * Add required feature flags to a URL.
  */
-export const addFeatureFlags = (url: string): string =>
-  [url, "enable-flag=rebac"].join(url.includes("?") ? "&" : "?");
+export const addFeatureFlags = (url: string): string => {
+  const [path, search] = url.split("?");
+  const params = new URLSearchParams(search);
+  flags.forEach(([flag, value]) => params.append(flag, value));
+  return [path, params].join("?");
+};

--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -1,3 +1,4 @@
+export { addFeatureFlags } from "./addFeatureFlags";
 export { exec } from "./exec";
 export { findLine } from "./findLine";
 export { generateRandomName } from "./generateRandomName";


### PR DESCRIPTION
## Done

- Use the URLs defined in the dashboard in the e2e tests to make them more easily to change in one place.
- Automatically add the feature flag.
