### PR TITLE
feat(actions): common utilities

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -64,11 +64,6 @@ jobs:
         node-version: [22.x]
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: "yarn"
       - name: Validate Renovate Configuration with renovate-config-validator
         uses: suzuki-shunsuke/github-action-renovate-config-validator@v1.1.1
   types:

--- a/actions/package.json
+++ b/actions/package.json
@@ -11,12 +11,17 @@
     "lint": "eslint src"
   },
   "dependencies": {
-    "@actions/core": "1.11.1"
+    "@actions/core": "1.11.1",
+    "@actions/exec": "1.1.1",
+    "@actions/github": "6.0.1"
   },
   "devDependencies": {
+    "@octokit/types": "14.1.0",
     "@vercel/ncc": "0.38.3",
     "eslint": "9.28.0",
     "typescript": "5.8.3",
+    "vite": "6.2.7",
+    "vite-tsconfig-paths": "5.1.4",
     "vitest": "3.2.1"
   }
 }

--- a/actions/src/lib/changelog.test.ts
+++ b/actions/src/lib/changelog.test.ts
@@ -1,0 +1,137 @@
+import { describe, it } from "vitest";
+
+import { appendItem, generate, parse } from "./changelog";
+
+describe("generate", () => {
+  it("handles list of items", ({ expect }) => {
+    const changelog = generate("release/1.2", [
+      "first feature",
+      "second feature",
+    ]);
+    expect(changelog).toEqual(`> [!important]
+> Merge this PR to open the \`release/1.2\` branch, and prepare for a release.
+
+---
+# What's changed?
+<!-- changelog -->
+- first feature
+- second feature
+<!-- /changelog -->`);
+  });
+
+  it("handles item with new line", ({ expect }) => {
+    const changelog = generate("release/1.2", [
+      "first feature\nwith details",
+      "second feature",
+    ]);
+    expect(changelog).toEqual(`> [!important]
+> Merge this PR to open the \`release/1.2\` branch, and prepare for a release.
+
+---
+# What's changed?
+<!-- changelog -->
+- first feature
+with details
+- second feature
+<!-- /changelog -->`);
+  });
+
+  it("handles no items", ({ expect }) => {
+    const changelog = generate("release/1.2", []);
+    expect(changelog).toEqual(`> [!important]
+> Merge this PR to open the \`release/1.2\` branch, and prepare for a release.
+
+---
+# What's changed?
+<!-- changelog -->
+<!-- /changelog -->`);
+  });
+});
+
+describe("parse", () => {
+  it("handles list of items", ({ expect }) => {
+    const items = parse(`> [!important]
+> Merge this PR to open the \`release/1.2\` branch, and prepare for a release.
+
+---
+# What's changed?
+<!-- changelog -->
+- first feature
+- second feature
+<!-- /changelog -->`);
+    expect(items).toStrictEqual(["first feature", "second feature"]);
+  });
+
+  it("handles item with new line", ({ expect }) => {
+    const items = parse(`> [!important]
+> Merge this PR to open the \`release/1.2\` branch, and prepare for a release.
+
+---
+# What's changed?
+<!-- changelog -->
+- first feature
+with details
+- second feature
+<!-- /changelog -->`);
+    expect(items).toStrictEqual([
+      "first feature\nwith details",
+      "second feature",
+    ]);
+  });
+
+  it("handles no items", ({ expect }) => {
+    const items = parse(`> [!important]
+> Merge this PR to open the \`release/1.2\` branch, and prepare for a release.
+
+---
+# What's changed?
+<!-- changelog -->
+<!-- /changelog -->`);
+    expect(items).toStrictEqual([]);
+  });
+
+  it("handles content after changelog", ({ expect }) => {
+    const items = parse(`> [!important]
+> Merge this PR to open the \`release/1.2\` branch, and prepare for a release.
+
+---
+# What's changed?
+<!-- changelog -->
+- first feature
+- second feature
+<!-- /changelog -->
+
+extra content`);
+    expect(items).toStrictEqual(["first feature", "second feature"]);
+  });
+});
+
+describe("appendItem", () => {
+  it("appends an item", ({ expect }) => {
+    const changelog = appendItem(
+      `> [!important]
+> Merge this PR to open the \`release/1.2\` branch, and prepare for a release.
+
+---
+# What's changed?
+<!-- changelog -->
+- first feature
+- second feature
+<!-- /changelog -->`,
+      "third feature",
+      "release/1.2",
+    );
+    expect(changelog).toEqual(
+      `> [!important]
+> Merge this PR to open the \`release/1.2\` branch, and prepare for a release.
+
+---
+# What's changed?
+<!-- changelog -->
+- first feature
+- second feature
+- third feature
+<!-- /changelog -->`,
+    );
+  });
+});

--- a/actions/src/lib/changelog.ts
+++ b/actions/src/lib/changelog.ts
@@ -1,0 +1,83 @@
+import { util } from "@/lib";
+
+/** Marker to indicate the start of the changelog items. */
+export const CHANGELOG_START_MARKER = "<!-- changelog -->";
+/** Marker to indicate the end of the changelog items. */
+export const CHANGELOG_END_MARKER = "<!-- /changelog -->";
+
+/**
+ * Generate the changelog header for the provided release branch.
+ */
+export function changelogHeader(releaseBranch: string): string {
+  return `> [!important]
+> Merge this PR to open the \`${releaseBranch}\` branch, and prepare for a release.
+
+---
+`;
+}
+
+/**
+ * For the provided release branch and items, generate the changelog.
+ */
+export function generate(releaseBranch: string, items: string[]): string {
+  let changelog = changelogHeader(releaseBranch);
+
+  changelog += "# What's changed?\n";
+  changelog += `${CHANGELOG_START_MARKER}\n`;
+
+  // TODO: Categorise changelog based on item severity.
+  for (const item of items) {
+    changelog += `- ${item}\n`;
+  }
+
+  changelog += `${CHANGELOG_END_MARKER}`;
+
+  return changelog;
+}
+
+/**
+ * For the provided changelog text, parse out all of the items within it.
+ */
+export function parse(changelog: string): string[] {
+  const [_preamble, changelogEnd] = util.splitOnce(
+    changelog,
+    CHANGELOG_START_MARKER,
+    false,
+  );
+  const [items, _] = util.splitOnce(changelogEnd, CHANGELOG_END_MARKER);
+
+  const changelogItems: string[] = [];
+  let currentItem = "";
+
+  for (let item of items.trim().split("\n")) {
+    // Test if the item is the start of a new bullet point.
+    if (item.startsWith("- ")) {
+      changelogItems.push(currentItem);
+      currentItem = "";
+
+      // Strip off the bullet point.
+      item = item.slice(2);
+    }
+
+    currentItem += item.trim() + "\n";
+  }
+
+  changelogItems.push(currentItem);
+
+  return changelogItems
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+}
+
+/**
+ * Append an item to the changelog, for a release branch.
+ */
+export function appendItem(
+  changelog: string,
+  item: string,
+  releaseBranch: string,
+): string {
+  const items = parse(changelog);
+  items.push(item);
+  return generate(releaseBranch, items);
+}

