### PR TITLE
chore: update outdated URLs with new ones

### DIFF
--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -89,7 +89,7 @@ export default class ErrorBoundary extends Component<Props, State> {
           <p>
             Further debugging can be done{" "}
             <a
-              href="https://juju.is/docs/olm/troubleshooting"
+              href={externalURLs.troubleshootDeployment}
               rel="noopener noreferrer"
               target="_blank"
             >

--- a/src/components/ErrorBoundary/__snapshots__/ErrorBoundary.test.tsx.snap
+++ b/src/components/ErrorBoundary/__snapshots__/ErrorBoundary.test.tsx.snap
@@ -90,7 +90,7 @@ exports[`Error Boundary > renders without crashing and matches snapshot 1`] = `
           Further debugging can be done
            
           <a
-            href="https://juju.is/docs/olm/troubleshooting"
+            href="https://documentation.ubuntu.com/juju/latest/howto/manage-your-deployment/index.html#troubleshoot-your-deployment"
             rel="noopener noreferrer"
             target="_blank"
           >

--- a/src/components/WebCLI/__snapshots__/WebCLI.test.tsx.snap
+++ b/src/components/WebCLI/__snapshots__/WebCLI.test.tsx.snap
@@ -48,7 +48,7 @@ exports[`WebCLI > renders correctly 1`] = `
         Welcome to the Juju Web CLI - see the
          
         <a
-          href="https://juju.is/docs/olm/the-juju-web-cli"
+          href="https://documentation.ubuntu.com/juju/latest/reference/juju-web-cli/"
           rel="noreferrer"
           target="_blank"
         >

--- a/src/pages/ControllersIndex/ControllersIndex.tsx
+++ b/src/pages/ControllersIndex/ControllersIndex.tsx
@@ -27,7 +27,7 @@ import {
 } from "store/juju/selectors";
 import type { Controller } from "store/juju/types";
 import { useAppSelector } from "store/store";
-import urls from "urls";
+import urls, { externalURLs } from "urls";
 import { breakLines } from "utils";
 
 import ControllersOverview from "./ControllerOverview";
@@ -218,7 +218,7 @@ const ControllersIndex = () => {
                     controller.{" "}
                     <a
                       className="p-list__link"
-                      href="https://juju.is/docs/olm/upgrading"
+                      href={externalURLs.upgradingThings}
                       target="_blank"
                       rel="noopener noreferrer"
                     >

--- a/src/pages/EntityDetails/EntityDetails.tsx
+++ b/src/pages/EntityDetails/EntityDetails.tsx
@@ -19,7 +19,7 @@ import {
   getModelUUIDFromList,
 } from "store/juju/selectors";
 import { useAppSelector } from "store/store";
-import urls from "urls";
+import urls, { externalURLs } from "urls";
 
 import ModelTabs from "./Model/ModelTabs";
 import { Label, TestId } from "./types";
@@ -81,10 +81,7 @@ const EntityDetails = ({ modelWatcherError }: Props) => {
                 {userName}
                 ". If this is a model that belongs to another user then check
                 that you have been{" "}
-                <a href="https://juju.is/docs/olm/manage-users#heading--model-access">
-                  granted access
-                </a>
-                .
+                <a href={externalURLs.modelAccess}>granted access</a>.
               </p>
               <p>
                 <Link to={urls.models.index}>View all models</Link>

--- a/src/pages/EntityDetails/Model/ApplicationsTab/ApplicationsTab.tsx
+++ b/src/pages/EntityDetails/Model/ApplicationsTab/ApplicationsTab.tsx
@@ -9,6 +9,7 @@ import {
   getModelUUIDFromList,
 } from "store/juju/selectors";
 import { useAppSelector } from "store/store";
+import { externalURLs } from "urls";
 
 import { renderCounts } from "../../counts";
 
@@ -120,7 +121,7 @@ export default function ApplicationsTab() {
         There are no applications associated with this model. Learn about{" "}
         <a
           className="p-link--external"
-          href="https://juju.is/docs/deploying-applications"
+          href={externalURLs.deployingApplication}
         >
           deploying applications
         </a>

--- a/src/pages/EntityDetails/Model/Model.tsx
+++ b/src/pages/EntityDetails/Model/Model.tsx
@@ -33,6 +33,7 @@ import {
   generateOffersRows,
   generateRelationRows,
 } from "tables/tableRows";
+import { externalURLs } from "urls";
 
 import ApplicationsTab from "./ApplicationsTab";
 import Logs from "./Logs";
@@ -175,10 +176,7 @@ const Model = () => {
           ) : (
             <span data-testid="no-machines-msg">
               There are no machines in this model -{" "}
-              <a
-                className="p-link--external"
-                href="https://juju.is/docs/olm/machines"
-              >
+              <a className="p-link--external" href={externalURLs.machine}>
                 learn more about machines
               </a>
             </span>
@@ -235,7 +233,7 @@ const Model = () => {
                 There are no integrations associated with this model -{" "}
                 <a
                   className="p-link--external"
-                  href="https://juju.is/integration"
+                  href="https://documentation.ubuntu.com/juju/latest/reference/relation/"
                 >
                   learn more about integration
                 </a>

--- a/src/pages/EntityDetails/Unit/Unit.tsx
+++ b/src/pages/EntityDetails/Unit/Unit.tsx
@@ -25,7 +25,7 @@ import {
   generateLocalApplicationRows,
   generateMachineRows,
 } from "tables/tableRows";
-import urls from "urls";
+import urls, { externalURLs } from "urls";
 
 import { Label } from "./types";
 
@@ -104,10 +104,7 @@ export default function Unit() {
               Could not find a unit with ID "{unitId}" for the user "{userName}
               ". If this is a model that belongs to another user then check that
               you have been{" "}
-              <a href="https://canonical-juju.readthedocs-hosted.com/en/latest/user/howto/manage-users/#manage-access-at-the-controller-model-application-or-offer-level">
-                granted access
-              </a>
-              .
+              <a href={externalURLs.manageAccess}>granted access</a>.
             </p>
             <p>
               <Link

--- a/src/pages/ModelsIndex/ModelsIndex.tsx
+++ b/src/pages/ModelsIndex/ModelsIndex.tsx
@@ -29,7 +29,7 @@ import {
 import { pluralize } from "store/juju/utils/models";
 import { useAppSelector } from "store/store";
 import type { ModelsGroupedBy } from "urls";
-import urls from "urls";
+import urls, { externalURLs } from "urls";
 
 import { Label, TestId } from "./types";
 
@@ -118,15 +118,9 @@ export default function Models() {
         <div className="models">
           <h3>{Label.NOT_FOUND}</h3>
           <p>
-            Learn about{" "}
-            <a href="https://juju.is/docs/olm/manage-models#heading--add-a-model">
-              adding models
-            </a>{" "}
-            or{" "}
-            <a href="https://juju.is/docs/olm/manage-users#heading--model-access">
-              granting access
-            </a>{" "}
-            to existing models.
+            Learn about <a href={externalURLs.addModel}>adding models</a> or{" "}
+            <a href={externalURLs.modelAccess}>granting access</a> to existing
+            models.
           </p>
         </div>
       );

--- a/src/urls.ts
+++ b/src/urls.ts
@@ -60,10 +60,24 @@ const urls = {
 };
 
 export const externalURLs = {
-  newIssue: "https://github.com/canonical/juju-dashboard/issues/new",
-  cliHelp: "https://juju.is/docs/olm/the-juju-web-cli",
+  addModel:
+    "https://documentation.ubuntu.com/juju/latest/howto/manage-models/#heading--add-a-model",
+  cliHelp:
+    "https://documentation.ubuntu.com/juju/latest/reference/juju-web-cli/",
   cliHelpCommand: (command: string) =>
     `https://documentation.ubuntu.com/juju/latest/reference/juju-cli/list-of-juju-cli-commands/${command.replace(/^\//, "")}`,
+  deployingApplication:
+    "https://documentation.ubuntu.com/juju/latest/howto/manage-applications/#deploy-an-application",
+  machine: "https://documentation.ubuntu.com/juju/latest/reference/machine/",
+  manageAccess:
+    "https://documentation.ubuntu.com/juju/latest/howto/manage-users/index.html#manage-access-at-the-controller-model-application-or-offer-level",
+  modelAccess:
+    "https://documentation.ubuntu.com/juju/latest/howto/manage-users/#heading--model-access",
+  newIssue: "https://github.com/canonical/juju-dashboard/issues/new",
+  troubleshootDeployment:
+    "https://documentation.ubuntu.com/juju/latest/howto/manage-your-deployment/index.html#troubleshoot-your-deployment",
+  upgradingThings:
+    "https://documentation.ubuntu.com/juju/latest/reference/upgrading-things/",
 };
 
 export const rebacURLS = generateReBACURLS(urls.permissions);


### PR DESCRIPTION
## Done

- Updated old URLs to use documentation.ubuntu.com/*
- Moved all external URLs to `externalURLs`

## QA

- Check that all these new URLs work and are leading to expected pages

## Details

https://warthogs.atlassian.net/browse/WD-23693
