### PR TITLE
feat: persist CLI history

### DIFF
--- a/src/components/WebCLI/Output/types.ts
+++ b/src/components/WebCLI/Output/types.ts
@@ -1,5 +1,7 @@
 import type { ReactNode } from "react";
 
+import type { HistoryItem } from "store/juju/types";
+
 export type Block = {
   header: string;
   rows: string[];
@@ -53,11 +55,6 @@ export type ProcessCommand = {
 } & CommandHandler;
 
 export type ProcessOutput = Record<string, ProcessCommand>;
-
-export type HistoryItem = {
-  command: string;
-  messages: string[];
-};
 
 export type Props = {
   content: HistoryItem[];

--- a/src/store/juju/actions.test.ts
+++ b/src/store/juju/actions.test.ts
@@ -7,6 +7,7 @@ import { auditEventFactory } from "testing/factories/juju/jimm";
 import {
   listSecretResultFactory,
   relationshipTupleFactory,
+  commandHistoryItem,
 } from "testing/factories/juju/juju";
 
 import { actions } from "./slice";
@@ -513,6 +514,17 @@ describe("actions", () => {
     expect(actions.removeCheckRelations({ requestId })).toStrictEqual({
       type: "juju/removeCheckRelations",
       payload: { requestId },
+    });
+  });
+
+  it("removeCheckRelations", () => {
+    const payload = {
+      modelUUID: "abc123",
+      historyItem: commandHistoryItem.build({ command: "status" }),
+    };
+    expect(actions.addCommandHistory(payload)).toStrictEqual({
+      type: "juju/addCommandHistory",
+      payload,
     });
   });
 });

--- a/src/store/juju/reducers.test.ts
+++ b/src/store/juju/reducers.test.ts
@@ -22,6 +22,8 @@ import {
   rebacAllowedFactory,
   rebacRelationshipFactory,
   rebacState,
+  commandHistoryState,
+  commandHistoryItem,
 } from "testing/factories/juju/juju";
 import {
   modelWatcherModelDataFactory,
@@ -1391,6 +1393,31 @@ describe("reducers", () => {
       ...state,
       rebac: rebacState.build({
         relationships: [],
+      }),
+    });
+  });
+
+  it("addCommandHistory", () => {
+    const state = jujuStateFactory.build({
+      commandHistory: commandHistoryState.build({
+        abc1234: [commandHistoryItem.build({ command: "help" })],
+      }),
+    });
+    expect(
+      reducer(
+        state,
+        actions.addCommandHistory({
+          modelUUID: "abc1234",
+          historyItem: commandHistoryItem.build({ command: "status" }),
+        }),
+      ),
+    ).toStrictEqual({
+      ...state,
+      commandHistory: commandHistoryState.build({
+        abc1234: [
+          commandHistoryItem.build({ command: "help" }),
+          commandHistoryItem.build({ command: "status" }),
+        ],
       }),
     });
   });

--- a/src/store/juju/selectors.test.ts
+++ b/src/store/juju/selectors.test.ts
@@ -33,6 +33,8 @@ import {
   modelSecretsContentFactory,
   rebacState,
   rebacRelationshipFactory,
+  commandHistoryState,
+  commandHistoryItem,
 } from "testing/factories/juju/juju";
 import {
   applicationInfoFactory,
@@ -129,6 +131,7 @@ import {
   getReBACRelationshipsLoaded,
   getReBACPermissions,
   getReBACPermission,
+  getCommandHistory,
 } from "./selectors";
 
 describe("selectors", () => {
@@ -2510,5 +2513,17 @@ describe("selectors", () => {
         ),
       ).toBe(true);
     });
+  });
+
+  it("getCommandHistory", () => {
+    const commandHistory = commandHistoryState.build({
+      abc1234: [commandHistoryItem.build()],
+    });
+    const state = rootStateFactory.build({
+      juju: jujuStateFactory.build({
+        commandHistory,
+      }),
+    });
+    expect(getCommandHistory(state)).toStrictEqual(commandHistory);
   });
 });

