### PR TITLE
fix: remove dns-name and fix setting the port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ yarn-error.log
 .DS_Store
 juju-dashboard*.tar.bz2
 coverage/
+.coverage
 .dotrun.json
 /.eslintcache
 .vscode/

--- a/charms/k8s-charm/tests/test_charm.py
+++ b/charms/k8s-charm/tests/test_charm.py
@@ -16,26 +16,34 @@ class TestCharm(unittest.TestCase):
         self.harness = Harness(JujuDashboardKubernetesCharm)
         self.addCleanup(self.harness.cleanup)
         self.harness.begin_with_initial_hooks()
-        self.harness.set_can_connect('dashboard', True)
-        self.container = self.harness.model.unit.get_container('dashboard')
-        self.container.make_dir('/srv')
-        self.container.make_dir('/etc/nginx/sites-available/', make_parents=True)
+        self.harness.set_can_connect("dashboard", True)
+        self.container = self.harness.model.unit.get_container("dashboard")
+        self.container.make_dir("/srv")
+        self.container.make_dir("/etc/nginx/sites-available/", make_parents=True)
         self.rel_id = self.harness.add_relation("controller", "controller")
         self.harness.add_relation_unit(self.rel_id, "controller/0")
-        self.harness.update_relation_data(self.rel_id, "controller", {
-            "controller-url": "wss://10.10.10.1:107070",
-            "is-juju": "True",
-            "identity-provider-url": ""
-        })
+        self.harness.update_relation_data(
+            self.rel_id,
+            "controller",
+            {
+                "controller-url": "wss://10.10.10.1:107070",
+                "is-juju": "True",
+                "identity-provider-url": "",
+            },
+        )
 
     def test_on_controller_relation_changed(self):
-        self.harness.update_relation_data(self.rel_id, "controller", {
-            "is-juju": "True",
-        })
-        with self.container.pull('/etc/nginx/sites-available/default') as f:
+        self.harness.update_relation_data(
+            self.rel_id,
+            "controller",
+            {
+                "is-juju": "True",
+            },
+        )
+        with self.container.pull("/etc/nginx/sites-available/default") as f:
             nginx_config = f.read()
         self.assertTrue("https://10.10.10.1:107070" in nginx_config)
-        with self.container.pull('/srv/config.js') as f:
+        with self.container.pull("/srv/config.js") as f:
             config = f.read()
         self.assertTrue("isJuju: true" in config)
 
@@ -44,17 +52,23 @@ class TestCharm(unittest.TestCase):
         self.harness.remove_relation(self.rel_id)
         self.assertEqual(
             self.harness.model.unit.status,
-            BlockedStatus("Missing controller integration")
+            BlockedStatus("Missing controller integration"),
         )
 
     def test_config_changed(self):
-        with self.container.pull('/srv/config.js') as f:
+        with self.container.pull("/srv/config.js") as f:
             config = f.read()
         self.assertTrue("analyticsEnabled: true" in config)
-        self.harness.update_config({"analytics-enabled": False})
-        with self.container.pull('/srv/config.js') as f:
+        with self.container.pull("/etc/nginx/sites-available/default") as f:
+            nginx_config = f.read()
+        self.assertTrue("listen 8080" in nginx_config)
+        self.harness.update_config({"analytics-enabled": False, "port": 123})
+        with self.container.pull("/srv/config.js") as f:
             config = f.read()
         self.assertTrue("analyticsEnabled: false" in config)
+        with self.container.pull("/etc/nginx/sites-available/default") as f:
+            nginx_config = f.read()
+        self.assertTrue("listen 123" in nginx_config)
 
     def test_config_changed_no_relation(self):
         self.harness.remove_relation(self.rel_id)
@@ -62,18 +76,18 @@ class TestCharm(unittest.TestCase):
         self.harness.update_config({"analytics-enabled": False})
         self.assertEqual(
             self.harness.model.unit.status,
-            BlockedStatus("Missing controller integration")
+            BlockedStatus("Missing controller integration"),
         )
 
     def test_update_status(self):
         self.harness.disable_hooks()
         self.harness.update_config({"analytics-enabled": False})
         self.harness.enable_hooks()
-        with self.container.pull('/srv/config.js') as f:
+        with self.container.pull("/srv/config.js") as f:
             config = f.read()
         self.assertTrue("analyticsEnabled: true" in config)
         self.harness.charm.on.update_status.emit()
-        with self.container.pull('/srv/config.js') as f:
+        with self.container.pull("/srv/config.js") as f:
             config = f.read()
         self.assertTrue("analyticsEnabled: false" in config)
 
@@ -81,10 +95,10 @@ class TestCharm(unittest.TestCase):
         self.harness.disable_hooks()
         self.harness.update_config({"analytics-enabled": False})
         self.harness.enable_hooks()
-        with self.container.pull('/srv/config.js') as f:
+        with self.container.pull("/srv/config.js") as f:
             config = f.read()
         self.assertTrue("analyticsEnabled: true" in config)
         self.harness.charm.on.upgrade_charm.emit()
-        with self.container.pull('/srv/config.js') as f:
+        with self.container.pull("/srv/config.js") as f:
             config = f.read()
         self.assertTrue("analyticsEnabled: false" in config)

--- a/charms/machine-charm/config.yaml
+++ b/charms/machine-charm/config.yaml
@@ -18,9 +18,6 @@ options:
     default: 8080
     description: The port to serve the dashboard on.
     type: int
-  dns-name:
-    description: DNS of the Juju dashboard.
-    type: string
   analytics-enabled:
     default: true
     description: Whether Google Analytics and Sentry error tracking is enabled. This data is used to improve Juju Dashboard.

--- a/charms/machine-charm/requirements.txt
+++ b/charms/machine-charm/requirements.txt
@@ -1,3 +1,2 @@
-charmhelpers
 ops
 jinja2

--- a/charms/machine-charm/src/nginx.conf.template
+++ b/charms/machine-charm/src/nginx.conf.template
@@ -4,14 +4,8 @@ map $http_upgrade $connection_upgrade {
 }
 
 server {
-{% if dns_name is defined and dns_name %}
-    listen 443 ssl;
-    ssl_certificate /srv/{{dns_name}}_fullchain.pem;
-    ssl_certificate_key /srv/{{dns_name}}.key;
-{% else %}
-    listen 8080 default_server;
-    listen [::]:8080 default_server;
-{% endif %}
+    listen {{port}} default_server;
+    listen [::]:{{port}} default_server;
 
     root {{dashboard_root}}/src/dist;
     index index.html;


### PR DESCRIPTION
## Done

- Remove unused dns-name config option.
- Fix setting the port.
- Replace hookenv port handling with the new methods from ops.

## QA

- Build and deploy the charms for both envs: https://github.com/canonical/juju-dashboard/blob/main/docs/building-charms.md
- Once deployed check that you can view the dashboard at the default port 8080.
- Update the port e.g. `juju config dashboard port=80`.
- Check that you can view the dashboard at the new port.

## Details

https://warthogs.atlassian.net/browse/WD-25746