--- a/actions/src/lib/git.ts
+++ b/actions/src/lib/git.ts
@@ -1,0 +1,85 @@
+import * as exec from "@actions/exec";
+
+export type ConfigScope = "global" | "system" | "local" | "worktree";
+
+/**
+ * Email and username for the Github Actions bot. Any commits from this user will show up as a bot
+ * in Github's UI.
+ *
+ * @link https://api.github.com/users/github-actions%5Bbot%5D
+ */
+const GITHUB_ACTIONS_BOT = {
+  email: "41898282+github-actions[bot]@users.noreply.github.com",
+  name: "github-actions[bot]",
+};
+
+export default class Git {
+  /**
+   * User configuration.
+   */
+  public user = GITHUB_ACTIONS_BOT;
+
+  /**
+   * Name of the remote.
+   */
+  public origin = "origin";
+
+  /**
+   * Name of the main branch.
+   */
+  public mainBranch = "main";
+
+  /**
+   * Execute the provided git command.
+   */
+  public async exec(...args: string[]) {
+    return exec.exec("git", args);
+  }
+
+  /**
+   * Set a git config value.
+   */
+  public async config(
+    key: string,
+    value: string,
+    scope: ConfigScope = "local",
+  ) {
+    return this.exec("config", `--${scope}`, key, value);
+  }
+
+  /**
+   * Setup git to use the provided user.
+   */
+  async configUser() {
+    await this.config("user.email", this.user.email);
+    await this.config("user.name", this.user.name);
+  }
+
+  /**
+   * Checkout the provided branch.
+   */
+  async checkout(branch: string) {
+    await this.exec("checkout", branch);
+  }
+
+  /**
+   * Create a new branch starting at `oldBranch`. If not provided, the main branch will be assumed.
+   */
+  async createBranch(name: string, oldBranch: string = this.mainBranch) {
+    await this.exec("branch", "-c", oldBranch, name);
+  }
+
+  /**
+   * Stage and commit the specified files, with a commit message.
+   */
+  async commit(message: string, files: string[]) {
+    await this.exec("commit", "-m", message, "--", ...files);
+  }
+
+  /**
+   * Push the listed branches to the origin.
+   */
+  async push(...branches: string[]) {
+    await this.exec("push", this.origin, ...branches);
+  }
+}

--- a/actions/src/lib/github/index.ts
+++ b/actions/src/lib/github/index.ts
@@ -1,0 +1,3 @@
+export type { Octokit, GithubRepository, GithubPullRequest } from "./types";
+export { Repository } from "./repository";
+export { PullRequest } from "./pull-request";

--- a/actions/src/lib/github/pull-request.ts
+++ b/actions/src/lib/github/pull-request.ts
@@ -1,0 +1,92 @@
+import type {
+  GithubPullRequest,
+  Octokit,
+  RepositoryIdentifier,
+  RequestParameters,
+} from "./types";
+
+export class PullRequest {
+  /**
+   * This is the identifier used by Octokit for pull request adjacent requests.
+   */
+  private identifier: RepositoryIdentifier & {
+    // NOTE: Octokit expects snake case for the pull request number.
+    pull_number: number;
+  };
+
+  constructor(
+    private octokit: Octokit,
+    repository: RepositoryIdentifier,
+    public pullRequest: GithubPullRequest,
+  ) {
+    this.identifier = {
+      ...repository,
+      pull_number: pullRequest.number,
+    };
+  }
+
+  public get number() {
+    return this.pullRequest.number;
+  }
+
+  public get body() {
+    return this.pullRequest.body;
+  }
+
+  public get labels() {
+    return this.pullRequest.labels;
+  }
+
+  public get head() {
+    return this.pullRequest.head.ref;
+  }
+
+  public get base() {
+    return this.pullRequest.base.ref;
+  }
+
+  public async close() {
+    await this.update({
+      state: "closed",
+    });
+  }
+
+  public async setLabels(labels: string[]) {
+    const { data: newLabels } = await this.octokit.rest.issues.setLabels({
+      repo: this.identifier.repo,
+      owner: this.identifier.owner,
+      issue_number: this.identifier.pull_number,
+
+      labels,
+    });
+
+    // Manually update the labels, instead of re-fetching.
+    this.pullRequest.labels = newLabels;
+  }
+
+  public async update(
+    params: RequestParameters<Octokit["rest"]["pulls"]["update"]>,
+  ) {
+    const { data: pullRequest } = await this.octokit.rest.pulls.update({
+      ...this.identifier,
+      ...params,
+    });
+
+    this.pullRequest = pullRequest;
+  }
+
+  /**
+   * Fetch a repository using `owner/repo`.
+   */
+  public static async get(
+    octokit: Octokit,
+    repository: RepositoryIdentifier,
+    number: number,
+  ) {
+    const { data: pullRequest } = await octokit.rest.pulls.get({
+      ...repository,
+      pull_number: number,
+    });
+    return new PullRequest(octokit, repository, pullRequest);
+  }
+}

