### PR TITLE
fix: correct controller overview chart percentages

### DIFF
--- a/src/pages/ControllersIndex/ControllerChart/ControllerChart.test.tsx
+++ b/src/pages/ControllersIndex/ControllerChart/ControllerChart.test.tsx
@@ -18,13 +18,13 @@ describe("Controllers chart", () => {
       />,
     );
     expect(screen.getByTestId("legend-blocked")).toHaveTextContent(
-      "Blocked: 6%, 5",
+      "Blocked: 17%, 5",
     );
     expect(screen.getByTestId("legend-alert")).toHaveTextContent(
-      "Alerts: 3%, 10",
+      "Alerts: 33%, 10",
     );
     expect(screen.getByTestId("legend-running")).toHaveTextContent(
-      "Running: 2%, 15",
+      "Running: 50%, 15",
     );
   });
 });

--- a/src/pages/ControllersIndex/ControllerChart/ControllerChart.tsx
+++ b/src/pages/ControllersIndex/ControllerChart/ControllerChart.tsx
@@ -12,11 +12,11 @@ function getPercentage(denominator: number, numerator: number) {
   if (denominator === 0 || numerator === 0) {
     return 0;
   }
-  const trunc = Math.trunc(denominator / numerator);
-  if (Number.isNaN(trunc)) {
+  const percentage = Math.round((numerator / denominator) * 100);
+  if (Number.isNaN(percentage)) {
     return 0;
   }
-  return trunc;
+  return percentage;
 }
 
 export default function ControllerChart({


### PR DESCRIPTION
## Done

- Correct controller percentage calculation

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Click on controllers tab
- Verify that the percentages add up to 100%

## Details

I also decided to use `Math.round` instead of `Math.trunc`, since the fractional component was already being discarded. `Math.round` will help the totals add to 100% in more situations (such as the 33% and 66% example in the screenshots below).

## Screenshots

### Before

![image](https://github.com/user-attachments/assets/33b06483-116a-45e6-a2cf-150a588de81d)

### After

![image](https://github.com/user-attachments/assets/fade1de7-e62b-4b84-9209-43ba892439ca)

