### PR TITLE
chore(ci): use labels and test ids in e2e tests

### DIFF
--- a/e2e/base/actions.spec.ts
+++ b/e2e/base/actions.spec.ts
@@ -6,6 +6,7 @@ import {
 } from "pages/EntityDetails/App/types";
 import { Label as ConfirmationDialogLabel } from "panels/ActionsPanel/ConfirmationDialog/types";
 import { TestId as ActionsPanelTestId } from "panels/ActionsPanel/types";
+import { ModelTab } from "urls";
 
 import { test } from "../fixtures/setup";
 import { ActionStack } from "../helpers/action";
@@ -74,7 +75,7 @@ test.describe("Actions", () => {
 
     // Go to the action logs
     if (process.env.AUTH_MODE === "oidc") {
-      await page.getByRole("link", { name: "Logs" }).click();
+      await page.getByRole("link", { name: ModelTab.LOGS }).click();
     } else {
       await page.getByTestId(AppTestId.SHOW_LOGS).click();
     }

--- a/e2e/base/actions.spec.ts
+++ b/e2e/base/actions.spec.ts
@@ -103,7 +103,7 @@ test.describe("Actions", () => {
       page.getByTestId(AppTestId.UNITS_TABLE).getByRole("checkbox"),
     ).not.toBeVisible();
     await expect(
-      page.getByRole("button", { name: "Run action" }),
+      page.getByRole("button", { name: AppLabel.RUN_ACTION }),
     ).not.toBeVisible();
   });
 });

--- a/e2e/base/actions.spec.ts
+++ b/e2e/base/actions.spec.ts
@@ -1,6 +1,11 @@
 import { expect } from "@playwright/test";
 
-import { TestId as AppTestId } from "pages/EntityDetails/App/types";
+import {
+  Label as AppLabel,
+  TestId as AppTestId,
+} from "pages/EntityDetails/App/types";
+import { Label as ConfirmationDialogLabel } from "panels/ActionsPanel/ConfirmationDialog/types";
+import { TestId as ActionsPanelTestId } from "panels/ActionsPanel/types";
 
 import { test } from "../fixtures/setup";
 import { ActionStack } from "../helpers/action";
