### PR TITLE
fix: small visual glitches in web CLI

### DIFF
--- a/src/components/WebCLI/Output/Output.test.tsx
+++ b/src/components/WebCLI/Output/Output.test.tsx
@@ -1,9 +1,11 @@
-import { screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { vi } from "vitest";
 
 import { renderComponent } from "testing/utils";
 
 import Output from "./Output";
+import { DEFAULT_HEIGHT, HELP_HEIGHT } from "./consts";
+import { TestId } from "./types";
 
 describe("Output", () => {
   it("should display content and not display help message", () => {
@@ -17,6 +19,10 @@ describe("Output", () => {
     );
     expect(screen.getByText("Output")).toBeInTheDocument();
     expect(screen.queryByText("Help message")).not.toBeInTheDocument();
+    expect(screen.getByTestId(TestId.CONTENT)).toHaveAttribute(
+      "style",
+      `height: ${DEFAULT_HEIGHT}px;`,
+    );
   });
 
   it("should not display content and display help message", () => {
@@ -28,8 +34,41 @@ describe("Output", () => {
         setShouldShowHelp={vi.fn()}
       />,
     );
-    expect(screen.queryByRole("Output")).not.toBeInTheDocument();
+    expect(screen.queryByText("Output")).not.toBeInTheDocument();
     expect(screen.getByText("Help message")).toBeInTheDocument();
+    expect(screen.getByTestId(TestId.CONTENT)).toHaveAttribute(
+      "style",
+      `height: ${HELP_HEIGHT}px;`,
+    );
+  });
+
+  it("should close the output when the help is closed", async () => {
+    const { rerender } = render(
+      <Output
+        content="Output"
+        helpMessage="Help message"
+        // Initially render with the help visible.
+        showHelp={true}
+        setShouldShowHelp={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId(TestId.CONTENT)).toHaveAttribute(
+      "style",
+      `height: ${HELP_HEIGHT}px;`,
+    );
+    rerender(
+      <Output
+        content="Output"
+        helpMessage="Help message"
+        // Rerender with the help hidden.
+        showHelp={false}
+        setShouldShowHelp={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId(TestId.CONTENT)).toHaveAttribute(
+      "style",
+      "height: 0px;",
+    );
   });
 
   it("should display the content with correct formatting", () => {

--- a/src/components/WebCLI/Output/consts.ts
+++ b/src/components/WebCLI/Output/consts.ts
@@ -1,0 +1,5 @@
+export const DEFAULT_HEIGHT = 300;
+// 20 is a magic number, sometimes the browser stops firing the drag at
+// an inopportune time and the element isn't left completely closed.
+export const CONSIDER_CLOSED = 20;
+export const HELP_HEIGHT = 40;

--- a/src/components/WebCLI/WebCLI.tsx
+++ b/src/components/WebCLI/WebCLI.tsx
@@ -227,7 +227,7 @@ const WebCLI = ({
   };
 
   return (
-    <div className="webcli">
+    <div className="webcli is-dark">
       <WebCLIOutput
         content={output}
         showHelp={shouldShowHelp || hasInlineError(InlineErrors.AUTHENTICATION)}
@@ -243,12 +243,7 @@ const WebCLI = ({
           ) : (
             <>
               Welcome to the Juju Web CLI - see the{" "}
-              <a
-                href={externalURLs.cliHelp}
-                className="p-link--inverted"
-                rel="noreferrer"
-                target="_blank"
-              >
+              <a href={externalURLs.cliHelp} rel="noreferrer" target="_blank">
                 full documentation here
               </a>
               .

--- a/src/components/WebCLI/__snapshots__/WebCLI.test.tsx.snap
+++ b/src/components/WebCLI/__snapshots__/WebCLI.test.tsx.snap
@@ -22,7 +22,7 @@ Machine  State    DNS             Inst id        Series  AZ          Message
 
 exports[`WebCLI > renders correctly 1`] = `
 <div
-  class="webcli"
+  class="webcli is-dark"
 >
   <div
     class="webcli__output"
@@ -47,7 +47,6 @@ exports[`WebCLI > renders correctly 1`] = `
         Welcome to the Juju Web CLI - see the
          
         <a
-          class="p-link--inverted"
           href="https://juju.is/docs/olm/the-juju-web-cli"
           rel="noreferrer"
           target="_blank"

--- a/src/components/WebCLI/_webcli.scss
+++ b/src/components/WebCLI/_webcli.scss
@@ -69,7 +69,6 @@ $canonical-purple: #2c001e;
     pre {
       background-color: $canonical-purple;
       border: none;
-      color: $color-x-light;
       width: 100%;
     }
 


### PR DESCRIPTION
## Done

- Fix the help link colour.
- close the terminal when closing the help
- adjust height of terminal help for mobile

## QA

- Go to a model and click the help icon next to the terminal input.
- The link in the help text should be readable.
- Click the help icon again and the help should close.

## Details

https://warthogs.atlassian.net/browse/WD-22301

## Screenshots

Link colour before fix:

<img width="875" alt="Screenshot 2025-05-26 at 10 26 46 am" src="https://github.com/user-attachments/assets/d81156dd-04f8-4c78-bd3f-adbd5c447393" />
