### PR TITLE
fix(actions): better changelog generation

### DIFF
--- a/.github/actions/create-cut-pr/index.js
+++ b/.github/actions/create-cut-pr/index.js
@@ -31810,6 +31810,12 @@ class PullRequest {
     get base() {
         return this.pullRequest.base.ref;
     }
+    /**
+     * Generate the changelog entry for this pull request.
+     */
+    changelogEntry() {
+        return `${this.title} by @${this.pullRequest.user.login} (#${this.number})`;
+    }
     async close() {
         await this.update({
             state: "closed",
@@ -32328,7 +32334,7 @@ async function run(ctx) {
         }
         // Add this PR to the changelog if required.
         if (ctx.pr.hasLabel(CHANGELOG_LABEL)) {
-            changelogItems.push(ctx.pr.title);
+            changelogItems.push(ctx.pr.changelogEntry());
         }
     }
     // Find the existing cut PR

--- a/.github/actions/create-release-pr/index.js
+++ b/.github/actions/create-release-pr/index.js
@@ -31810,6 +31810,12 @@ class PullRequest {
     get base() {
         return this.pullRequest.base.ref;
     }
+    /**
+     * Generate the changelog entry for this pull request.
+     */
+    changelogEntry() {
+        return `${this.title} by @${this.pullRequest.user.login} (#${this.number})`;
+    }
     async close() {
         await this.update({
             state: "closed",
@@ -32304,7 +32310,7 @@ async function run(ctx) {
         }
         else if (ctx.pr.hasLabel(CHANGELOG_LABEL)) {
             // Triggered from a PR that's indicated it should be included in the changelog, so add it.
-            changelogItems.push(ctx.pr.title);
+            changelogItems.push(ctx.pr.changelogEntry());
         }
     }
     // Find an existing release PR for this branch.

--- a/actions/src/create-cut-pr/main.ts
+++ b/actions/src/create-cut-pr/main.ts
@@ -84,7 +84,7 @@ export async function run(ctx: Ctx) {
 
     // Add this PR to the changelog if required.
     if (ctx.pr.hasLabel(CHANGELOG_LABEL)) {
-      changelogItems.push(ctx.pr.title);
+      changelogItems.push(ctx.pr.changelogEntry());
     }
   }
 

--- a/actions/src/create-release-pr/main.test.ts
+++ b/actions/src/create-release-pr/main.test.ts
@@ -117,7 +117,7 @@ describe("create-release-pr", () => {
     [
       "with changelog label",
       [CHANGELOG_LABEL] as string[],
-      `${CHANGELOG_START_MARKER}\n- my cool feature\n${CHANGELOG_END_MARKER}`,
+      `${CHANGELOG_START_MARKER}\n- my cool feature by @user (#111)\n${CHANGELOG_END_MARKER}`,
     ],
     ["without changelog label", [] as string[], null],
   ] as const)(

--- a/actions/src/create-release-pr/main.ts
+++ b/actions/src/create-release-pr/main.ts
@@ -81,7 +81,7 @@ export async function run(ctx: Ctx) {
       return {};
     } else if (ctx.pr.hasLabel(CHANGELOG_LABEL)) {
       // Triggered from a PR that's indicated it should be included in the changelog, so add it.
-      changelogItems.push(ctx.pr.title);
+      changelogItems.push(ctx.pr.changelogEntry());
     }
   }
 

--- a/actions/src/lib/github/pull-request.ts
+++ b/actions/src/lib/github/pull-request.ts
@@ -48,6 +48,13 @@ export class PullRequest {
   public get base() {
     return this.pullRequest.base.ref;
   }
+  
+  /**
+   * Generate the changelog entry for this pull request.
+   */
+  public changelogEntry() {
+    return `${this.title} by @${this.pullRequest.user.login} (#${this.number})`;
+  }
 
   public async close() {
     await this.update({

--- a/actions/src/lib/test-utils.ts
+++ b/actions/src/lib/test-utils.ts
@@ -28,6 +28,7 @@ export function mockPr({
     title,
     body,
     hasLabel: (label: string) => labels.includes(label),
+    changelogEntry: () => `${title} by @user (#${number})`,
   };
 }
 


### PR DESCRIPTION
## Done

Include the PR number and author when generating a changelog item from a PR.