--- a/actions/src/lib/github/repository.ts
+++ b/actions/src/lib/github/repository.ts
@@ -1,0 +1,94 @@
+import { PullRequest } from "./pull-request";
+import type {
+  GithubPullRequest,
+  GithubRepository,
+  Octokit,
+  RepositoryIdentifier,
+  RequestParameters,
+} from "./types";
+
+export class Repository {
+  /**
+   * Identifier components for the repository, corresponding to `owner/repo`.
+   */
+  public identifier: RepositoryIdentifier;
+
+  constructor(
+    private octokit: Octokit,
+    public repo: GithubRepository,
+  ) {
+    this.identifier = { repo: repo.name, owner: repo.owner.login };
+  }
+
+  /**
+   * Fetch all branches on this repository, and return them as an async iterator.
+   */
+  public async *branches(
+    params: RequestParameters<Octokit["rest"]["repos"]["listBranches"]> = {},
+  ) {
+    const iter = this.octokit.paginate.iterator(
+      this.octokit.rest.repos.listBranches,
+      {
+        ...this.identifier,
+        ...params,
+      },
+    );
+
+    for await (const { data: branches } of iter) {
+      yield* branches;
+    }
+  }
+
+  /**
+   * Fetch all pull requests for this repository, and produce them in an async iterator.
+   */
+  public async *pullRequests(
+    params: RequestParameters<Octokit["rest"]["pulls"]["list"]> = {},
+  ) {
+    const iter = this.octokit.paginate.iterator(this.octokit.rest.pulls.list, {
+      ...this.identifier,
+      ...params,
+    });
+
+    for await (const { data: pullRequests } of iter) {
+      for (const pullRequest of pullRequests) {
+        yield new PullRequest(
+          this.octokit,
+          this.identifier,
+          pullRequest as GithubPullRequest,
+        );
+      }
+    }
+  }
+
+  /**
+   * Create a new pull request in this repository.
+   */
+  public async createPullRequest(
+    params: {
+      head: string;
+      base: string;
+    } & RequestParameters<Octokit["rest"]["pulls"]["create"]>,
+  ) {
+    const { data: pullRequest } = await this.octokit.rest.pulls.create({
+      ...this.identifier,
+      ...params,
+    });
+    return new PullRequest(this.octokit, this.identifier, pullRequest);
+  }
+
+  /**
+   * Return the default branch name configured for this repository.
+   */
+  public get defaultBranch() {
+    return this.repo.default_branch;
+  }
+
+  /**
+   * Fetch a repository using `owner/repo`.
+   */
+  public static async get(octokit: Octokit, identifier: RepositoryIdentifier) {
+    const { data: fetchedRepo } = await octokit.rest.repos.get(identifier);
+    return new Repository(octokit, fetchedRepo);
+  }
+}

--- a/actions/src/lib/github/types.ts
+++ b/actions/src/lib/github/types.ts
@@ -1,0 +1,50 @@
+import type github from "@actions/github";
+import type {
+  GetResponseDataTypeFromEndpointMethod,
+  RequestInterface,
+} from "@octokit/types";
+
+/**
+ * Octokit interface for interfacing with GitHub API.
+ */
+export type Octokit = ReturnType<typeof github.getOctokit>;
+
+/**
+ * Pull request on GitHub.
+ *
+ * @note The GitHub API doesn't return a consistent representation across all endpoints (eg. list
+ * vs get). For ease of use, this type is defined as a subset of all available fields, so that
+ * responses from multiple APIs can be used directly.
+ */
+export type GithubPullRequest = Pick<
+  GetResponseDataTypeFromEndpointMethod<Octokit["rest"]["pulls"]["get"]>,
+  | "id"
+  | "user"
+  | "url"
+  | "number"
+  | "body"
+  | "title"
+  | "labels"
+  | "head"
+  | "base"
+  | "state"
+>;
+
+/**
+ * Common identifier for a repository. Equivalent to `owner/repo`.
+ */
+export type RepositoryIdentifier = { repo: string; owner: string };
+
+/**
+ * GitHub repository.
+ */
+export type GithubRepository = GetResponseDataTypeFromEndpointMethod<
+  Octokit["rest"]["repos"]["get"]
+>;
+
+/**
+ * Utility type for fetching parameters for an Octokit request.
+ */
+export type RequestParameters<T extends RequestInterface> = Partial<
+  Parameters<T>[0]
+>;

--- a/actions/src/lib/index.ts
+++ b/actions/src/lib/index.ts
@@ -1,0 +1,65 @@
+import * as core from "@actions/core";
+import * as github from "@actions/github";
+import type { Context } from "@actions/github/lib/context";
+import type { GitHub } from "@actions/github/lib/utils";
+
+import Git from "./git";
+import type { GithubPullRequest } from "./github";
+import { Repository } from "./github";
+
+export { default as Git } from "./git";
+export * as changelog from "./changelog";
+export * as github from "./github";
+export * as util from "./util";
+export * as versioning from "./versioning";
+
+export type Ctx = {
+  octokit: InstanceType<typeof GitHub>;
+  context: Context;
+  repo: Repository;
+  git: Git;
+  pr?: GithubPullRequest;
+};
+
+export async function createCtx(fallback?: {
+  pullRequestInput: string;
+}): Promise<Ctx> {
+  // Configure octokit.
+  const githubToken = core.getInput("github-token");
+  const octokit = github.getOctokit(githubToken);
+
+  // Fetch the repository that the action is running in.
+  const repo = await Repository.get(octokit, github.context.repo);
+
+  // Fetch the pull request that triggered the action, if available.
+  let pr: GithubPullRequest | undefined = undefined;
+  let prNumber = github.context.payload.pull_request?.number;
+
+  if (prNumber === undefined && fallback?.pullRequestInput !== undefined) {
+    // Try using fallback input.
+    const inputPrNumber = Number(core.getInput(fallback.pullRequestInput));
+
+    if (!isNaN(inputPrNumber)) {
+      prNumber = inputPrNumber;
+    }
+  }
+
+  if (prNumber !== undefined) {
+    ({ data: pr } = await octokit.rest.pulls.get({
+      repo: github.context.repo.repo,
+      owner: github.context.repo.owner,
+      pull_number: prNumber,
+    }));
+  }
+
+  const git = new Git();
+  await git.configUser();
+
+  return {
+    octokit,
+    context: github.context,
+    repo,
+    git,
+    pr,
+  };
+}

