### PR TITLE
chore(CI): set read permissions for workflows

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches:
       - main
+permissions: read-all
 jobs:
   prettier:
     name: Check Prettier

--- a/.github/workflows/e2e-jimm-k8s-charm-oidc-auth.yml
+++ b/.github/workflows/e2e-jimm-k8s-charm-oidc-auth.yml
@@ -14,6 +14,8 @@ on:
         description: The password to use when logging in as the admin user.
         default: test
 
+permissions: read-all
+
 jobs:
   test:
     name: Run tests

--- a/.github/workflows/e2e-juju-k8s-charm-local-auth.yml
+++ b/.github/workflows/e2e-juju-k8s-charm-local-auth.yml
@@ -9,6 +9,8 @@ on:
         description: The password to use when logging in as the admin user.
         default: password1
 
+permissions: read-all
+
 jobs:
   test:
     name: Run tests

--- a/.github/workflows/e2e-juju-machine-charm-candid-auth.yml
+++ b/.github/workflows/e2e-juju-machine-charm-candid-auth.yml
@@ -9,6 +9,8 @@ on:
         description: The password to use when logging in as the admin user.
         default: password1
 
+permissions: read-all
+
 jobs:
   test:
     name: Run tests

--- a/.github/workflows/e2e-juju-machine-charm-local-auth.yml
+++ b/.github/workflows/e2e-juju-machine-charm-local-auth.yml
@@ -9,6 +9,8 @@ on:
         description: The password to use when logging in as the admin user.
         default: password1
 
+permissions: read-all
+
 jobs:
   test:
     name: Run tests

--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -49,6 +49,8 @@ on:
         type: string
         default: main
 
+permissions: read-all
+
 jobs:
   juju-machine-local:
     name: Test Juju, machine-charm and local-auth

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches:
       - main
+permissions: read-all
 jobs:
   test:
     name: Test

--- a/.github/workflows/tics-coverage.yml
+++ b/.github/workflows/tics-coverage.yml
@@ -2,6 +2,7 @@ name: Upload TICS report
 on:
   schedule:
     - cron: "0 22 * * 5"
+permissions: read-all
 
 jobs:
   TICS:


### PR DESCRIPTION
## Done

- Address code scanning alerts (https://github.com/canonical/juju-dashboard/security/code-scanning) by setting read-only permissions on workflows..

## Details

https://warthogs.atlassian.net/browse/WD-22134