### PR TITLE
feat: publish docker image to ghcr

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,19 @@ jobs:
           if [ '${{ matrix.charm-kind }}' = 'k8s' ]; then
               echo "$OUTPUT" | grep '^id=' >> "$GITHUB_OUTPUT"
           fi
+      - name: Log in to GitHub Container Registry
+        if: ${{ matrix.charm-kind == 'k8s' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload docker image
+        if: ${{ matrix.charm-kind == 'k8s' }}
+        run: |
+          FINAL_TAG='ghcr.io/canonical/juju-dashboard:${{ needs.pre-release.outputs.version }}'
+          docker image tag '${{ steps.build.outputs.id }}' "$FINAL_TAG"
+          docker image push "$FINAL_TAG"
       - name: Get charm path
         id: post-build
         run: |


### PR DESCRIPTION
## Done

- Publish built k8s image to ghcr on release

## QA

- Successful run (manually triggered): https://github.com/canonical/juju-dashboard/actions/runs/17147765838/job/48647243767
- ghcr entry: https://github.com/canonical/juju-dashboard/pkgs/container/juju-dashboard

## Details

In place of #2051