--- a/actions/src/lib/util.ts
+++ b/actions/src/lib/util.ts
@@ -1,0 +1,22 @@
+/**
+ * Split a string once at a seperator. If there isn't one instance of the seperator, an error will
+ * be raised.
+ */
+export function splitOnce(
+  str: string,
+  sep: string,
+  allowEmpty: boolean = true,
+): [string, string] {
+  const parts = str.split(sep);
+
+  if (
+    parts.length !== 2 ||
+    (!allowEmpty && !parts.every((part) => part.length > 0))
+  ) {
+    throw new Error(
+      `expected split to produce 2 items, but found ${parts.length}`,
+    );
+  }
+
+  return [parts[0], parts[1]];
+}

--- a/actions/src/lib/versioning/branch.test.ts
+++ b/actions/src/lib/versioning/branch.test.ts
@@ -1,0 +1,42 @@
+import { describe, it } from "vitest";
+
+import { versioningInfoFromBranch } from "./branch";
+
+describe("versioningInfoFromBranch", () => {
+  it.for([
+    ["release/1.2", 1, 2, false],
+    ["release/1.0", 1, 0, true],
+    ["release/0.0", 0, 0, true],
+  ] as const)(
+    "parse branch name: %s",
+    ([branch, majorVersion, minorVersion, isMajorRelease], { expect }) => {
+      expect(versioningInfoFromBranch(branch)).toStrictEqual({
+        version: `${majorVersion}.${minorVersion}`,
+        majorVersion,
+        minorVersion,
+        isMajorRelease,
+      });
+    },
+  );
+
+  it.for([
+    "release/5.6.3",
+    "release/1",
+    "release/",
+    "release/.1",
+    "release/1.",
+    "release/.",
+    "release/a.b",
+  ])("rejects malformed branch name: %s", (branch, { expect }) => {
+    expect(() => versioningInfoFromBranch(branch)).toThrow(
+      "malformed release branch name",
+    );
+  });
+
+  it.for(["something/1.2", "release-1.2.3", "main"])(
+    "ignore non-release branch: %s",
+    (branch, { expect }) => {
+      expect(versioningInfoFromBranch(branch)).toBeNull();
+    },
+  );
+});

--- a/actions/src/lib/versioning/branch.ts
+++ b/actions/src/lib/versioning/branch.ts
@@ -1,0 +1,62 @@
+import type { VersioningInfo } from "./types";
+
+import { util } from "@/lib";
+
+/**
+ * Prefix for release branches.
+ */
+export const RELEASE_BRANCH_PREFIX = "release";
+
+/**
+ * Parse a branch name into its version information. If the provided branch isn't a release
+ * branch, `null` will be returned.
+ *
+ * A release branch begins with `release/`.
+ *
+ * @param branch - Branch name to parse.
+ * @returns {ReleaseInfo} Release information parsed from the branch name.
+ * @returns {null} Returned if the branch isn't a release branch.
+ * @throws {Error} If the branch is a malformed release branch, an error will be thrown.
+ */
+export function versioningInfoFromBranch(
+  branch: string,
+): VersioningInfo | null {
+  let prefix: string | undefined;
+  let versionStr: string | undefined;
+
+  try {
+    [prefix, versionStr] = util.splitOnce(branch, "/");
+  } catch (_e) {
+    prefix = undefined;
+    versionStr = undefined;
+  }
+
+  if (prefix !== RELEASE_BRANCH_PREFIX) {
+    // Unexpected branch format, so mustn't be a release branch.
+    return null;
+  }
+
+  // Ensure the numbered versions are valid.
+  let majorVersion: number | undefined;
+  let minorVersion: number | undefined;
+  try {
+    [majorVersion, minorVersion] = util
+      .splitOnce(versionStr, ".", false)
+      .map((version) => Number(version))
+      .filter((version) => !isNaN(version) && Number.isSafeInteger(version));
+  } catch (_e) {
+    majorVersion = undefined;
+    minorVersion = undefined;
+  }
+
+  if (majorVersion === undefined || minorVersion === undefined) {
+    throw new Error(`malformed release branch name: ${branch}`);
+  }
+
+  return {
+    version: `${majorVersion}.${minorVersion}`,
+    majorVersion,
+    minorVersion,
+    isMajorRelease: minorVersion === 0,
+  };
+}

--- a/actions/src/lib/versioning/index.ts
+++ b/actions/src/lib/versioning/index.ts
@@ -1,0 +1,9 @@
+export {
+  versionFromLabels,
+  changelogFromLabels,
+  severityFromLabels,
+} from "./labels";
+export { versioningInfoFromBranch } from "./branch";
+export { severityFits, severityFromVersion } from "./severity";
+
+export type { Severity, Version, VersioningInfo } from "./types";

