### PR TITLE
feat: display full scrollback in web CLI

### DIFF
--- a/src/components/WebCLI/Output/Output.test.tsx
+++ b/src/components/WebCLI/Output/Output.test.tsx
@@ -311,7 +311,12 @@ describe("Output", () => {
     // Mock the scroll height as this is not being rendered in a real DOM.
     Object.defineProperty(content, "scrollHeight", {
       configurable: true,
-      value: 111,
+      value: 500,
+    });
+    content.scrollTop = 350;
+    Object.defineProperty(content, "clientHeight", {
+      configurable: true,
+      value: 50,
     });
     rerender(
       <Output
@@ -331,8 +336,55 @@ describe("Output", () => {
       />,
     );
     expect(scrollToSpy).toHaveBeenCalledWith({
-      top: 111,
+      top: 500,
     });
+    scrollToSpy.mockRestore();
+  });
+
+  it("should not scroll to the bottom when user has scrolled up", async () => {
+    const { rerender } = render(
+      <Output
+        content={[
+          {
+            command: "status",
+            messages: ["Output"],
+          },
+        ]}
+        helpMessage="Help message"
+        showHelp={false}
+        setShouldShowHelp={vi.fn()}
+      />,
+    );
+    const content = screen.getByTestId(TestId.CONTENT);
+    const scrollToSpy = vi.spyOn(content, "scrollTo");
+    // Mock the scroll height as this is not being rendered in a real DOM.
+    Object.defineProperty(content, "scrollHeight", {
+      configurable: true,
+      value: 500,
+    });
+    content.scrollTop = 250;
+    Object.defineProperty(content, "clientHeight", {
+      configurable: true,
+      value: 50,
+    });
+    rerender(
+      <Output
+        content={[
+          {
+            command: "status",
+            messages: ["Output1"],
+          },
+          {
+            command: "help",
+            messages: ["Output2"],
+          },
+        ]}
+        helpMessage="Help message"
+        showHelp={false}
+        setShouldShowHelp={vi.fn()}
+      />,
+    );
+    expect(scrollToSpy).not.toHaveBeenCalled();
     scrollToSpy.mockRestore();
   });
 });

