### PR TITLE
chore(ci): build and run the dashboard via the docker image

### DIFF
--- a/.github/actions/setup-docker-dashboard/action.yml
+++ b/.github/actions/setup-docker-dashboard/action.yml
@@ -34,14 +34,15 @@ runs:
         DOCKER_BUILDKIT=1 docker build -t juju-dashboard:local .
     - name: Configure Dashboard
       run: |
-        echo -e "
-          var jujuDashboardConfig = {
-            controllerAPIEndpoint: \"${{ inputs.controller-ws-address }}\",
-            baseAppURL: \"/\",
-            identityProviderURL: \"\",
-            isJuju: ${{ inputs.is-juju }},
-            analyticsEnabled: false,
-          };" > public/config.js
+        cat << EOF > public/config.js
+        var jujuDashboardConfig = {
+          controllerAPIEndpoint: "${{ inputs.controller-ws-address }}",
+          baseAppURL: "/",
+          identityProviderURL: "",
+          isJuju: ${{ inputs.is-juju }},
+          analyticsEnabled: false,
+        };
+        EOF
       shell: bash
     - name: Run the Docker image
       if: ${{ inputs.run == 'true' }}


### PR DESCRIPTION
## Done

Create an action to build and run the dashboard via the docker image

## QA

You can see that the dashboard is running in my test PR: https://github.com/canonical/juju-dashboard/actions/runs/16258643609/job/45899427392?pr=2000#step:11:1.

## Details

https://warthogs.atlassian.net/browse/WD-23521
