### PR TITLE
fix: handle commands that return a single line

### DIFF
--- a/src/components/WebCLI/Output/Output.test.tsx
+++ b/src/components/WebCLI/Output/Output.test.tsx
@@ -42,6 +42,33 @@ describe("Output", () => {
     );
   });
 
+  it("displays help while not loading and there is no content", () => {
+    renderComponent(
+      <Output
+        content=""
+        helpMessage="Help message"
+        showHelp={false}
+        loading={false}
+        setShouldShowHelp={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Help message")).toBeInTheDocument();
+  });
+
+  it("displays nothing while loading and there is no content", () => {
+    renderComponent(
+      <Output
+        content=""
+        helpMessage="Help message"
+        showHelp={false}
+        loading={true}
+        setShouldShowHelp={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText("Help message")).not.toBeInTheDocument();
+    expect(screen.getByTestId(TestId.CONTENT)).toHaveTextContent("");
+  });
+
   it("should close the output when the help is closed", async () => {
     const { rerender } = render(
       <Output

--- a/src/components/WebCLI/Output/Output.tsx
+++ b/src/components/WebCLI/Output/Output.tsx
@@ -9,6 +9,7 @@ import { TestId } from "./types";
 type Props = {
   content: string;
   helpMessage: ReactNode;
+  loading?: boolean;
   showHelp: boolean;
   setShouldShowHelp: (showHelp: boolean) => void;
 };
@@ -18,6 +19,7 @@ const dragHandles = ["webcli__output-dragarea", "webcli__output-handle"];
 const WebCLIOutput = ({
   content,
   helpMessage,
+  loading,
   showHelp,
   setShouldShowHelp,
 }: Props) => {
@@ -151,7 +153,7 @@ const WebCLIOutput = ({
         style={{ height: `${height}px` }}
         data-testid={TestId.CONTENT}
       >
-        {showHelp || !content ? (
+        {showHelp || (!loading && !content) ? (
           <code data-testid={TestId.HELP}>{helpMessage}</code>
         ) : (
           <code

--- a/src/components/WebCLI/WebCLI.test.tsx
+++ b/src/components/WebCLI/WebCLI.test.tsx
@@ -64,6 +64,54 @@ describe("WebCLI", () => {
     );
   });
 
+  it("shows the help in the output when enter is pressed", async () => {
+    renderComponent(<WebCLI {...props} />);
+    await server.connected;
+    const input = screen.getByRole("textbox");
+    await userEvent.type(input, "status{enter}");
+    const messages = [{ output: ["test"] }, { done: true }];
+    messages.forEach((message) => {
+      server.send(JSON.stringify(message));
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId(OutputTestId.CONTENT)).toHaveTextContent(
+        "test",
+      ),
+    );
+    fireEvent.keyDown(screen.getByRole("button", { name: Label.HELP }), {
+      key: "Enter",
+    });
+    expect(
+      document.querySelector(".webcli__output-content code"),
+    ).toHaveTextContent(
+      `Welcome to the Juju Web CLI - see the full documentation here.`,
+    );
+  });
+
+  it("shows the help in the output when space is pressed", async () => {
+    renderComponent(<WebCLI {...props} />);
+    await server.connected;
+    fireEvent.keyDown(screen.getByRole("button", { name: Label.HELP }), {
+      key: " ",
+    });
+    expect(
+      document.querySelector(".webcli__output-content code"),
+    ).toHaveTextContent(
+      `Welcome to the Juju Web CLI - see the full documentation here.`,
+    );
+  });
+
+  it("does not show the help in the output when keys other than space or enter are pressed", async () => {
+    renderComponent(<WebCLI {...props} />);
+    await server.connected;
+    fireEvent.keyDown(screen.getByRole("button", { name: Label.HELP }), {
+      key: "a",
+    });
+    expect(
+      document.querySelector(".webcli__output-content code"),
+    ).not.toHaveTextContent("");
+  });
+
   it("shows the help when there is no output", async () => {
     renderComponent(<WebCLI {...props} />);
     await server.connected;
@@ -310,7 +358,7 @@ describe("WebCLI", () => {
     await server.connected;
     expect(await screen.findByTestId(OutputTestId.CONTENT)).toHaveAttribute(
       "style",
-      "height: 1px;",
+      "height: 0px;",
     );
     const handle = document.querySelector(".webcli__output-handle");
     expect(handle).toBeTruthy();
@@ -331,7 +379,7 @@ describe("WebCLI", () => {
     await server.connected;
     expect(await screen.findByTestId(OutputTestId.CONTENT)).toHaveAttribute(
       "style",
-      "height: 1px;",
+      "height: 0px;",
     );
     const handle = document.querySelector(".webcli__output-handle");
     expect(handle).toBeTruthy();

--- a/src/components/WebCLI/WebCLI.tsx
+++ b/src/components/WebCLI/WebCLI.tsx
@@ -42,7 +42,8 @@ const WebCLI = ({
   protocol = "wss",
 }: Props) => {
   const connection = useRef<Connection | null>(null);
-  const [shouldShowHelp, setShouldShowHelp] = useState(false);
+  const [shouldShowHelp, setShouldShowHelp] = useState(true);
+  const [loading, setLoading] = useState(false);
   const [historyPosition, setHistoryPosition] = useState(0);
   const [inlineErrors, setInlineError, hasInlineError] = useInlineErrors();
   const inputRef = useRef<HTMLInputElement>(null);
@@ -143,6 +144,7 @@ const WebCLI = ({
         wsMessageStore.current = wsMessageStore.current + message;
         setOutput(wsMessageStore.current);
       },
+      setLoading,
     }).connect();
     connection.current = conn;
   }, [setInlineError, wsAddress]);
@@ -222,7 +224,11 @@ const WebCLI = ({
     }
   };
 
-  const showHelp = () => {
+  const showHelp = (event: React.MouseEvent | React.KeyboardEvent) => {
+    // Only trigger the help from the space or enter keys (or mouse clicks).
+    if ("key" in event && !["Enter", " "].includes(event.key)) {
+      return;
+    }
     setShouldShowHelp(!shouldShowHelp);
   };
 
@@ -250,6 +256,7 @@ const WebCLI = ({
             </>
           )
         }
+        loading={loading}
       />
       <div className="webcli__input">
         <div className="webcli__input-prompt">$ juju</div>
@@ -269,6 +276,7 @@ const WebCLI = ({
         </form>
         <div className="webcli__input-help">
           <i
+            aria-label={Label.HELP}
             className="p-icon--help is-light"
             onClick={showHelp}
             onKeyDown={showHelp}

--- a/src/components/WebCLI/__snapshots__/WebCLI.test.tsx.snap
+++ b/src/components/WebCLI/__snapshots__/WebCLI.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`WebCLI > renders correctly 1`] = `
 >
   <div
     class="webcli__output"
-    style="height: 1px;"
+    style="height: 0px;"
   >
     <div
       aria-hidden="true"
@@ -39,7 +39,7 @@ exports[`WebCLI > renders correctly 1`] = `
     <pre
       class="webcli__output-content"
       data-testid="output-content"
-      style="height: 1px;"
+      style="height: 0px;"
     >
       <code
         data-testid="output-help"
@@ -81,6 +81,7 @@ exports[`WebCLI > renders correctly 1`] = `
       class="webcli__input-help"
     >
       <i
+        aria-label="Display help"
         class="p-icon--help is-light"
         role="button"
         tabindex="0"

--- a/src/components/WebCLI/types.ts
+++ b/src/components/WebCLI/types.ts
@@ -3,6 +3,7 @@ export enum Label {
   AUTHENTICATION_ERROR = "Unable to authenticate.",
   NOT_OPEN_ERROR = "WebSocket connection is not open.",
   UNKNOWN_ERROR = "Unknown error.",
+  HELP = "Display help",
 }
 
 export enum Fields {


### PR DESCRIPTION
## Done

- Fix an issue where a command that returned a single line of output would display the help instead of the result.
- Fix an issue with the help being triggered by all keys.

## QA

- Go to a model and type a command that returns a single line e.g. `run` or `config`.
- The error message should be displayed.
- Tab to the help icon and press enter or space and the help should get toggled. Pressing other keys should not toggle the help.

## Details

https://warthogs.atlassian.net/browse/WD-22300