--- a/src/components/WebCLI/Output/Output.test.tsx
+++ b/src/components/WebCLI/Output/Output.test.tsx
@@ -11,14 +11,24 @@ describe("Output", () => {
   it("should display content and not display help message", () => {
     renderComponent(
       <Output
-        command="status"
-        content={["Output"]}
+        content={[
+          {
+            command: "status",
+            messages: ["Output1"],
+          },
+          {
+            command: "help",
+            messages: ["Output2"],
+          },
+        ]}
         helpMessage="Help message"
         showHelp={false}
         setShouldShowHelp={vi.fn()}
       />,
     );
-    expect(screen.getByText("Output")).toBeInTheDocument();
+    expect(screen.getByTestId(TestId.CONTENT)).toHaveTextContent(
+      ["$ status", "Output1 ", "$ help", "Output2"].join(""),
+    );
     expect(screen.queryByText("Help message")).not.toBeInTheDocument();
     expect(screen.getByTestId(TestId.CONTENT)).toHaveAttribute(
       "style",
@@ -29,8 +39,12 @@ describe("Output", () => {
   it("should not display content and display help message", () => {
     renderComponent(
       <Output
-        command="status"
-        content={["Output"]}
+        content={[
+          {
+            command: "status",
+            messages: ["Output"],
+          },
+        ]}
         helpMessage="Help message"
         showHelp={true}
         setShouldShowHelp={vi.fn()}
@@ -47,7 +61,6 @@ describe("Output", () => {
   it("displays help while not loading and there is no content", () => {
     renderComponent(
       <Output
-        command="status"
         content={[]}
         helpMessage="Help message"
         showHelp={false}
@@ -61,7 +74,6 @@ describe("Output", () => {
   it("displays nothing while loading and there is no content", () => {
     renderComponent(
       <Output
-        command="status"
         content={[]}
         helpMessage="Help message"
         showHelp={false}
@@ -76,8 +88,12 @@ describe("Output", () => {
   it("should close the output when the help is closed", async () => {
     const { rerender } = render(
       <Output
-        command="status"
-        content={["Output"]}
+        content={[
+          {
+            command: "status",
+            messages: ["Output"],
+          },
+        ]}
         helpMessage="Help message"
         // Initially render with the help visible.
         showHelp={true}
@@ -90,8 +106,12 @@ describe("Output", () => {
     );
     rerender(
       <Output
-        command="status"
-        content={["Output"]}
+        content={[
+          {
+            command: "status",
+            messages: ["Output"],
+          },
+        ]}
         helpMessage="Help message"
         // Rerender with the help hidden.
         showHelp={false}
@@ -108,8 +128,12 @@ describe("Output", () => {
     const content = [`\u001b[1;39mApp\n\u001b[0m\u001b[33munknown`];
     renderComponent(
       <Output
-        command="status"
-        content={content}
+        content={[
+          {
+            command: "status",
+            messages: content,
+          },
+        ]}
         helpMessage="Help message"
         showHelp={false}
         setShouldShowHelp={vi.fn()}
@@ -124,8 +148,12 @@ describe("Output", () => {
     const messages = ["Model       Controller", "k8s         workloads"];
     renderComponent(
       <Output
-        command="remove-unit"
-        content={messages}
+        content={[
+          {
+            command: "remove-unit",
+            messages,
+          },
+        ]}
         helpMessage="Help message"
         showHelp={false}
         setShouldShowHelp={vi.fn()}
@@ -153,8 +181,12 @@ describe("Output", () => {
     const messages = ["Model       Controller", "k8s         workloads"];
     renderComponent(
       <Output
-        command="remove-unit"
-        content={messages}
+        content={[
+          {
+            command: "remove-unit",
+            messages,
+          },
+        ]}
         helpMessage="Help message"
         showHelp={false}
         setShouldShowHelp={vi.fn()}
@@ -181,8 +213,12 @@ describe("Output", () => {
     const messages = ["Model       Controller", "k8s         workloads"];
     renderComponent(
       <Output
-        command="status"
-        content={messages}
+        content={[
+          {
+            command: "status",
+            messages,
+          },
+        ]}
         helpMessage="Help message"
         showHelp={false}
         setShouldShowHelp={vi.fn()}
@@ -206,8 +242,12 @@ describe("Output", () => {
     const customId = "custom";
     renderComponent(
       <Output
-        command="status"
-        content={messages}
+        content={[
+          {
+            command: "status",
+            messages,
+          },
+        ]}
         helpMessage="Help message"
         showHelp={false}
         setShouldShowHelp={vi.fn()}
@@ -228,8 +268,12 @@ describe("Output", () => {
     const messages = ["Model       Controller", "k8s         workloads"];
     renderComponent(
       <Output
-        command="remove-unit"
-        content={messages}
+        content={[
+          {
+            command: "remove-unit",
+            messages,
+          },
+        ]}
         helpMessage="Help message"
         showHelp={false}
         setShouldShowHelp={vi.fn()}
@@ -246,5 +290,49 @@ describe("Output", () => {
     expect(await screen.findByTestId(TestId.CODE)).toHaveTextContent(
       "Model Controller",
     );
+  });
+
+  it("should scroll to the bottom when new commands are sent", async () => {
+    const { rerender } = render(
+      <Output
+        content={[
+          {
+            command: "status",
+            messages: ["Output"],
+          },
+        ]}
+        helpMessage="Help message"
+        showHelp={false}
+        setShouldShowHelp={vi.fn()}
+      />,
+    );
+    const content = screen.getByTestId(TestId.CONTENT);
+    const scrollToSpy = vi.spyOn(content, "scrollTo");
+    // Mock the scroll height as this is not being rendered in a real DOM.
+    Object.defineProperty(content, "scrollHeight", {
+      configurable: true,
+      value: 111,
+    });
+    rerender(
+      <Output
+        content={[
+          {
+            command: "status",
+            messages: ["Output1"],
+          },
+          {
+            command: "help",
+            messages: ["Output2"],
+          },
+        ]}
+        helpMessage="Help message"
+        showHelp={false}
+        setShouldShowHelp={vi.fn()}
+      />,
+    );
+    expect(scrollToSpy).toHaveBeenCalledWith({
+      top: 111,
+    });
+    scrollToSpy.mockRestore();
   });
 });

--- a/src/components/WebCLI/Output/Output.tsx
+++ b/src/components/WebCLI/Output/Output.tsx
@@ -6,7 +6,12 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import { processTableLinks, processCommandOutput } from "../utils";
 
-import { HELP_HEIGHT, CONSIDER_CLOSED, DEFAULT_HEIGHT } from "./consts";
+import {
+  HELP_HEIGHT,
+  CONSIDER_CLOSED,
+  DEFAULT_HEIGHT,
+  AUTO_SCROLL_DISTANCE,
+} from "./consts";
 import type { Props } from "./types";
 import { TestId } from "./types";
 
@@ -42,7 +47,20 @@ const WebCLIOutput = ({
 
   useEffect(() => {
     if (contentChanged && outputRef.current) {
-      outputRef.current.scrollTo({ top: outputRef.current.scrollHeight });
+      const newResponseHeight = document.querySelector(
+        ".webcli__output-content-response:last-child",
+      )?.clientHeight;
+      const scrollHeight = outputRef.current.scrollHeight;
+      // Get the distance the scroll area is from the bottom.
+      const distance =
+        scrollHeight -
+        (outputRef.current.clientHeight +
+          outputRef.current.scrollTop +
+          // Need to get the position from the bottom before the new content in.
+          (newResponseHeight || 0));
+      if (distance <= AUTO_SCROLL_DISTANCE) {
+        outputRef.current.scrollTo({ top: scrollHeight });
+      }
     }
   }, [contentChanged]);
 
@@ -144,6 +162,7 @@ const WebCLIOutput = ({
       height !== DEFAULT_HEIGHT
     ) {
       setHeight(DEFAULT_HEIGHT);
+      outputRef.current?.scrollTo({ top: outputRef.current.scrollHeight });
     }
   }, [content, contentChanged, height]);
 
@@ -166,7 +185,7 @@ const WebCLIOutput = ({
       response = defaultProcessOutput(command, messages);
     }
     return (
-      <div key={`message-${i}`}>
+      <div key={`message-${i}`} className="webcli__output-content-response">
         <div>$ {command}</div>
         {response}
       </div>

--- a/src/components/WebCLI/Output/consts.ts
+++ b/src/components/WebCLI/Output/consts.ts
@@ -3,3 +3,6 @@ export const DEFAULT_HEIGHT = 300;
 // an inopportune time and the element isn't left completely closed.
 export const CONSIDER_CLOSED = 20;
 export const HELP_HEIGHT = 40;
+// The range the scroll area needs to be from the bottom to automatically scroll
+// to the bottom when new content comes in.
+export const AUTO_SCROLL_DISTANCE = 100;

--- a/src/components/WebCLI/Output/types.ts
+++ b/src/components/WebCLI/Output/types.ts
@@ -54,9 +54,13 @@ export type ProcessCommand = {
 
 export type ProcessOutput = Record<string, ProcessCommand>;
 
+export type HistoryItem = {
+  command: string;
+  messages: string[];
+};
+
 export type Props = {
-  content: string[];
-  command?: string | null;
+  content: HistoryItem[];
   helpMessage: ReactNode;
   loading?: boolean;
   processOutput?: ProcessOutput;

--- a/src/components/WebCLI/__snapshots__/WebCLI.test.tsx.snap
+++ b/src/components/WebCLI/__snapshots__/WebCLI.test.tsx.snap
@@ -1,22 +1,22 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`WebCLI > displays ansi colored content colored 1`] = `
-"
-Model       Controller       Cloud/Region     Version    SLA          Timestamp
+"$ status --colorModel       Controller       Cloud/Region     Version    SLA          Timestamp
 controller  google-us-east1  google/us-east1  2.9-beta1  unsupported  17:44:14Z
 
 Machine  State    DNS             Inst id        Series  AZ          Message
 0        started  35.190.153.209  juju-3686b9-0  focal   us-east1-b  RUNNING
+
 "
 `;
 
 exports[`WebCLI > displays messages received over the websocket 1`] = `
-"
-Model       Controller       Cloud/Region     Version    SLA          Timestamp
+"$ status --colorModel       Controller       Cloud/Region     Version    SLA          Timestamp
 controller  google-us-east1  google/us-east1  2.9-beta1  unsupported  17:44:14Z
 
 Machine  State    DNS             Inst id        Series  AZ          Message
 0        started  35.190.153.209  juju-3686b9-0  focal   us-east1-b  RUNNING
+
 "
 `;
 

--- a/src/components/WebCLI/_webcli.scss
+++ b/src/components/WebCLI/_webcli.scss
@@ -69,11 +69,13 @@ $canonical-purple: #2c001e;
     }
 
     pre > code {
-      padding-bottom: 1rem;
+      padding-bottom: $webcli-input-height;
     }
 
     &-content {
+      margin-bottom: 0;
       overflow-y: scroll;
+      padding-bottom: 0;
     }
 
     &-dragarea {


### PR DESCRIPTION
## Done

- Display the previous commands and their responses in the web CLI.

## QA

- Go the web CLI in a model.
- Run a couple of commands and you should see that the commands and their responses are displayed in the scrollback.

## Details

https://warthogs.atlassian.net/browse/WD-22814

## Screenshots

<img width="828" alt="Screenshot 2025-06-19 at 4 39 06 pm" src="https://github.com/user-attachments/assets/1af2912a-7d95-4e22-a24f-cf276ae495a2" />

