### PR TITLE
fix(k8s-charm): `upstream-source` for docker image

### DIFF
--- a/charms/k8s-charm/build.sh
+++ b/charms/k8s-charm/build.sh
@@ -12,13 +12,13 @@ DASHBOARD_IMAGE_ID=""
 
 # 1. Build or reuse the Juju Dashboard Docker image
 if [ "$BUILD_TYPE" == "source" ]; then
+    DASHBOARD_IMAGE_ID="dashboard-image:local"
+    
     # Navigate to the root and build the image in a subshell
     (
         cd "$ROOT_DIR"
-        DOCKER_BUILDKIT=1 docker build -t juju-dashboard:local .
+        DOCKER_BUILDKIT=1 docker build -t "$DASHBOARD_IMAGE_ID" .
     )
-
-    DASHBOARD_IMAGE_ID="juju-dashboard:local"
 
 elif [ "$BUILD_TYPE" == "dashboard-resource" ]; then
     # The ID comes directly from the input resource

--- a/charms/k8s-charm/metadata.yaml
+++ b/charms/k8s-charm/metadata.yaml
@@ -25,6 +25,7 @@ resources:
     type: oci-image
     description: |
       Canonical build of the dashboard (canonicalwebteam/juju-dashboard:latest)
+    upstream-source: dashboard-image:local
 
 provides:
   dashboard:


### PR DESCRIPTION
## Done

- Update metadata for k8s charm to include `upstream-source` field

## Details

This field isn't actually used by charmcraft directly, but it's relied on for other automations, including the `publish-charm` action of [canonical/charming-actions](https://github.com/canonical/charming-actions). The action uses this field to query the local Docker image repository in order to push the image to Charmhub, so it must match whatever is used in the build script.