### PR TITLE
use `replaceAll` instead of `replace` to catch every instance of replaced values

### DIFF
--- a/src/components/JujuCLI/JujuCLI.tsx
+++ b/src/components/JujuCLI/JujuCLI.tsx
@@ -184,7 +184,9 @@ const JujuCLI = () => {
                         userName: modelInfo.owner,
                         modelName: modelInfo.name,
                         appName,
-                        unitId: column.value.replace("/", "-").replace("*", ""),
+                        unitId: column.value
+                          .replaceAll("/", "-")
+                          .replaceAll("*", ""),
                       }),
                     };
                   },


### PR DESCRIPTION
Fixes https://github.com/canonical/juju-dashboard/security/code-scanning/32