--- a/actions/src/lib/versioning/labels.test.ts
+++ b/actions/src/lib/versioning/labels.test.ts
@@ -1,0 +1,90 @@
+import { describe, it } from "vitest";
+
+import {
+  versionFromLabels,
+  changelogFromLabels,
+  severityFromLabels,
+} from "./labels";
+
+describe("versionFromLabels", () => {
+  describe("produce version", () => {
+    it("patch pull request", ({ expect }) => {
+      expect(versionFromLabels(["version: patch"])).toEqual("patch");
+    });
+
+    it("minor pull request", ({ expect }) => {
+      expect(versionFromLabels(["version: minor"])).toEqual("minor");
+    });
+
+    it("major pull request", ({ expect }) => {
+      expect(versionFromLabels(["version: major"])).toEqual("major");
+    });
+
+    it("ignoring other labels", ({ expect }) => {
+      expect(
+        versionFromLabels([
+          "version: patch",
+          "changelog",
+          "random label",
+          "something else",
+        ]),
+      ).toEqual("patch");
+    });
+  });
+
+  describe("produce nothing", () => {
+    it("handles no labels", ({ expect }) => {
+      expect(versionFromLabels([])).toEqual(null);
+    });
+
+    it("handles no version labels", ({ expect }) => {
+      expect(versionFromLabels(["component-a", "component-b"])).toEqual(null);
+    });
+
+    it("with multiple version labels", ({ expect }) => {
+      expect(() =>
+        versionFromLabels(["version: major", "version: minor"]),
+      ).toThrow("multiple version labels detected");
+    });
+  });
+});
+
+describe("changelogFromLabels", () => {
+  it("detects changelog label", ({ expect }) => {
+    expect(changelogFromLabels(["changelog"])).toEqual(true);
+  });
+
+  it("detects changelog label with other labels", ({ expect }) => {
+    expect(
+      changelogFromLabels(["changelog", "component-a", "component-b"]),
+    ).toEqual(true);
+  });
+
+  it("ignores other labels", ({ expect }) => {
+    expect(changelogFromLabels(["component-a", "component-b"])).toEqual(false);
+  });
+
+  it("handles no labels", ({ expect }) => {
+    expect(changelogFromLabels([])).toEqual(false);
+  });
+});
+
+describe("severityFromLabels", () => {
+  it("detects major", ({ expect }) => {
+    expect(severityFromLabels(["release-severity: major"])).toEqual("major");
+  });
+
+  it("detects minor", ({ expect }) => {
+    expect(severityFromLabels(["release-severity: minor"])).toEqual("minor");
+  });
+
+  it("ignores other labels", ({ expect }) => {
+    expect(
+      severityFromLabels(["release-severity: major", "component-a"]),
+    ).toEqual("major");
+  });
+
+  it("handles no release labels", ({ expect }) => {
+    expect(severityFromLabels(["component-a", "component-b"])).toBe(null);
+  });
+});

--- a/actions/src/lib/versioning/labels.ts
+++ b/actions/src/lib/versioning/labels.ts
@@ -1,0 +1,84 @@
+import type { Severity, Version } from "./types";
+
+/**
+ * Mapping between a pull request label and the version.
+ */
+export const PULL_REQUEST_VERSION_LABELS: Record<string, Version> = {
+  "version: major": "major",
+  "version: minor": "minor",
+  "version: patch": "patch",
+};
+
+/**
+ * Pull request label that indicates the pull request is to be included in the changelog.
+ */
+export const PULL_REQUEST_CHANGELOG_LABEL = "changelog";
+
+/**
+ * Mapping between a pull request label and the severity.
+ */
+export const SEVERITY_LABELS: Record<string, Severity> = {
+  "release-severity: major": "major",
+  "release-severity: minor": "minor",
+};
+
+/**
+ * Determine the version from a collection of labels. If no version label is detected, `null` will
+ * be returned.
+ */
+export function versionFromLabels(labels: string[]): Version | null {
+  let version: Version | null = null;
+
+  for (const label of labels) {
+    if (label in PULL_REQUEST_VERSION_LABELS) {
+      if (version !== null) {
+        throw new Error("multiple version labels detected.");
+      }
+
+      version = PULL_REQUEST_VERSION_LABELS[label];
+
+      continue;
+    }
+  }
+
+  return version;
+}
+
+/**
+ * Determine if a list of labels includes a label for changelog.
+ */
+export function changelogFromLabels(labels: string[]): boolean {
+  let changelog = false;
+
+  for (const label of labels) {
+    if (label === PULL_REQUEST_CHANGELOG_LABEL) {
+      changelog = true;
+
+      continue;
+    }
+  }
+
+  return changelog;
+}
+
+/**
+ * Determine the severity from a collection of labels. If no severity label is detected, `null`
+ * will be returned.
+ */
+export function severityFromLabels(labels: string[]): Severity | null {
+  let severity: Severity | null = null;
+
+  for (const label of labels) {
+    if (label in SEVERITY_LABELS) {
+      if (severity !== null) {
+        throw new Error("multiple severity labels detected.");
+      }
+
+      severity = SEVERITY_LABELS[label];
+
+      continue;
+    }
+  }
+
+  return severity;
+}

--- a/actions/src/lib/versioning/severity.test.ts
+++ b/actions/src/lib/versioning/severity.test.ts
@@ -1,0 +1,35 @@
+import { describe, it } from "vitest";
+
+import { severityFits, severityFromVersion } from "./severity";
+
+describe("severityFits", () => {
+  it("minor in major", ({ expect }) => {
+    expect(severityFits("major", "minor")).toBe(true);
+  });
+
+  it("major in major", ({ expect }) => {
+    expect(severityFits("major", "major")).toBe(true);
+  });
+
+  it("minor in minor", ({ expect }) => {
+    expect(severityFits("minor", "minor")).toBe(true);
+  });
+
+  it("major not in minor", ({ expect }) => {
+    expect(severityFits("minor", "major")).toBe(false);
+  });
+});
+
+describe("severityFromVersion", () => {
+  it("handles patch", ({ expect }) => {
+    expect(severityFromVersion("patch")).toEqual("minor");
+  });
+
+  it("handles minor", ({ expect }) => {
+    expect(severityFromVersion("minor")).toEqual("minor");
+  });
+
+  it("handles major", ({ expect }) => {
+    expect(severityFromVersion("major")).toEqual("major");
+  });
+});

