### PR TITLE
refactor: wrap WebCLI in a new component

### DIFF
--- a/src/components/JujuCLI/JujuCLI.test.tsx
+++ b/src/components/JujuCLI/JujuCLI.test.tsx
@@ -1,0 +1,160 @@
+import { screen } from "@testing-library/react";
+import { vi } from "vitest";
+
+import * as WebCLIModule from "components/WebCLI";
+import type { RootState } from "store/store";
+import { jujuStateFactory, rootStateFactory } from "testing/factories";
+import {
+  credentialFactory,
+  generalStateFactory,
+  configFactory,
+} from "testing/factories/general";
+import { modelListInfoFactory } from "testing/factories/juju/juju";
+import { controllerFactory } from "testing/factories/juju/juju";
+import {
+  applicationInfoFactory,
+  modelWatcherModelDataFactory,
+  modelWatcherModelInfoFactory,
+} from "testing/factories/juju/model-watcher";
+import { renderComponent } from "testing/utils";
+
+import JujuCLI from "./JujuCLI";
+
+vi.mock("components/WebCLI", () => ({
+  __esModule: true,
+  default: () => {
+    return <div className="webcli" data-testid="webcli"></div>;
+  },
+}));
+
+describe("JujuCLI", () => {
+  let state: RootState;
+  const path = "/models/:userName/:modelName";
+  const url = "/models/kirk@external/enterprise";
+
+  beforeEach(() => {
+    state = rootStateFactory.withGeneralConfig().build({
+      general: generalStateFactory.build({
+        config: configFactory.build({
+          controllerAPIEndpoint: "wss://example.com:17070/api",
+        }),
+        credentials: {
+          "wss://example.com:17070/api": credentialFactory.build({
+            user: "user-kirk@external",
+          }),
+        },
+      }),
+      juju: jujuStateFactory.build({
+        controllers: {
+          "wss://example.com:17070/api": [
+            controllerFactory.build({ uuid: "controller123" }),
+          ],
+        },
+        models: {
+          abc123: modelListInfoFactory.build({
+            uuid: "abc123",
+            name: "enterprise",
+            ownerTag: "user-kirk@external",
+          }),
+        },
+        modelWatcherData: {
+          abc123: modelWatcherModelDataFactory.build({
+            model: modelWatcherModelInfoFactory.build({
+              "controller-uuid": "controller123",
+            }),
+          }),
+        },
+      }),
+    });
+  });
+
+  it("shows the CLI in juju 2.9", async () => {
+    state.general.config = configFactory.build({
+      isJuju: true,
+    });
+    renderComponent(<JujuCLI />, { path, url, state });
+    expect(await screen.findByTestId("webcli")).toBeInTheDocument();
+  });
+
+  it("shows the CLI in juju higher than 2.9", async () => {
+    state.general.config = configFactory.build({
+      isJuju: true,
+    });
+    state.juju.modelWatcherData = {
+      abc123: modelWatcherModelDataFactory.build({
+        applications: {
+          "ceph-mon": applicationInfoFactory.build(),
+        },
+        model: modelWatcherModelInfoFactory.build({
+          name: "enterprise",
+          owner: "kirk@external",
+          version: "3.0.7",
+          "controller-uuid": "controller123",
+        }),
+      }),
+    };
+    renderComponent(<JujuCLI />, { path, url, state });
+    expect(await screen.findByTestId("webcli")).toBeInTheDocument();
+  });
+
+  it("does not show the CLI in JAAS", async () => {
+    state.general.config = configFactory.build({
+      isJuju: false,
+    });
+    state.juju.modelWatcherData = {
+      abc123: modelWatcherModelDataFactory.build({
+        applications: {
+          "ceph-mon": applicationInfoFactory.build(),
+        },
+        model: modelWatcherModelInfoFactory.build({
+          name: "enterprise",
+          owner: "kirk@external",
+          version: "3.0.7",
+          "controller-uuid": "controller123",
+        }),
+      }),
+    };
+    renderComponent(<JujuCLI />, { path, url, state });
+    expect(screen.queryByTestId("webcli")).not.toBeInTheDocument();
+  });
+
+  it("does not show the webCLI in juju 2.8", async () => {
+    state.general.config = configFactory.build({
+      isJuju: true,
+    });
+    state.juju.modelWatcherData = {
+      abc123: modelWatcherModelDataFactory.build({
+        applications: {
+          "ceph-mon": applicationInfoFactory.build(),
+        },
+        model: modelWatcherModelInfoFactory.build({
+          name: "enterprise",
+          owner: "kirk@external",
+          version: "2.8.7",
+        }),
+      }),
+    };
+    renderComponent(<JujuCLI />, { path, url, state });
+    expect(screen.queryByTestId("webcli")).not.toBeInTheDocument();
+  });
+
+  it("passes the controller details to the webCLI", () => {
+    state.general.config = configFactory.build({
+      isJuju: true,
+    });
+    const cliComponent = vi
+      .spyOn(WebCLIModule, "default")
+      .mockImplementation(vi.fn());
+    renderComponent(<JujuCLI />, { path, url, state });
+    expect(cliComponent.mock.calls[0][0]).toMatchObject({
+      controllerWSHost: "example.com:17070",
+      credentials: {
+        password: "verysecure123",
+        user: "user-kirk@external",
+      },
+      modelUUID: "abc123",
+      protocol: "wss",
+    });
+    cliComponent.mockReset();
+  });
+});

