### PR TITLE
ci: publish docker image in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,33 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-  release:
+  release-docker-image:
+    name: "Release Docker image to GHCR"
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+
+    needs: [pre-release]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ghcr.io/canonical/juju-dashboard:${{ needs.pre-release.outputs.version }}
+
+  release-charms:
     name: "Release Juju Dashboard"
     runs-on: ubuntu-22.04
 
@@ -169,7 +195,7 @@ jobs:
     name: "Create tags and releases"
     runs-on: ubuntu-22.04
 
-    needs: [pre-release, release]
+    needs: [pre-release, release-charms]
 
     defaults:
       run:


### PR DESCRIPTION
## Done

This PR adds a step the release workflow to publish the dashboard's docker image to GHCR (Github Container Registry). This will make it useful for the JIMM project to use in local development and testing.

The workflow is mostly just lifted from the examples at https://github.com/docker/build-push-action/. One useful thing to note is that we build for amd64 and arm64 without using the `docker/setup-qemu-action@v3` action which would setup virtualisation for building images for other architectures. Use of QEMU would greatly slow down the docker image build and because the image contains static file contents and no compilation this should work.