--- a/actions/src/lib/versioning/severity.ts
+++ b/actions/src/lib/versioning/severity.ts
@@ -1,0 +1,19 @@
+import type { Severity, Version } from "./types";
+
+/**
+ * Check if the `inner` severity fits within the `outer` severity.
+ */
+export function severityFits(outer: Severity, inner: Severity): boolean {
+  return outer === "major" || outer === inner;
+}
+
+/**
+ * Given a version type, determine the associated release severity.
+ */
+export function severityFromVersion(version: Version): Severity {
+  if (version === "patch" || version === "minor") {
+    return "minor";
+  }
+
+  return "major";
+}

--- a/actions/src/lib/versioning/types.ts
+++ b/actions/src/lib/versioning/types.ts
@@ -1,0 +1,24 @@
+/**
+ * Summary of version information.
+ */
+export type VersioningInfo = {
+  /** Major/minor version string. */
+  version: `${number}.${number}`;
+  /** Major component of the version. */
+  majorVersion: number;
+  /** Minor component of the version. */
+  minorVersion: number;
+  /** Whether this version is a major release. */
+  isMajorRelease: boolean;
+};
+
+/**
+ * Components of a SemVer version.
+ */
+export type Version = "major" | "minor" | "patch";
+
+/**
+ * Corresponds to the release branch types of the 'stable mainline' approach, where all branches
+ * are either a major or minor branch.
+ */
+export type Severity = "major" | "minor";