--- a/src/components/JujuCLI/JujuCLI.tsx
+++ b/src/components/JujuCLI/JujuCLI.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from "react";
+import { useParams } from "react-router";
+
+import type { EntityDetailsRoute } from "components/Routes";
+import WebCLI from "components/WebCLI";
+import { getUserPass, getIsJuju } from "store/general/selectors";
+import {
+  getControllerDataByUUID,
+  getModelInfo,
+  getModelUUIDFromList,
+} from "store/juju/selectors";
+import { useAppSelector } from "store/store";
+import { getMajorMinorVersion } from "utils";
+
+const JujuCLI = () => {
+  const routeParams = useParams<EntityDetailsRoute>();
+  const { userName, modelName } = routeParams;
+  const modelUUID = useAppSelector((state) =>
+    getModelUUIDFromList(state, modelName, userName),
+  );
+  const modelInfo = useAppSelector((state) => getModelInfo(state, modelUUID));
+
+  const isJuju = useAppSelector(getIsJuju);
+
+  const [showWebCLI, setShowWebCLI] = useState(false);
+
+  // In a JAAS environment the controllerUUID will be the sub controller not
+  // the primary controller UUID that we connect to.
+  const controllerUUID = modelInfo?.["controller-uuid"];
+  // The primary controller data is the controller endpoint we actually connect
+  // to. In the case of a normally bootstrapped controller this will be the
+  // same as the model controller, however in a JAAS environment, this primary
+  // controller will be JAAS and the model controller will be different.
+  const primaryControllerData = useAppSelector((state) =>
+    getControllerDataByUUID(state, controllerUUID),
+  );
+  const credentials = useAppSelector((state) =>
+    getUserPass(state, primaryControllerData?.[0]),
+  );
+  const controllerWSHost =
+    primaryControllerData?.[0]
+      .replace("ws://", "")
+      .replace("wss://", "")
+      .replace("/api", "") || null;
+  const wsProtocol = primaryControllerData?.[0].split("://")[0];
+
+  useEffect(() => {
+    if (isJuju && getMajorMinorVersion(modelInfo?.version) >= 2.9) {
+      // The Web CLI is only available in Juju controller versions 2.9 and
+      // above. This will allow us to only show the shell on multi-controller
+      // setups with different versions where the correct controller version
+      // is available.
+      setShowWebCLI(true);
+    }
+  }, [modelInfo, isJuju]);
+
+  return (
+    <>
+      {showWebCLI && controllerWSHost ? (
+        <WebCLI
+          controllerWSHost={controllerWSHost}
+          credentials={credentials}
+          modelUUID={modelUUID}
+          protocol={wsProtocol ?? "wss"}
+        />
+      ) : null}
+    </>
+  );
+};
+
+export default JujuCLI;

--- a/src/components/JujuCLI/index.ts
+++ b/src/components/JujuCLI/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./JujuCLI";