--- a/src/store/juju/selectors.ts
+++ b/src/store/juju/selectors.ts
@@ -1150,3 +1150,8 @@ export const getReBACRelationshipsLoaded = createSelector(
   [(state, requestId: string) => getReBACRelationships(state, requestId)],
   (permission) => permission?.loaded ?? false,
 );
+
+export const getCommandHistory = createSelector(
+  [slice],
+  ({ commandHistory }) => commandHistory,
+);

--- a/src/store/juju/slice.ts
+++ b/src/store/juju/slice.ts
@@ -34,6 +34,7 @@ import type {
   ModelSecrets,
   SecretsContent,
   ReBACAllowed,
+  HistoryItem,
 } from "./types";
 
 export const DEFAULT_AUDIT_EVENTS_LIMIT = 50;
@@ -119,6 +120,7 @@ const slice = createSlice({
       loaded: false,
       loading: false,
     },
+    commandHistory: {},
     controllers: null,
     models: {},
     modelsError: null,
@@ -589,6 +591,20 @@ const slice = createSlice({
       if (existingIndex >= 0) {
         state.rebac.relationships.splice(existingIndex, 1);
       }
+    },
+    addCommandHistory: (
+      state,
+      {
+        payload: { modelUUID, historyItem },
+      }: PayloadAction<{
+        modelUUID: string;
+        historyItem: HistoryItem;
+      }>,
+    ) => {
+      if (!(modelUUID in state.commandHistory)) {
+        state.commandHistory[modelUUID] = [];
+      }
+      state.commandHistory[modelUUID].push(historyItem);
     },
   },
 });

--- a/src/store/juju/types.ts
+++ b/src/store/juju/types.ts
@@ -106,9 +106,17 @@ export type ReBACState = {
   relationships: ReBACRelationship[];
 };
 
+export type HistoryItem = {
+  command: string;
+  messages: string[];
+};
+
+export type CommandHistory = Record<string, HistoryItem[]>;
+
 export type JujuState = {
   auditEvents: AuditEventsState;
   crossModelQuery: CrossModelQueryState;
+  commandHistory: CommandHistory;
   controllers: Controllers | null;
   models: ModelsList;
   modelsError: string | null;

--- a/src/store/middleware/check-auth.ts
+++ b/src/store/middleware/check-auth.ts
@@ -100,6 +100,7 @@ export const checkAuthMiddleware: Middleware<
       jujuActions.addCheckRelations.type,
       jujuActions.checkRelations.type,
       jujuActions.removeCheckRelations.type,
+      jujuActions.addCommandHistory.type,
     ];
 
     const thunkAllowlist = [

--- a/src/testing/factories/juju/juju.ts
+++ b/src/testing/factories/juju/juju.ts
@@ -18,9 +18,11 @@ import { JIMMRelation } from "juju/jimm/JIMMV4";
 import { DEFAULT_AUDIT_EVENTS_LIMIT } from "store/juju/slice";
 import type {
   AuditEventsState,
+  CommandHistory,
   Controller,
   ControllerLocation,
   CrossModelQueryState,
+  HistoryItem,
   JujuState,
   ModelData,
   ModelFeatures,
@@ -274,9 +276,17 @@ export const rebacState = Factory.define<ReBACState>(() => ({
   relationships: [],
 }));
 
+export const commandHistoryItem = Factory.define<HistoryItem>(() => ({
+  command: "status",
+  messages: [],
+}));
+
+export const commandHistoryState = Factory.define<CommandHistory>(() => ({}));
+
 export const jujuStateFactory = Factory.define<JujuState>(() => ({
   auditEvents: auditEventsStateFactory.build(),
   crossModelQuery: crossModelQueryStateFactory.build(),
+  commandHistory: commandHistoryState.build(),
   controllers: null,
   models: {},
   modelsLoaded: false,


### PR DESCRIPTION
## Done

- Support storing the history for each model.
- Store the history in Redux.
- Recreate the history when revisiting a model.

## QA

- Go to a model details page.
- Enter a command in the CLI.
- Navigate away from the model details and then back again and open the CLI and it should display the previous output.

## Details

https://warthogs.atlassian.net/browse/WD-22422
