### PR TITLE
refactor: move dashboard-specific code out of WebCLI

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -52,7 +52,7 @@ contribute and what kinds of contributions are welcome.
 ## Setting up the dashboard for development
 
 To get started working on the dashboard you will need to set up a local
-development environement and you will also need access to a Juju controller (JAAS may be
+development environment and you will also need access to a Juju controller (JAAS may be
 sufficient to get started).
 
 Once set up you might like to take a look at our [codebase overview and development guidelines](#codebase-and-development-guidelines).

--- a/src/components/WebCLI/WebCLI.test.tsx
+++ b/src/components/WebCLI/WebCLI.test.tsx
@@ -34,6 +34,8 @@ describe("WebCLI", () => {
       user: "eggman@external",
       password: "somelongpassword",
     },
+    onCommandSent: vi.fn(),
+    activeUser: "eggman@external",
   };
 
   beforeEach(() => {
@@ -241,6 +243,21 @@ describe("WebCLI", () => {
         commands: ["status"],
       }),
     );
+  });
+
+  it("sends commands over the websocket", async () => {
+    renderComponent(<WebCLI {...props} />);
+    await server.connected;
+    const input = screen.getByRole("textbox");
+    await userEvent.type(input, "some-command{enter}");
+    await expect(server).toReceiveMessage(
+      JSON.stringify({
+        user: "eggman@external",
+        credentials: "somelongpassword",
+        commands: ["some-command"],
+      }),
+    );
+    expect(props.onCommandSent).toBeCalledWith("some-command");
   });
 
   it("displays messages received over the websocket", async () => {


### PR DESCRIPTION
## Done

- Moved dashboard-specific code like the `useAnalytics` and the `useStore` hooks out of the WebCLI
- Corrected a typo in `HACKING.md`

## Details

We are moving code strictly tied to the dashboard out of the WebCLI component to reduce tight coupling of the two. This is to aid in making the WebCLI component a standalone project someday.

## QA

- Login to the dashboard
- Go to Model details page and expand the WebCLI
- Try using it with a couple of commands, clicking help, etc. Everything should work fine.

## Details
https://warthogs.atlassian.net/browse/WD-22424

## Screenshots
<img width="1352" alt="Screenshot 2025-06-05 at 10 27 00 AM" src="https://github.com/user-attachments/assets/a037597f-0719-434c-982a-1f329717334c" />