--- a/src/pages/EntityDetails/EntityDetails.test.tsx
+++ b/src/pages/EntityDetails/EntityDetails.test.tsx
@@ -2,7 +2,6 @@ import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
 
-import * as WebCLIModule from "components/WebCLI";
 import type { RootState } from "store/store";
 import { jujuStateFactory, rootStateFactory } from "testing/factories";
 import {
@@ -27,13 +26,6 @@ vi.mock("components/Topology", () => {
   const Topology = () => <div className="topology"></div>;
   return { default: Topology };
 });
-
-vi.mock("components/WebCLI", () => ({
-  __esModule: true,
-  default: () => {
-    return <div className="webcli" data-testid="webcli"></div>;
-  },
-}));
 
 describe("Entity Details Container", () => {
   let state: RootState;
@@ -122,104 +114,6 @@ describe("Entity Details Container", () => {
       state,
     });
     expect(await screen.findByText(children)).toBeInTheDocument();
-  });
-
-  it("shows the CLI in juju 2.9", async () => {
-    state.general.config = configFactory.build({
-      isJuju: true,
-    });
-    renderComponent(<EntityDetails />, { path, url, state });
-    await waitFor(() => {
-      expect(screen.queryByTestId("webcli")).toBeInTheDocument();
-    });
-  });
-
-  it("shows the CLI in juju higher than 2.9", async () => {
-    state.general.config = configFactory.build({
-      isJuju: true,
-    });
-    state.juju.modelWatcherData = {
-      abc123: modelWatcherModelDataFactory.build({
-        applications: {
-          "ceph-mon": applicationInfoFactory.build(),
-        },
-        model: modelWatcherModelInfoFactory.build({
-          name: "enterprise",
-          owner: "kirk@external",
-          version: "3.0.7",
-          "controller-uuid": "controller123",
-        }),
-      }),
-    };
-    renderComponent(<EntityDetails />, { path, url, state });
-    await waitFor(() => {
-      expect(screen.queryByTestId("webcli")).toBeInTheDocument();
-    });
-  });
-
-  it("does not show the CLI in JAAS", async () => {
-    state.general.config = configFactory.build({
-      isJuju: false,
-    });
-    state.juju.modelWatcherData = {
-      abc123: modelWatcherModelDataFactory.build({
-        applications: {
-          "ceph-mon": applicationInfoFactory.build(),
-        },
-        model: modelWatcherModelInfoFactory.build({
-          name: "enterprise",
-          owner: "kirk@external",
-          version: "3.0.7",
-          "controller-uuid": "controller123",
-        }),
-      }),
-    };
-    renderComponent(<EntityDetails />, { path, url, state });
-    await waitFor(() => {
-      expect(screen.queryByTestId("webcli")).not.toBeInTheDocument();
-    });
-  });
-
-  it("does not show the webCLI in juju 2.8", async () => {
-    state.general.config = configFactory.build({
-      isJuju: true,
-    });
-    state.juju.modelWatcherData = {
-      abc123: modelWatcherModelDataFactory.build({
-        applications: {
-          "ceph-mon": applicationInfoFactory.build(),
-        },
-        model: modelWatcherModelInfoFactory.build({
-          name: "enterprise",
-          owner: "kirk@external",
-          version: "2.8.7",
-        }),
-      }),
-    };
-    renderComponent(<EntityDetails />, { path, url, state });
-    await waitFor(() => {
-      expect(screen.queryByTestId("webcli")).not.toBeInTheDocument();
-    });
-  });
-
-  it("passes the controller details to the webCLI", () => {
-    state.general.config = configFactory.build({
-      isJuju: true,
-    });
-    const cliComponent = vi
-      .spyOn(WebCLIModule, "default")
-      .mockImplementation(vi.fn());
-    renderComponent(<EntityDetails />, { path, url, state });
-    expect(cliComponent.mock.calls[0][0]).toMatchObject({
-      controllerWSHost: "example.com:17070",
-      credentials: {
-        password: "verysecure123",
-        user: "user-kirk@external",
-      },
-      modelUUID: "abc123",
-      protocol: "wss",
-    });
-    cliComponent.mockReset();
   });
 
   it("gives the header a class when the header should be a single column", async () => {

--- a/src/pages/EntityDetails/EntityDetails.tsx
+++ b/src/pages/EntityDetails/EntityDetails.tsx
@@ -1,28 +1,24 @@
 import { Button, Notification, Strip } from "@canonical/react-components";
 import classNames from "classnames";
 import type { ReactNode } from "react";
-import { useEffect, useState } from "react";
 import { useParams, Link, Outlet } from "react-router";
 
 import Breadcrumb from "components/Breadcrumb";
+import JujuCLI from "components/JujuCLI";
 import LoadingSpinner from "components/LoadingSpinner";
 import NotFound from "components/NotFound";
 import type { EntityDetailsRoute } from "components/Routes";
-import WebCLI from "components/WebCLI";
 import { useEntityDetailsParams } from "components/hooks";
 import useCanConfigureModel from "hooks/useCanConfigureModel";
 import useWindowTitle from "hooks/useWindowTitle";
 import BaseLayout from "layout/BaseLayout/BaseLayout";
-import { getIsJuju, getUserPass } from "store/general/selectors";
 import {
-  getControllerDataByUUID,
   getModelInfo,
   getModelListLoaded,
   getModelUUIDFromList,
 } from "store/juju/selectors";
 import { useAppSelector } from "store/store";
 import urls from "urls";
-import { getMajorMinorVersion } from "utils";
 
 import ModelTabs from "./Model/ModelTabs";
 import { Label, TestId } from "./types";
@@ -58,40 +54,7 @@ const EntityDetails = ({ modelWatcherError }: Props) => {
   // away from the model.
   useCanConfigureModel(true);
 
-  const isJuju = useAppSelector(getIsJuju);
-
-  const [showWebCLI, setShowWebCLI] = useState(false);
-
-  // In a JAAS environment the controllerUUID will be the sub controller not
-  // the primary controller UUID that we connect to.
-  const controllerUUID = modelInfo?.["controller-uuid"];
-  // The primary controller data is the controller endpoint we actually connect
-  // to. In the case of a normally bootstrapped controller this will be the
-  // same as the model controller, however in a JAAS environment, this primary
-  // controller will be JAAS and the model controller will be different.
-  const primaryControllerData = useAppSelector((state) =>
-    getControllerDataByUUID(state, controllerUUID),
-  );
   const entityType = getEntityType(routeParams);
-  const credentials = useAppSelector((state) =>
-    getUserPass(state, primaryControllerData?.[0]),
-  );
-  const controllerWSHost =
-    primaryControllerData?.[0]
-      .replace("ws://", "")
-      .replace("wss://", "")
-      .replace("/api", "") || null;
-  const wsProtocol = primaryControllerData?.[0].split("://")[0];
-
-  useEffect(() => {
-    if (isJuju && getMajorMinorVersion(modelInfo?.version) >= 2.9) {
-      // The Web CLI is only available in Juju controller versions 2.9 and
-      // above. This will allow us to only show the shell on multi-controller
-      // setups with different versions where the correct controller version
-      // is available.
-      setShowWebCLI(true);
-    }
-  }, [modelInfo, isJuju]);
 
   useWindowTitle(modelInfo?.name ? `Model: ${modelInfo?.name}` : "...");
 
@@ -133,17 +96,7 @@ const EntityDetails = ({ modelWatcherError }: Props) => {
   return (
     <BaseLayout
       data-testid={TestId.COMPONENT}
-      status={
-        showWebCLI &&
-        controllerWSHost && (
-          <WebCLI
-            controllerWSHost={controllerWSHost}
-            credentials={credentials}
-            modelUUID={modelUUID}
-            protocol={wsProtocol ?? "wss"}
-          />
-        )
-      }
+      status={<JujuCLI />}
       title={
         <>
           <Breadcrumb />


### PR DESCRIPTION
## Done

- Wrap the WebCLI component in a new `JujuCLI` component.
- Move selectors/hooks get model/controller data for the CLI out of EntityDetails and into the new component.

## QA

- Connect to a local Juju.
- Go to a model.
- Check you can run CLI commands for that model.

## Details

https://warthogs.atlassian.net/browse/WD-22423