--- a/actions/tsconfig.json
+++ b/actions/tsconfig.json
@@ -1,6 +1,14 @@
 {
   "compilerOptions": {
     "baseUrl": "src",
+    "paths": {
+      "@/lib": [
+        "./lib/index.ts"
+      ],
+      "@/lib/*": [
+        "./lib/*"
+      ]
+    },
     "moduleResolution": "bundler"
   },
   "include": [

--- a/actions/vite.config.ts
+++ b/actions/vite.config.ts
@@ -1,3 +1,6 @@
 import { defineConfig } from "vite";
+import tsconfigPaths from "vite-tsconfig-paths";
 
-export default defineConfig({});
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+});

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -78,7 +78,7 @@ export default [
       "@typescript-eslint/await-thenable": "error",
       "react/jsx-filename-extension": [1, { extensions: [".js", ".tsx"] }],
       "import/prefer-default-export": 0,
-      "import/imports-first": ["error", "absolute-first"],
+      "import/first": ["error"],
       "import/newline-after-import": "error",
       "import/order": [
         "error",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,7 +22,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@actions/exec@npm:^1.1.1":
+"@actions/exec@npm:1.1.1, @actions/exec@npm:^1.1.1":
   version: 1.1.1
   resolution: "@actions/exec@npm:1.1.1"
   dependencies:
@@ -31,7 +31,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@actions/http-client@npm:^2.0.1":
+"@actions/github@npm:6.0.1":
+  version: 6.0.1
+  resolution: "@actions/github@npm:6.0.1"
+  dependencies:
+    "@actions/http-client": "npm:^2.2.0"
+    "@octokit/core": "npm:^5.0.1"
+    "@octokit/plugin-paginate-rest": "npm:^9.2.2"
+    "@octokit/plugin-rest-endpoint-methods": "npm:^10.4.0"
+    "@octokit/request": "npm:^8.4.1"
+    "@octokit/request-error": "npm:^5.1.1"
+    undici: "npm:^5.28.5"
+  checksum: 10c0/eaa4109eb1c6ccda5d0c261c4401b8d8ebf0b3f871eb553e1e7a53b86455ad0a7dc7f443c8351aba4fbad979070511f7f86ca84a9056449ef053066cfdb3576b
+  languageName: node
+  linkType: hard
+
+"@actions/http-client@npm:^2.0.1, @actions/http-client@npm:^2.2.0":
   version: 2.2.3
   resolution: "@actions/http-client@npm:2.2.3"
   dependencies:
@@ -1065,6 +1080,142 @@ __metadata:
     mkdirp: "npm:^1.0.4"
     rimraf: "npm:^3.0.2"
   checksum: 10c0/11b2151e6d1de6f6eb23128de5aa8a429fd9097d839a5190cb77aa47a6b627022c42d50fa7c47a00f1c9f8f0c1560092b09b061855d293fa0741a2a94cfb174d
+  languageName: node
+  linkType: hard
+
+"@octokit/auth-token@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@octokit/auth-token@npm:4.0.0"
+  checksum: 10c0/57acaa6c394c5abab2f74e8e1dcf4e7a16b236f713c77a54b8f08e2d14114de94b37946259e33ec2aab0566b26f724c2b71d2602352b59e541a9854897618f3c
+  languageName: node
+  linkType: hard
+
+"@octokit/core@npm:^5.0.1":
+  version: 5.2.1
+  resolution: "@octokit/core@npm:5.2.1"
+  dependencies:
+    "@octokit/auth-token": "npm:^4.0.0"
+    "@octokit/graphql": "npm:^7.1.0"
+    "@octokit/request": "npm:^8.4.1"
+    "@octokit/request-error": "npm:^5.1.1"
+    "@octokit/types": "npm:^13.0.0"
+    before-after-hook: "npm:^2.2.0"
+    universal-user-agent: "npm:^6.0.0"
+  checksum: 10c0/9759c70a6a6477a636f336d717657761243bab0e9d34c4012a8b2d70aafd89ba3d24289fb7e05352999c6ec526fe572b8aff9ad59e90761842fb72fb7d59ed95
+  languageName: node
+  linkType: hard
+
+"@octokit/endpoint@npm:^9.0.6":
+  version: 9.0.6
+  resolution: "@octokit/endpoint@npm:9.0.6"
+  dependencies:
+    "@octokit/types": "npm:^13.1.0"
+    universal-user-agent: "npm:^6.0.0"
+  checksum: 10c0/8e06197b21869aeb498e0315093ca6fbee12bd1bdcfc1667fcd7d79d827d84f2c5a30702ffd28bba7879780e367d14c30df5b20d47fcaed5de5fdc05f5d4e013
+  languageName: node
+  linkType: hard
+
+"@octokit/graphql@npm:^7.1.0":
+  version: 7.1.1
+  resolution: "@octokit/graphql@npm:7.1.1"
+  dependencies:
+    "@octokit/request": "npm:^8.4.1"
+    "@octokit/types": "npm:^13.0.0"
+    universal-user-agent: "npm:^6.0.0"
+  checksum: 10c0/c27216200f3f4ce7ce2a694fb7ea43f8ea4a807fbee3a423c41ed137dd7948dfc0bbf6ea1656f029a7625c84b583acdef740a7032266d0eff55305c91c3a1ed6
+  languageName: node
+  linkType: hard
+
+"@octokit/openapi-types@npm:^20.0.0":
+  version: 20.0.0
+  resolution: "@octokit/openapi-types@npm:20.0.0"
+  checksum: 10c0/5176dcc3b9d182ede3d446750cfa5cf31139624785a73fcf3511e3102a802b4d7cc45e999c27ed91d73fe8b7d718c8c406facb48688926921a71fe603b7db95d
+  languageName: node
+  linkType: hard
+
+"@octokit/openapi-types@npm:^24.2.0":
+  version: 24.2.0
+  resolution: "@octokit/openapi-types@npm:24.2.0"
+  checksum: 10c0/8f47918b35e9b7f6109be6f7c8fc3a64ad13a48233112b29e92559e64a564b810eb3ebf81b4cd0af1bb2989d27b9b95cca96e841ec4e23a3f68703cefe62fd9e
+  languageName: node
+  linkType: hard
+
+"@octokit/openapi-types@npm:^25.1.0":
+  version: 25.1.0
+  resolution: "@octokit/openapi-types@npm:25.1.0"
+  checksum: 10c0/b5b1293b11c6ec7112c7a2713f8507c2696d5db8902ce893b594080ab0329f5a6fcda1b5ac6fe6eed9425e897f4d03326c1bdf5c337e35d324e7b925e52a2661
+  languageName: node
+  linkType: hard
+
+"@octokit/plugin-paginate-rest@npm:^9.2.2":
+  version: 9.2.2
+  resolution: "@octokit/plugin-paginate-rest@npm:9.2.2"
+  dependencies:
+    "@octokit/types": "npm:^12.6.0"
+  peerDependencies:
+    "@octokit/core": 5
+  checksum: 10c0/e9c85b17064fe6b62f9af88dba008f3daef456b1195340ea0831990e9c4dbabe89be950b6e5dc924ebcca18ad1aaa0cf6df7d824dc8be26ce9a55f20336ff815
+  languageName: node
+  linkType: hard
+
+"@octokit/plugin-rest-endpoint-methods@npm:^10.4.0":
+  version: 10.4.1
+  resolution: "@octokit/plugin-rest-endpoint-methods@npm:10.4.1"
+  dependencies:
+    "@octokit/types": "npm:^12.6.0"
+  peerDependencies:
+    "@octokit/core": 5
+  checksum: 10c0/4b8f64c0f7fa12464546ad312a5289c2a799967e01e90e2c4923ec6e9604cf212dcb50d9795c9a688867f973c9c529c5950368564c560406c652bcd298f090af
+  languageName: node
+  linkType: hard
+
+"@octokit/request-error@npm:^5.1.1":
+  version: 5.1.1
+  resolution: "@octokit/request-error@npm:5.1.1"
+  dependencies:
+    "@octokit/types": "npm:^13.1.0"
+    deprecation: "npm:^2.0.0"
+    once: "npm:^1.4.0"
+  checksum: 10c0/dc9fc76ea5e4199273e4665ce9ddf345fe8f25578d9999c9a16f276298e61ee6fe0e6f5a6147b91ba3b34fdf5b9e6b7af6ae13d6333175e95b30c574088f7a2d
+  languageName: node
+  linkType: hard
+
+"@octokit/request@npm:^8.4.1":
+  version: 8.4.1
+  resolution: "@octokit/request@npm:8.4.1"
+  dependencies:
+    "@octokit/endpoint": "npm:^9.0.6"
+    "@octokit/request-error": "npm:^5.1.1"
+    "@octokit/types": "npm:^13.1.0"
+    universal-user-agent: "npm:^6.0.0"
+  checksum: 10c0/1a69dcb7336de708a296db9e9a58040e5b284a87495a63112f80eb0007da3fc96a9fadecb9e875fc63cf179c23a0f81031fbef2a6f610a219e45805ead03fcf3
+  languageName: node
+  linkType: hard
+
+"@octokit/types@npm:14.1.0":
+  version: 14.1.0
+  resolution: "@octokit/types@npm:14.1.0"
+  dependencies:
+    "@octokit/openapi-types": "npm:^25.1.0"
+  checksum: 10c0/4640a6c0a95386be4d015b96c3a906756ea657f7df3c6e706d19fea6bf3ac44fd2991c8c817afe1e670ff9042b85b0e06f7fd373f6bbd47da64208701bb46d5b
+  languageName: node
+  linkType: hard
+
+"@octokit/types@npm:^12.6.0":
+  version: 12.6.0
+  resolution: "@octokit/types@npm:12.6.0"
+  dependencies:
+    "@octokit/openapi-types": "npm:^20.0.0"
+  checksum: 10c0/0bea58bda46c93287f5a80a0e52bc60e7dc7136b8a38c3569d63d073fb9df4a56acdb9d9bdba9978f37c374a4a6e3e52886ef5b08cace048adb0012cacef942c
+  languageName: node
+  linkType: hard
+
+"@octokit/types@npm:^13.0.0, @octokit/types@npm:^13.1.0":
+  version: 13.10.0
+  resolution: "@octokit/types@npm:13.10.0"
+  dependencies:
+    "@octokit/openapi-types": "npm:^24.2.0"
+  checksum: 10c0/f66a401b89d653ec28e5c1529abdb7965752db4d9d40fa54c80e900af4c6bf944af6bd0a83f5b4f1eecb72e3d646899dfb27ffcf272ac243552de7e3b97a038d
   languageName: node
   linkType: hard
 
@@ -3512,6 +3663,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"before-after-hook@npm:^2.2.0":
+  version: 2.2.3
+  resolution: "before-after-hook@npm:2.2.3"
+  checksum: 10c0/0488c4ae12df758ca9d49b3bb27b47fd559677965c52cae7b335784724fb8bf96c42b6e5ba7d7afcbc31facb0e294c3ef717cc41c5bc2f7bd9e76f8b90acd31c
+  languageName: node
+  linkType: hard
+
 "bn.js@npm:^4.0.0, bn.js@npm:^4.1.0, bn.js@npm:^4.11.9":
   version: 4.12.0
   resolution: "bn.js@npm:4.12.0"
@@ -4958,6 +5116,13 @@ __metadata:
   version: 2.0.0
   resolution: "depd@npm:2.0.0"
   checksum: 10c0/58bd06ec20e19529b06f7ad07ddab60e504d9e0faca4bd23079fac2d279c3594334d736508dc350e06e510aba5e22e4594483b3a6562ce7c17dd797f4cc4ad2c
+  languageName: node
+  linkType: hard
+
+"deprecation@npm:^2.0.0":
+  version: 2.3.1
+  resolution: "deprecation@npm:2.3.1"
+  checksum: 10c0/23d688ba66b74d09b908c40a76179418acbeeb0bfdf218c8075c58ad8d0c315130cb91aa3dffb623aa3a411a3569ce56c6460de6c8d69071c17fe6dd2442f032
   languageName: node
   linkType: hard
 
@@ -8474,9 +8639,14 @@ __metadata:
   resolution: "juju-dashboard-actions@workspace:actions"
   dependencies:
     "@actions/core": "npm:1.11.1"
+    "@actions/exec": "npm:1.1.1"
+    "@actions/github": "npm:6.0.1"
+    "@octokit/types": "npm:14.1.0"
     "@vercel/ncc": "npm:0.38.3"
     eslint: "npm:9.28.0"
     typescript: "npm:5.8.3"
+    vite: "npm:6.2.7"
+    vite-tsconfig-paths: "npm:5.1.4"
     vitest: "npm:3.2.1"
   languageName: unknown
   linkType: soft
@@ -9541,7 +9711,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"once@npm:^1.3.0":
+"once@npm:^1.3.0, once@npm:^1.4.0":
   version: 1.4.0
   resolution: "once@npm:1.4.0"
   dependencies:
@@ -12828,7 +12998,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^5.25.4":
+"undici@npm:^5.25.4, undici@npm:^5.28.5":
   version: 5.29.0
   resolution: "undici@npm:5.29.0"
   dependencies:
@@ -12852,6 +13022,13 @@ __metadata:
   dependencies:
     imurmurhash: "npm:^0.1.4"
   checksum: 10c0/617240eb921af803b47d322d75a71a363dacf2e56c29ae5d1404fad85f64f4ec81ef10ee4fd79215d0202cbe1e5a653edb0558d59c9c81d3bd538c2d58e4c026
+  languageName: node
+  linkType: hard
+
+"universal-user-agent@npm:^6.0.0":
+  version: 6.0.1
+  resolution: "universal-user-agent@npm:6.0.1"
+  checksum: 10c0/5c9c46ffe19a975e11e6443640ed4c9e0ce48fcc7203325757a8414ac49940ebb0f4667f2b1fa561489d1eb22cb2d05a0f7c82ec20c5cba42e58e188fb19b187
   languageName: node
   linkType: hard
 
@@ -13047,6 +13224,58 @@ __metadata:
     vite:
       optional: true
   checksum: 10c0/6228f23155ea25d92b1e1702284cf8dc52ad3c683c5ca691edd5a4c82d2913e7326d00708cef1cbfde9bb226261df0e0a12e03ef1d43b6a92d8f02b483ef37e3
+  languageName: node
+  linkType: hard
+
+"vite@npm:6.2.7":
+  version: 6.2.7
+  resolution: "vite@npm:6.2.7"
+  dependencies:
+    esbuild: "npm:^0.25.0"
+    fsevents: "npm:~2.3.3"
+    postcss: "npm:^8.5.3"
+    rollup: "npm:^4.30.1"
+  peerDependencies:
+    "@types/node": ^18.0.0 || ^20.0.0 || >=22.0.0
+    jiti: ">=1.21.0"
+    less: "*"
+    lightningcss: ^1.21.0
+    sass: "*"
+    sass-embedded: "*"
+    stylus: "*"
+    sugarss: "*"
+    terser: ^5.16.0
+    tsx: ^4.8.1
+    yaml: ^2.4.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    jiti:
+      optional: true
+    less:
+      optional: true
+    lightningcss:
+      optional: true
+    sass:
+      optional: true
+    sass-embedded:
+      optional: true
+    stylus:
+      optional: true
+    sugarss:
+      optional: true
+    terser:
+      optional: true
+    tsx:
+      optional: true
+    yaml:
+      optional: true
+  bin:
+    vite: bin/vite.js
+  checksum: 10c0/2da5df6bfdc386a3b24d7350c508e075a49a5b5c33eb4a327203eb175398a1da99d185c68bd2287be897032810700d95ea7ce72d1113d86f43de61f0ce4435da
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Done

- tweak eslint rules to remove conflicting rules
- remove un-needed `actions/setup-node` from renovate step (this isn't needed as the renovate action provides it's own NodeJS instance, and dashboard code isn't being run)
- implement utilities for future actions:
  - `lib/github`: Abstractions over `Octokit` (Github REST API) for easy interactions with repositories and pull requests
  - `lib/versioning`: Collection of methods relating to calculating and resolving release versions, including translating to/from pull request labels, parsing release branch names, and detecting version conflicts
  - `lib/changelog`: Methods for building and parsing changelogs
  - `lib/git`: Basic abstraction over simple git operations, intended to be slightly nicer then `exec('git ... ')` (and easier to mock too)

## Details

WD-23116