### PR TITLE
fix: make the commands websocket authentication work with candid

### DIFF
--- a/e2e/juju/web-cli.spec.ts
+++ b/e2e/juju/web-cli.spec.ts
@@ -19,9 +19,6 @@ test.describe("Web CLI", () => {
   });
 
   test("Web CLI", async ({ page, jujuCLI }) => {
-    // Skipping candid auth as web CLI websocket can't be authenticated with it.
-    test.skip(process.env.AUTH_MODE === "candid");
-
     const { user, model } = await actions.prepare((add) => {
       const user = add(jujuCLI.createUser());
       const model = add(new AddModel(user));

--- a/src/components/WebCLI/WebCLI.test.tsx
+++ b/src/components/WebCLI/WebCLI.test.tsx
@@ -177,7 +177,7 @@ describe("WebCLI", () => {
     });
     bakerySpy.mockImplementation((key) => {
       const macaroons: Record<string, string> = {
-        "wss://localhost:1234": "WyJtYWMiLCAiYXJvb24iXQo=",
+        "wss://localhost:1234/api": "WyJtYWMiLCAiYXJvb24iXQo=",
       };
       return macaroons[key];
     });

--- a/src/components/WebCLI/WebCLI.tsx
+++ b/src/components/WebCLI/WebCLI.tsx
@@ -173,7 +173,7 @@ const WebCLI = ({
       const origin = connection.current?.address
         ? new URL(connection.current?.address)?.origin
         : null;
-      const macaroons = origin ? bakery.storage.get(origin) : null;
+      const macaroons = origin ? bakery.storage.get(`${origin}/api`) : null;
       if (macaroons) {
         const deserialized = JSON.parse(atob(macaroons));
         const originalWSOrigin = wsAddress ? new URL(wsAddress).origin : null;


### PR DESCRIPTION
## Done

- Fix the origin that the macaroons are stored under when authenticating with the web CLI using Candid.

## QA

- Connect to a controller that uses Candid.
- Go to a model details page.
- Enter a command into the CLI e.g. `status`.
- A result should be returned from Juju.

## Details

https://warthogs.atlassian.net/browse/WD-22214
