### PR TITLE
fix: make `Git.exec` private to prevent second-order code execution

### DIFF
--- a/actions/src/lib/git.ts
+++ b/actions/src/lib/git.ts
@@ -32,7 +32,7 @@ export default class Git {
   /**
    * Execute the provided git command.
    */
-  public async exec(...args: string[]) {
+  private async exec(...args: string[]) {
     return exec.exec("git", args);
   }
 


### PR DESCRIPTION
Fix https://github.com/canonical/juju-dashboard/security/code-scanning/31