@@ -45,9 +50,9 @@ test.describe("Actions", () => {
     await page
       .locator(`label[for="table-checkbox-${application.name}/0"]`)
       .click();
-    await page.getByTestId("run-action-button").click();
+    await page.getByTestId(AppTestId.RUN_ACTION_BUTTON).click();
 
-    await expect(page.getByTestId("actions-panel")).toBeInViewport();
+    await expect(page.getByTestId(ActionsPanelTestId.PANEL)).toBeInViewport();
 
     // Run the action
     await page
@@ -56,20 +61,22 @@ test.describe("Actions", () => {
       })
       .click();
     await page
-      .getByTestId("actions-panel")
-      .getByRole("button", { name: "Run action" })
+      .getByTestId(ActionsPanelTestId.PANEL)
+      .getByRole("button", { name: AppLabel.RUN_ACTION })
       .click();
 
     await expect(page.getByText(`Run ${application.action}?`)).toBeInViewport();
-    await page.getByText("Confirm").click();
+    await page.getByText(ConfirmationDialogLabel.CONFIRM_BUTTON).click();
 
-    await expect(page.getByTestId("actions-panel")).not.toBeInViewport();
+    await expect(
+      page.getByTestId(ActionsPanelTestId.PANEL),
+    ).not.toBeInViewport();
 
     // Go to the action logs
     if (process.env.AUTH_MODE === "oidc") {
       await page.getByRole("link", { name: "Logs" }).click();
     } else {
-      await page.getByTestId("show-logs").click();
+      await page.getByTestId(AppTestId.SHOW_LOGS).click();
     }
 
     await expect(

--- a/e2e/base/auth-validation.spec.ts
+++ b/e2e/base/auth-validation.spec.ts
@@ -1,5 +1,7 @@
 import { expect } from "@playwright/test";
 
+import { Label as LogInLabel } from "components/LogIn/types";
+
 import { test } from "../fixtures/setup";
 import { ActionStack } from "../helpers/action";
 
@@ -16,10 +18,10 @@ test.describe("Authentication Validation", () => {
 
   test("Can't bypass authentication", async ({ page }) => {
     await page.goto("/models");
-    await expect(page.getByText("Log in to the dashboard")).toBeVisible();
+    await expect(page.getByText(LogInLabel.LOGIN_TO_DASHBOARD)).toBeVisible();
 
     await page.goto("/controllers");
-    await expect(page.getByText("Log in to the dashboard")).toBeVisible();
+    await expect(page.getByText(LogInLabel.LOGIN_TO_DASHBOARD)).toBeVisible();
   });
 
   test("Needs valid credentials", async ({ page, jujuCLI }) => {
@@ -28,7 +30,7 @@ test.describe("Authentication Validation", () => {
 
     let expectedText = "Could not log into controller";
     if (process.env.AUTH_MODE === "candid") {
-      expectedText = "Connecting";
+      expectedText = LogInLabel.LOADING;
     } else if (process.env.AUTH_MODE === "oidc") {
       expectedText = "incorrect username or password";
     }
@@ -71,7 +73,7 @@ test.describe("Authentication Validation", () => {
         page.getByText("Unable to check authentication status.").first(),
       ).toBeVisible();
       await expect(
-        page.getByText("Log in to the dashboard").first(),
+        page.getByText(LogInLabel.LOGIN_TO_DASHBOARD).first(),
       ).toBeVisible();
     }
   });

--- a/e2e/base/auth-validation.spec.ts
+++ b/e2e/base/auth-validation.spec.ts
@@ -1,6 +1,8 @@
 import { expect } from "@playwright/test";
 
+import { OIDCAuthLabel } from "auth/types";
 import { Label as LogInLabel } from "components/LogIn/types";
+import { Label as APILabel } from "juju/types";
 
 import { test } from "../fixtures/setup";
 import { ActionStack } from "../helpers/action";
@@ -28,7 +30,7 @@ test.describe("Authentication Validation", () => {
     const fakeUser = jujuCLI.fakeUser("invalid-user", "password");
     await fakeUser.dashboardLogin(page, "/", true);
 
-    let expectedText = "Could not log into controller";
+    let expectedText: string = APILabel.CONTROLLER_LOGIN_ERROR;
     if (process.env.AUTH_MODE === "candid") {
       expectedText = LogInLabel.LOADING;
     } else if (process.env.AUTH_MODE === "oidc") {
@@ -53,9 +55,11 @@ test.describe("Authentication Validation", () => {
     if (process.env.AUTH_MODE === "candid") {
       await page.evaluate(() => window.localStorage.clear());
       await expect(
-        page.getByText("Controller authentication required").first(),
+        page.getByText(LogInLabel.AUTH_REQUIRED).first(),
       ).toBeVisible();
-      await expect(page.getByText("Authenticate").first()).toBeVisible();
+      await expect(
+        page.getByText(LogInLabel.AUTHENTICATE).first(),
+      ).toBeVisible();
     } else {
       await context.addCookies([
         {
@@ -69,9 +73,7 @@ test.describe("Authentication Validation", () => {
         },
       ]);
       await page.goto("/");
-      await expect(
-        page.getByText("Unable to check authentication status.").first(),
-      ).toBeVisible();
+      await expect(page.getByText(OIDCAuthLabel.WHOAMI).first()).toBeVisible();
       await expect(
         page.getByText(LogInLabel.LOGIN_TO_DASHBOARD).first(),
       ).toBeVisible();

--- a/e2e/base/configure.spec.ts
+++ b/e2e/base/configure.spec.ts
@@ -1,5 +1,12 @@
 import { expect } from "@playwright/test";
 
+import { Label as AppLabel } from "pages/EntityDetails/App/types";
+import { Label as ConfirmationDialogLabel } from "panels/ConfigPanel/ConfirmationDialog/types";
+import {
+  Label as ConfigPanelLabel,
+  TestId as ConfigPanelTestId,
+} from "panels/ConfigPanel/types";
+
 import { test } from "../fixtures/setup";
 import { ActionStack } from "../helpers/action";
 import {
@@ -41,28 +48,34 @@ test.describe("configure application", () => {
     await page.getByRole("link", { name: model.name }).click();
     await page.getByRole("link", { name: application.name }).click();
     // Open the configure panel for the corresponding application:
-    await page.getByRole("button", { name: "Configure" }).click();
-    const configPanel = page.getByTestId("config-panel");
+    await page.getByRole("button", { name: AppLabel.CONFIGURE }).click();
+    const configPanel = page.getByTestId(ConfigPanelTestId.PANEL);
     await expect(configPanel).toBeInViewport();
     // Set the config:
     const textbox = page.getByTestId(application.config).getByRole("textbox");
     const changed = "new value";
     await textbox.clear();
     await textbox.fill(changed);
-    await configPanel.getByRole("button", { name: "Save and apply" }).click();
+    await configPanel
+      .getByRole("button", { name: ConfigPanelLabel.SAVE_BUTTON })
+      .click();
     // Confirm the change:
     await expect(
       page.getByRole("heading", {
-        name: "Are you sure you wish to apply these changes?",
+        name: ConfirmationDialogLabel.SAVE_CONFIRM,
       }),
     ).toBeInViewport();
-    await page.getByRole("button", { name: "Yes, apply changes" }).click();
+    await page
+      .getByRole("button", {
+        name: ConfirmationDialogLabel.SAVE_CONFIRM_CONFIRM_BUTTON,
+      })
+      .click();
     // The panel should now close:
     await expect(configPanel).not.toBeInViewport();
     await user.reloadDashboard(page);
     // Open the configure panel again:
-    await page.getByRole("button", { name: "Configure" }).click();
-    await expect(page.getByTestId("config-panel")).toBeInViewport();
+    await page.getByRole("button", { name: AppLabel.CONFIGURE }).click();
+    await expect(page.getByTestId(ConfigPanelTestId.PANEL)).toBeInViewport();
     // Check that the config persisted:
     await expect(
       page.getByTestId(application.config).getByRole("textbox"),

--- a/e2e/base/configure.spec.ts
+++ b/e2e/base/configure.spec.ts
@@ -88,7 +88,7 @@ test.describe("configure application", () => {
       `/models/${model.owner.dashboardUsername}/${model.name}/app/${application.name}?enable-flag=rebac`,
     );
     await expect(
-      page.getByRole("button", { name: "Configure" }),
+      page.getByRole("button", { name: AppLabel.CONFIGURE }),
     ).not.toBeVisible();
   });
 });

--- a/e2e/base/controllers.spec.ts
+++ b/e2e/base/controllers.spec.ts
@@ -1,5 +1,7 @@
 import { expect } from "@playwright/test";
 
+import { Label as PrimaryNavLabel } from "components/PrimaryNav/types";
+
 import { JujuEnv, test } from "../fixtures/setup";
 import { ActionStack } from "../helpers/action";
 
@@ -19,7 +21,9 @@ test.describe("Controllers", () => {
       return add(jujuCLI.createUser());
     });
     await user.dashboardLogin(page, "/");
-    const controllersTab = page.getByRole("link", { name: "Controllers" });
+    const controllersTab = page.getByRole("link", {
+      name: PrimaryNavLabel.CONTROLLERS,
+    });
     await expect(controllersTab).toBeInViewport();
     await controllersTab.click();
     await expect(

--- a/e2e/base/models.spec.ts
+++ b/e2e/base/models.spec.ts
@@ -1,5 +1,7 @@
 import { expect } from "@playwright/test";
 
+import { Label as AccessButtonLabel } from "components/ModelTableList/AccessButton/types";
+import { Label as ModelLabel } from "pages/EntityDetails/Model/types";
 import { Label as EntityDetailsLabel } from "pages/EntityDetails/types";
 
 import { test } from "../fixtures/setup";
@@ -64,7 +66,7 @@ test.describe("Models", () => {
     // The access button only appears on hover.
     await page.getByRole("link", { name: sharedModel.name }).hover();
     await expect(
-      page.getByRole("button", { name: "Access" }),
+      page.getByRole("button", { name: AccessButtonLabel.ACCESS_BUTTON }),
     ).not.toBeVisible();
   });
 
@@ -76,7 +78,7 @@ test.describe("Models", () => {
       `/models/${user1.cliUsername}/${user1Model.name}?enable-flag=rebac`,
     );
     await expect(
-      page.getByRole("button", { name: "Manage access" }),
+      page.getByRole("button", { name: ModelLabel.ACCESS_BUTTON }),
     ).not.toBeVisible();
   });
 });

--- a/e2e/base/models.spec.ts
+++ b/e2e/base/models.spec.ts
@@ -1,5 +1,7 @@
 import { expect } from "@playwright/test";
 
+import { Label as EntityDetailsLabel } from "pages/EntityDetails/types";
+
 import { test } from "../fixtures/setup";
 import { ActionStack } from "../helpers/action";
 import { AddModel, GiveModelAccess } from "../helpers/actions";
@@ -52,7 +54,7 @@ test.describe("Models", () => {
       page,
       `/models/${user1.cliUsername}/${user1Model.name}`,
     );
-    await expect(page.getByText("Model not found")).toBeVisible();
+    await expect(page.getByText(EntityDetailsLabel.NOT_FOUND)).toBeVisible();
   });
 
   test("model list does not display access button to non-admins", async ({

--- a/e2e/jimm/audit-logs.spec.ts
+++ b/e2e/jimm/audit-logs.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from "@playwright/test";
 
 import { Label as LogsLabel } from "pages/EntityDetails/Model/Logs/types";
+import { Label as LogsPageLabel } from "pages/Logs/types";
 import { Label as PageNotFoundLabel } from "pages/PageNotFound/types";
 
 import { test } from "../fixtures/setup";
@@ -44,7 +45,7 @@ test.describe("audit logs", () => {
   test("all logs page", async ({ page }) => {
     await user.dashboardLogin(page, "/logs?enable-flag=rebac");
     await expect(
-      page.getByRole("heading", { name: "Audit logs" }),
+      page.getByRole("heading", { name: LogsPageLabel.TITLE }),
     ).toBeVisible();
     await expect(
       page

--- a/e2e/jimm/audit-logs.spec.ts
+++ b/e2e/jimm/audit-logs.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from "@playwright/test";
 
+import { Label as LogsLabel } from "pages/EntityDetails/Model/Logs/types";
 import { Label as PageNotFoundLabel } from "pages/PageNotFound/types";
 
 import { test } from "../fixtures/setup";
@@ -58,10 +59,9 @@ test.describe("audit logs", () => {
       page,
       `/models/${model.owner.dashboardUsername}/${model.name}?activeView=logs&tableView=audit-logs&enable-flag=rebac`,
     );
-    await expect(page.getByRole("tab", { name: "Audit logs" })).toHaveAttribute(
-      "aria-selected",
-      "true",
-    );
+    await expect(
+      page.getByRole("tab", { name: LogsLabel.AUDIT_LOGS }),
+    ).toHaveAttribute("aria-selected", "true");
     await expect(
       page
         .locator("tr", { hasText: user.displayName })

--- a/e2e/jimm/audit-logs.spec.ts
+++ b/e2e/jimm/audit-logs.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from "@playwright/test";
 
+import { Label as PrimaryNavLabel } from "components/PrimaryNav/types";
 import { Label as LogsLabel } from "pages/EntityDetails/Model/Logs/types";
 import { Label as LogsPageLabel } from "pages/Logs/types";
 import { Label as PageNotFoundLabel } from "pages/PageNotFound/types";
@@ -74,14 +75,16 @@ test.describe("audit logs", () => {
   test("all logs link is not displayed for non-admins", async ({ page }) => {
     await nonAdminUser.dashboardLogin(page, "/models?enable-flag=rebac");
     await expect(
-      page.getByRole("banner").getByRole("link", { name: "Logs" }),
+      page
+        .getByRole("banner")
+        .getByRole("link", { name: PrimaryNavLabel.LOGS }),
     ).not.toBeVisible();
   });
 
   test("all logs page can't be accessed by non-admins", async ({ page }) => {
     await nonAdminUser.dashboardLogin(page, "/logs?enable-flag=rebac");
     await expect(
-      page.getByRole("heading", { name: "Audit logs" }),
+      page.getByRole("heading", { name: LogsPageLabel.TITLE }),
     ).not.toBeVisible();
     await expect(
       page.getByRole("heading", {
@@ -93,7 +96,9 @@ test.describe("audit logs", () => {
   test("model logs link is not displayed for non-admins", async ({ page }) => {
     await nonAdminUser.dashboardLogin(page, "/models?enable-flag=rebac");
     await expect(
-      page.getByRole("banner").getByRole("link", { name: "Logs" }),
+      page
+        .getByRole("banner")
+        .getByRole("link", { name: PrimaryNavLabel.LOGS }),
     ).not.toBeVisible();
   });
 
@@ -103,7 +108,7 @@ test.describe("audit logs", () => {
       `/models/${model.owner.dashboardUsername}/${model.name}?activeView=logs&tableView=audit-logs&enable-flag=rebac`,
     );
     await expect(
-      page.getByRole("tab", { name: "Audit logs" }),
+      page.getByRole("tab", { name: LogsPageLabel.TITLE }),
     ).not.toBeVisible();
   });
 });

--- a/e2e/jimm/cross-model-queries.spec.ts
+++ b/e2e/jimm/cross-model-queries.spec.ts
@@ -1,5 +1,8 @@
 import { expect } from "@playwright/test";
 
+import { Label as SearchFormLabel } from "pages/AdvancedSearch/SearchForm/types";
+import { Label as AdvancedSearchLabel } from "pages/AdvancedSearch/types";
+
 import { test } from "../fixtures/setup";
 import { ActionStack } from "../helpers/action";
 import {
@@ -39,10 +42,10 @@ test.describe("cross model queries", () => {
   test("results are displayed ", async ({ page }) => {
     await user.dashboardLogin(page, "/search");
     await expect(
-      page.getByRole("heading", { name: "Advanced search" }),
+      page.getByRole("heading", { name: AdvancedSearchLabel.TITLE }),
     ).toBeVisible();
     await page
-      .getByRole("textbox", { name: "Search query" })
+      .getByRole("textbox", { name: SearchFormLabel.FIELD_QUERY })
       .fill(".applications");
     await page.keyboard.down("Enter");
     await expect(

--- a/e2e/jimm/rebac.spec.ts
+++ b/e2e/jimm/rebac.spec.ts
@@ -48,7 +48,9 @@ test.describe("ReBAC Admin", () => {
   test("link is not displayed for non-admins", async ({ page }) => {
     await nonAdminUser.dashboardLogin(page, "/models?enable-flag=rebac");
     await expect(
-      page.getByRole("banner").getByRole("link", { name: "Permissions" }),
+      page
+        .getByRole("banner")
+        .getByRole("link", { name: PrimaryNavLabel.PERMISSIONS }),
     ).not.toBeVisible();
   });
 

--- a/e2e/jimm/rebac.spec.ts
+++ b/e2e/jimm/rebac.spec.ts
@@ -1,5 +1,7 @@
 import { expect } from "@playwright/test";
 
+import { Label as PrimaryNavLabel } from "components/PrimaryNav/types";
+
 import { test } from "../fixtures/setup";
 import { ActionStack } from "../helpers/action";
 import { GiveControllerAccess } from "../helpers/actions";
@@ -34,7 +36,9 @@ test.describe("ReBAC Admin", () => {
       return user;
     });
     await user.dashboardLogin(page, "/permissions/users?enable-flag=rebac");
-    await expect(page.getByRole("link", { name: "Permissions" })).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: PrimaryNavLabel.PERMISSIONS }),
+    ).toBeVisible();
     await expect(page.getByRole("heading", { name: "Users" })).toBeVisible();
     await expect(
       page.locator("td", { hasText: jujuCLI.identityAdmin.dashboardUsername }),

--- a/e2e/juju/model-access-control.spec.ts
+++ b/e2e/juju/model-access-control.spec.ts
@@ -1,9 +1,12 @@
 import { expect } from "@playwright/test";
 
+import { Label as AccessButtonLabel } from "components/ModelTableList/AccessButton/types";
+import { TestId as StatusGroupTestId } from "components/ModelTableList/StatusGroup/types";
 import {
   Label as ShareModelLabel,
   TestId as ShareModelTestId,
 } from "panels/ShareModelPanel/types";
+import { Label as ShareModelPanelLabel } from "panels/ShareModelPanel/types";
 
 import { test } from "../fixtures/setup";
 import { ActionStack } from "../helpers/action";
@@ -35,13 +38,15 @@ test.describe("Model Access Control", () => {
   test("Can change model permissions", async ({ browser, page }) => {
     await user2.dashboardLogin(page, "/models");
     const row = page.getByRole("row", { name: model.name });
-    await row.getByTestId("column-updated").hover();
-    await page.getByRole("button", { name: "Access" }).click();
+    await row.getByTestId(StatusGroupTestId.COLUMN_UPDATED).hover();
+    await page
+      .getByRole("button", { name: AccessButtonLabel.ACCESS_BUTTON })
+      .click();
 
     await expect(page.getByTestId(ShareModelTestId.PANEL)).toBeInViewport();
 
     await page
-      .getByRole("textbox", { name: "Username" })
+      .getByRole("textbox", { name: ShareModelPanelLabel.FIELD_USERNAME })
       .fill(user1.cliUsername);
     await page
       .getByRole("button", { name: ShareModelLabel.ADD_BUTTON })

--- a/e2e/juju/model-access-control.spec.ts
+++ b/e2e/juju/model-access-control.spec.ts
@@ -1,5 +1,10 @@
 import { expect } from "@playwright/test";
 
+import {
+  Label as ShareModelLabel,
+  TestId as ShareModelTestId,
+} from "panels/ShareModelPanel/types";
+
 import { test } from "../fixtures/setup";
 import { ActionStack } from "../helpers/action";
 import { AddModel } from "../helpers/actions";
@@ -33,12 +38,14 @@ test.describe("Model Access Control", () => {
     await row.getByTestId("column-updated").hover();
     await page.getByRole("button", { name: "Access" }).click();
 
-    await expect(page.getByTestId("share-panel")).toBeInViewport();
+    await expect(page.getByTestId(ShareModelTestId.PANEL)).toBeInViewport();
 
     await page
       .getByRole("textbox", { name: "Username" })
       .fill(user1.cliUsername);
-    await page.getByRole("button", { name: "Add user" }).click();
+    await page
+      .getByRole("button", { name: ShareModelLabel.ADD_BUTTON })
+      .click();
 
     await expect(page.getByTestId("toast-card").last()).toContainText(
       `${user1.cliUsername} now has access to this model`,

--- a/e2e/juju/web-cli.spec.ts
+++ b/e2e/juju/web-cli.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from "@playwright/test";
 
 import { TestId as OutputTestId } from "components/WebCLI/Output/types";
+import { Fields as WebCLIFields } from "components/WebCLI/types";
 
 import { test } from "../fixtures/setup";
 import { ActionStack } from "../helpers/action";
@@ -30,7 +31,9 @@ test.describe("Web CLI", () => {
       page,
       `/models/${user.dashboardUsername}/${model.name}`,
     );
-    await page.getByRole("textbox", { name: "command" }).fill("help");
+    await page
+      .getByRole("textbox", { name: WebCLIFields.COMMAND })
+      .fill("help");
     await page.keyboard.down("Enter");
     await expect(page.getByTestId(OutputTestId.CODE)).toContainText(
       "Juju provides easy, intelligent application orchestration on top of Kubernetes",

--- a/e2e/juju/web-cli.spec.ts
+++ b/e2e/juju/web-cli.spec.ts
@@ -1,5 +1,7 @@
 import { expect } from "@playwright/test";
 
+import { TestId as OutputTestId } from "components/WebCLI/Output/types";
+
 import { test } from "../fixtures/setup";
 import { ActionStack } from "../helpers/action";
 import { AddModel } from "../helpers/actions";
@@ -30,7 +32,7 @@ test.describe("Web CLI", () => {
     );
     await page.getByRole("textbox", { name: "command" }).fill("help");
     await page.keyboard.down("Enter");
-    await expect(page.getByTestId("output-code")).toContainText(
+    await expect(page.getByTestId(OutputTestId.CODE)).toContainText(
       "Juju provides easy, intelligent application orchestration on top of Kubernetes",
     );
   });

--- a/src/auth/OIDCAuth.ts
+++ b/src/auth/OIDCAuth.ts
@@ -9,12 +9,9 @@ import type { AppDispatch } from "store/store";
 
 import { Auth, type ControllerData } from "./Auth";
 import { pollingMixin } from "./mixins";
+import { OIDCAuthLabel } from "./types";
 
 import { AuthMethod } from ".";
-
-export enum Label {
-  WHOAMI = "Unable to check authentication status. You can attempt to log in anyway.",
-}
 
 export class OIDCAuth extends pollingMixin(Auth) {
   constructor(dispatch: AppDispatch) {
@@ -50,7 +47,7 @@ export class OIDCAuth extends pollingMixin(Auth) {
       this.dispatch(
         generalActions.storeLoginError({
           wsControllerURL,
-          error: Label.WHOAMI,
+          error: OIDCAuthLabel.WHOAMI,
         }),
       );
       // Halt the connection attempt.

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,6 +1,6 @@
 export { Auth } from "./Auth";
 export { CandidAuth } from "./CandidAuth";
 export { LocalAuth } from "./LocalAuth";
-export { OIDCAuth } from "./OIDCAuth";
+export { OIDCAuth, Label as OIDCAuthLabel } from "./OIDCAuth";
 export { initialiseAuthFromConfig } from "./utils";
 export { AuthMethod } from "./types";

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,6 +1,6 @@
 export { Auth } from "./Auth";
 export { CandidAuth } from "./CandidAuth";
 export { LocalAuth } from "./LocalAuth";
-export { OIDCAuth, Label as OIDCAuthLabel } from "./OIDCAuth";
+export { OIDCAuth } from "./OIDCAuth";
 export { initialiseAuthFromConfig } from "./utils";
-export { AuthMethod } from "./types";
+export { AuthMethod, OIDCAuthLabel } from "./types";

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -3,3 +3,7 @@ export enum AuthMethod {
   LOCAL = "local",
   OIDC = "oidc",
 }
+
+export enum OIDCAuthLabel {
+  WHOAMI = "Unable to check authentication status. You can attempt to log in anyway.",
+}

--- a/src/components/LogIn/LogIn.tsx
+++ b/src/components/LogIn/LogIn.tsx
@@ -46,7 +46,7 @@ export default function LogIn() {
         reactHotToast.custom((t: ToastInstance) => (
           <ToastCard toastInstance={t} type="caution">
             <p className="u-no-margin--top u-no-padding--top">
-              Controller authentication required
+              {Label.AUTH_REQUIRED}
             </p>
             <AuthenticationButton
               appearance="positive"
@@ -58,7 +58,7 @@ export default function LogIn() {
                 reactHotToast.remove(t.id);
               }}
             >
-              Authenticate
+              {Label.AUTHENTICATE}
             </AuthenticationButton>
           </ToastCard>
         ));

--- a/src/components/LogIn/types.ts
+++ b/src/components/LogIn/types.ts
@@ -4,6 +4,8 @@ export enum ErrorResponse {
 }
 
 export enum Label {
+  AUTHENTICATE = "Authenticate",
+  AUTH_REQUIRED = "Controller authentication required",
   INVALID_NAME = "Invalid user name",
   INVALID_FIELD = "Invalid user name or password",
   POLLING_ERROR = "Error when trying to connect and start polling models.",

--- a/src/components/ModelTableList/StatusGroup/StatusGroup.tsx
+++ b/src/components/ModelTableList/StatusGroup/StatusGroup.tsx
@@ -83,11 +83,11 @@ function generateModelTableDataByStatus(
         "data-testid": `model-uuid-${model?.uuid}`,
         columns: [
           {
-            "data-testid": "column-name",
+            "data-testid": TestId.COLUMN_NAME,
             content: generateModelNameCell(model, groupLabel),
           },
           {
-            "data-testid": "column-summary",
+            "data-testid": TestId.COLUMN_SUMMARY,
             content: (
               <ModelSummary
                 modelData={model}
@@ -97,13 +97,13 @@ function generateModelTableDataByStatus(
             className: "u-overflow--visible",
           },
           {
-            "data-testid": "column-owner",
+            "data-testid": TestId.COLUMN_OWNER,
             content: (
               <TruncatedTooltip message={owner}>{owner}</TruncatedTooltip>
             ),
           },
           {
-            "data-testid": "column-cloud",
+            "data-testid": TestId.COLUMN_CLOUD,
             content: (
               <TruncatedTooltip message={generateCloudAndRegion(model)}>
                 {cloud}
@@ -111,7 +111,7 @@ function generateModelTableDataByStatus(
             ),
           },
           {
-            "data-testid": "column-credential",
+            "data-testid": TestId.COLUMN_CREDENTIAL,
             content: (
               <TruncatedTooltip message={credential}>
                 {credential}
@@ -119,7 +119,7 @@ function generateModelTableDataByStatus(
             ),
           },
           {
-            "data-testid": "column-controller",
+            "data-testid": TestId.COLUMN_CONTROLLER,
             content: (
               <TruncatedTooltip message={controller}>
                 {controller}
@@ -128,7 +128,7 @@ function generateModelTableDataByStatus(
           },
           // We're not currently able to get a last-accessed or updated from JAAS.
           {
-            "data-testid": "column-updated",
+            "data-testid": TestId.COLUMN_UPDATED,
             content: (
               <>
                 {canAdministerModel(activeUser, model?.info?.users) && (

--- a/src/components/ModelTableList/StatusGroup/types.ts
+++ b/src/components/ModelTableList/StatusGroup/types.ts
@@ -1,3 +1,10 @@
-export const TestId = {
-  STATUS_GROUP: "status-group",
-};
+export enum TestId {
+  STATUS_GROUP = "status-group",
+  COLUMN_NAME = "column-name",
+  COLUMN_SUMMARY = "column-summary",
+  COLUMN_OWNER = "column-owner",
+  COLUMN_CLOUD = "column-cloud",
+  COLUMN_CREDENTIAL = "column-credential",
+  COLUMN_CONTROLLER = "column-controller",
+  COLUMN_UPDATED = "column-updated",
+}

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -74,7 +74,7 @@ const useControllersLink = () => {
     component: NavLink,
     to: urls.controllers,
     icon: "controllers",
-    label: "Controllers",
+    label: Label.CONTROLLERS,
     status,
   };
 };

--- a/src/components/PrimaryNav/types.ts
+++ b/src/components/PrimaryNav/types.ts
@@ -1,5 +1,6 @@
 export enum Label {
   ADVANCED_SEARCH = "Advanced search",
+  CONTROLLERS = "Controllers",
   LOGS = "Logs",
   PERMISSIONS = "Permissions",
 }

--- a/src/components/WebCLI/index.ts
+++ b/src/components/WebCLI/index.ts
@@ -1,2 +1,2 @@
 export { default } from "./WebCLI";
-export { Label as WebCLILabel } from "./types";
+export { Label as WebCLILabel, Fields as WebCLIFields } from "./types";

--- a/src/components/WebCLI/types.ts
+++ b/src/components/WebCLI/types.ts
@@ -4,3 +4,7 @@ export enum Label {
   NOT_OPEN_ERROR = "WebSocket connection is not open.",
   UNKNOWN_ERROR = "Unknown error.",
 }
+
+export enum Fields {
+  COMMAND = "command",
+}

--- a/src/juju/api-hooks/common.test.tsx
+++ b/src/juju/api-hooks/common.test.tsx
@@ -14,7 +14,8 @@ import {
 import { modelListInfoFactory } from "testing/factories/juju/juju";
 import { ComponentProviders, changeURL, createStore } from "testing/utils";
 
-import { LOGIN_TIMEOUT, Label as APILabel } from "../api";
+import { LOGIN_TIMEOUT } from "../api";
+import { Label as APILabel } from "../types";
 
 import {
   useModelConnectionCallback,

--- a/src/juju/api.test.ts
+++ b/src/juju/api.test.ts
@@ -52,10 +52,9 @@ import {
   startModelWatcher,
   stopModelWatcher,
   connectToModel,
-  Label,
 } from "./api";
 import type { AllWatcherDelta } from "./types";
-import { DeltaChangeTypes, DeltaEntityTypes } from "./types";
+import { DeltaChangeTypes, DeltaEntityTypes, Label } from "./types";
 
 describe("Juju API", () => {
   beforeEach(() => {

--- a/src/juju/api.ts
+++ b/src/juju/api.ts
@@ -42,20 +42,15 @@ import { logger } from "utils/logger";
 
 import { getModelByUUID } from "../store/juju/selectors";
 
-import type {
-  AllWatcherDelta,
-  ApplicationInfo,
-  ConnectionWithFacades,
-  Facades,
-  FullStatusAnnotations,
-  FullStatusWithAnnotations,
+import {
+  Label,
+  type AllWatcherDelta,
+  type ApplicationInfo,
+  type ConnectionWithFacades,
+  type Facades,
+  type FullStatusAnnotations,
+  type FullStatusWithAnnotations,
 } from "./types";
-
-export enum Label {
-  LOGIN_TIMEOUT_ERROR = "Timed out when connecting to model.",
-  START_MODEL_WATCHER_NO_CONNECTION_ERROR = "Could not connect to model",
-  START_MODEL_WATCHER_NO_ID_ERROR = "Could not watch model for changes",
-}
 
 export const PING_TIME = 20000;
 export const LOGIN_TIMEOUT = 5000;
@@ -145,7 +140,7 @@ export async function loginWithBakery(
   try {
     conn = await juju.login(loginParams, CLIENT_VERSION);
   } catch (error) {
-    return { error: "Could not log into controller" };
+    return { error: Label.CONTROLLER_LOGIN_ERROR };
   }
 
   const intervalId = conn ? startPingerLoop(conn) : null;

--- a/src/juju/types.ts
+++ b/src/juju/types.ts
@@ -18,6 +18,13 @@ import type JIMMV4 from "./jimm/JIMMV4";
 // See https://github.com/juju/juju/blob/main/rpc/params/multiwatcher.go
 // for the Juju types for the AllWatcher responses.
 
+export enum Label {
+  CONTROLLER_LOGIN_ERROR = "Could not log into controller",
+  LOGIN_TIMEOUT_ERROR = "Timed out when connecting to model.",
+  START_MODEL_WATCHER_NO_CONNECTION_ERROR = "Could not connect to model",
+  START_MODEL_WATCHER_NO_ID_ERROR = "Could not watch model for changes",
+}
+
 export interface ActionData {
   [id: string]: ActionChangeDelta;
 }

--- a/src/pages/AdvancedSearch/AdvancedSearch.tsx
+++ b/src/pages/AdvancedSearch/AdvancedSearch.tsx
@@ -8,7 +8,7 @@ import { useAppSelector } from "store/store";
 import ErrorsBlock from "./ErrorsBlock";
 import ResultsBlock from "./ResultsBlock";
 import SearchForm from "./SearchForm";
-import { TestId } from "./types";
+import { Label, TestId } from "./types";
 
 const AdvancedSearch = (): JSX.Element => {
   const crossModelQueriesEnabled = useAppSelector(isCrossModelQueriesEnabled);
@@ -17,7 +17,7 @@ const AdvancedSearch = (): JSX.Element => {
       allowed={crossModelQueriesEnabled}
       data-testid={TestId.COMPONENT}
     >
-      <BaseLayout data-testid={TestId.COMPONENT} title="Advanced search">
+      <BaseLayout data-testid={TestId.COMPONENT} title={Label.TITLE}>
         <SearchForm />
         <ErrorsBlock />
         <ResultsBlock />

--- a/src/pages/AdvancedSearch/SearchForm/SearchForm.tsx
+++ b/src/pages/AdvancedSearch/SearchForm/SearchForm.tsx
@@ -90,7 +90,7 @@ const SearchForm = (): JSX.Element => {
         <div className="search-form__fields">
           <div className="search-form__field">
             <Field
-              aria-label="Search query"
+              aria-label={Label.FIELD_QUERY}
               as={Textarea}
               onKeyDown={(event: React.KeyboardEvent<HTMLTextAreaElement>) => {
                 if (event.key === "Enter") {

--- a/src/pages/AdvancedSearch/SearchForm/types.ts
+++ b/src/pages/AdvancedSearch/SearchForm/types.ts
@@ -3,6 +3,7 @@ export type FormFields = {
 };
 
 export enum Label {
+  FIELD_QUERY = "Search query",
   HELP = "Help",
   SEARCH = "Search",
   COPY_JSON = "Copy JSON",

--- a/src/pages/AdvancedSearch/types.ts
+++ b/src/pages/AdvancedSearch/types.ts
@@ -3,6 +3,10 @@ export enum CodeSnippetView {
   JSON = "json",
 }
 
+export enum Label {
+  TITLE = "Advanced search",
+}
+
 export enum TestId {
   COMPONENT = "AdvancedSearch",
 }

--- a/src/pages/Logs/Logs.tsx
+++ b/src/pages/Logs/Logs.tsx
@@ -7,7 +7,7 @@ import CheckPermissions from "components/CheckPermissions";
 import { useAuditLogsPermitted } from "juju/api-hooks/permissions";
 import BaseLayout from "layout/BaseLayout/BaseLayout";
 
-import { TestId } from "./types";
+import { Label, TestId } from "./types";
 
 const Logs = (): JSX.Element => {
   const { loading, permitted } = useAuditLogsPermitted();
@@ -17,7 +17,7 @@ const Logs = (): JSX.Element => {
       data-testid={TestId.COMPONENT}
       loading={loading}
     >
-      <BaseLayout data-testid={TestId.COMPONENT} title="Audit logs">
+      <BaseLayout data-testid={TestId.COMPONENT} title={Label.TITLE}>
         <ActionBar>
           <AuditLogsTableActions />
         </ActionBar>

--- a/src/pages/Logs/index.ts
+++ b/src/pages/Logs/index.ts
@@ -1,2 +1,2 @@
 export { default } from "./Logs";
-export { TestId as LogsTestId } from "./types";
+export { Label as LogsLabel, TestId as LogsTestId } from "./types";

--- a/src/pages/Logs/types.ts
+++ b/src/pages/Logs/types.ts
@@ -1,3 +1,7 @@
+export enum Label {
+  TITLE = "Audit logs",
+}
+
 export enum TestId {
   COMPONENT = "Logs",
 }

--- a/src/panels/ShareModelPanel/ShareModel.tsx
+++ b/src/panels/ShareModelPanel/ShareModel.tsx
@@ -337,7 +337,7 @@ export default function ShareModel() {
               id="username"
               name="username"
               type="text"
-              label="Username"
+              label={Label.FIELD_USERNAME}
               required
               value={newUserFormik.values.username}
               onChange={newUserFormik.handleChange}

--- a/src/panels/ShareModelPanel/types.ts
+++ b/src/panels/ShareModelPanel/types.ts
@@ -1,6 +1,7 @@
 export enum Label {
   ADD_BUTTON = "Add user",
   BACK_BUTTON = "Back",
+  FIELD_USERNAME = "Username",
   SHOW_ADD_FORM = "Add new user",
   PERMISSION_ERROR = "Error while trying to update model permissions.",
   NEW_USER_SUBMIT_ERROR = "Error while trying to submit new user form.",

--- a/src/store/middleware/check-auth.test.ts
+++ b/src/store/middleware/check-auth.test.ts
@@ -3,6 +3,7 @@ import type { Mock } from "vitest";
 import { vi } from "vitest";
 
 import * as jujuModule from "juju/api";
+import { Label } from "juju/types";
 import { thunks as appThunks } from "store/app";
 import { actions as generalActions } from "store/general";
 import type { RootState } from "store/store";
@@ -44,7 +45,7 @@ describe("model poller", () => {
       dispatch: vi.fn(),
     };
     vi.spyOn(jujuModule, "loginWithBakery").mockImplementation(async () => ({
-      error: "Uh oh!",
+      error: Label.CONTROLLER_LOGIN_ERROR,
       wsControllerURL: "wss://example.com/api",
     }));
   });

--- a/src/store/middleware/model-poller.test.ts
+++ b/src/store/middleware/model-poller.test.ts
@@ -7,6 +7,7 @@ import { Auth, LocalAuth, OIDCAuth } from "auth";
 import * as jujuModule from "juju/api";
 import * as jimmModule from "juju/jimm/api";
 import { pollWhoamiStart } from "juju/jimm/listeners";
+import { Label } from "juju/types";
 import { actions as appActions, thunks as appThunks } from "store/app";
 import type { ControllerArgs } from "store/app/actions";
 import { actions as generalActions } from "store/general";
@@ -154,14 +155,14 @@ describe("model poller", () => {
 
   it("dispatches login errors", async () => {
     vi.spyOn(jujuModule, "loginWithBakery").mockImplementation(async () => ({
-      error: "Uh oh!",
+      error: Label.CONTROLLER_LOGIN_ERROR,
     }));
     await runMiddleware();
     expect(next).not.toHaveBeenCalled();
     expect(fakeStore.dispatch).toHaveBeenCalledWith(
       generalActions.storeLoginError({
         wsControllerURL: "wss://example.com",
-        error: "Uh oh!",
+        error: Label.CONTROLLER_LOGIN_ERROR,
       }),
     );
   });


### PR DESCRIPTION
## Done

- Use the Label and TestId enums in the e2e tests to make it so the tests pass if the text/id is changed.


Passing run:
https://github.com/canonical/juju-dashboard/actions/runs/15008489507/job/42172661840?pr=1969