### PR TITLE
test: update run playwright action and keycloak backend e2e test fix

### DIFF
--- a/.github/actions/run-playwright/action.yml
+++ b/.github/actions/run-playwright/action.yml
@@ -22,12 +22,17 @@ runs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: "yarn"
+        cache-dependency-path: ${{ github.action_path }}/../../../yarn.lock
     - name: Install dependencies
       if: ${{ inputs.setup == 'true' }}
+      # action_path is .github/actions/run-playwright so we 
+      # need to go up three levels to get to the repo root.
+      working-directory: ${{ github.action_path }}/../../..
       shell: bash
       run: yarn install
     - name: Install Playwright Browsers
       if: ${{ inputs.setup == 'true' }}
+      working-directory: ${{ github.action_path }}/../../..
       run: yarn playwright install --with-deps --only-shell chromium
       shell: bash
     - name: Get dashboard address
@@ -42,6 +47,7 @@ runs:
       shell: bash
     - name: Run Playwright tests
       if: ${{ inputs.run == 'true' }}
+      working-directory: ${{ github.action_path }}/../../..
       run: yarn playwright test
       shell: bash
       env:
@@ -50,5 +56,6 @@ runs:
       if: ${{ !cancelled() && inputs.run == 'true' }}
       with:
         name: ${{ inputs.test-identifier }}
-        path: test-results/
+        path: ${{ github.action_path }}/../../../test-results/
         retention-days: 30
+

--- a/.github/actions/run-playwright/action.yml
+++ b/.github/actions/run-playwright/action.yml
@@ -50,9 +50,9 @@ runs:
       id: dashboard
       run: |
         if [[ -z "${DASHBOARD_ADDRESS}" ]]; then
-          echo "address=http://$(address=$(juju show-unit dashboard/0 | yq '.dashboard/0.public-address'); if [ "$address" != "null" ]; then echo $address; else juju show-unit dashboard/0 | yq '.dashboard/0.address'; fi):8080" >> $GITHUB_OUTPUT
+          echo "address=$(address=$(juju show-unit dashboard/0 | yq '.dashboard/0.public-address'); if [ "$address" != "null" ]; then echo $address; else juju show-unit dashboard/0 | yq '.dashboard/0.address'; fi):8080" >> $GITHUB_OUTPUT
         else
-          echo "address=http://$DASHBOARD_ADDRESS" >> $GITHUB_OUTPUT
+          echo "address=$DASHBOARD_ADDRESS" >> $GITHUB_OUTPUT
         fi
       shell: bash
 

--- a/.github/actions/run-playwright/action.yml
+++ b/.github/actions/run-playwright/action.yml
@@ -21,8 +21,6 @@ runs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
-        cache: "yarn"
-        cache-dependency-path: ${{ github.action_path }}/../../../yarn.lock
     - name: Install dependencies
       if: ${{ inputs.setup == 'true' }}
       # action_path is .github/actions/run-playwright so we 

--- a/.github/actions/run-playwright/action.yml
+++ b/.github/actions/run-playwright/action.yml
@@ -48,9 +48,12 @@ runs:
     - name: Get dashboard address
       if: ${{ inputs.run == 'true' }}
       id: dashboard
+      # If the DASHBOARD_ADDRESS env var is set, use that, and allow
+      # the caller to set the scheme (http/https), otherwise assume http
+      # for testing a charmed deployment.
       run: |
         if [[ -z "${DASHBOARD_ADDRESS}" ]]; then
-          echo "address=$(address=$(juju show-unit dashboard/0 | yq '.dashboard/0.public-address'); if [ "$address" != "null" ]; then echo $address; else juju show-unit dashboard/0 | yq '.dashboard/0.address'; fi):8080" >> $GITHUB_OUTPUT
+          echo "address=http://$(address=$(juju show-unit dashboard/0 | yq '.dashboard/0.public-address'); if [ "$address" != "null" ]; then echo $address; else juju show-unit dashboard/0 | yq '.dashboard/0.address'; fi):8080" >> $GITHUB_OUTPUT
         else
           echo "address=$DASHBOARD_ADDRESS" >> $GITHUB_OUTPUT
         fi

--- a/.github/actions/run-playwright/action.yml
+++ b/.github/actions/run-playwright/action.yml
@@ -12,15 +12,19 @@ inputs:
     default: "true"
     description: Whether to set up Playwright.
     required: false
+  node-version:
+    description: The Node.js version to use.
+    required: false
+    default: "22"
 
 runs:
   using: "composite"
   steps:
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Install Node.js
       if: ${{ inputs.setup == 'true' }}
       uses: actions/setup-node@v4
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: ${{ inputs.node-version }}
     - name: Install dependencies
       if: ${{ inputs.setup == 'true' }}
       # action_path is .github/actions/run-playwright so we 

--- a/.github/actions/run-playwright/action.yml
+++ b/.github/actions/run-playwright/action.yml
@@ -20,23 +20,35 @@ inputs:
 runs:
   using: "composite"
   steps:
+
+    # github.action_path is .github/actions/run-playwright so we need to 
+    # go up three levels to get to the repo root. Some actions don't accept
+    # relative paths so we normalize it first here.
+    - name: Normalize repo root path
+      id: repo-root
+      run: |
+        REPO_ROOT=$(realpath "${{ github.action_path }}/../../..")
+        echo "repo_root=$REPO_ROOT" >> $GITHUB_OUTPUT
+      shell: bash
+
     - name: Install Node.js
       if: ${{ inputs.setup == 'true' }}
       uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
+
     - name: Install dependencies
       if: ${{ inputs.setup == 'true' }}
-      # action_path is .github/actions/run-playwright so we 
-      # need to go up three levels to get to the repo root.
-      working-directory: ${{ github.action_path }}/../../..
+      working-directory: ${{ steps.repo-root.outputs.repo_root }}
       shell: bash
       run: yarn install
+
     - name: Install Playwright Browsers
       if: ${{ inputs.setup == 'true' }}
-      working-directory: ${{ github.action_path }}/../../..
+      working-directory: ${{ steps.repo-root.outputs.repo_root }}
       run: yarn playwright install --with-deps --only-shell chromium
       shell: bash
+
     - name: Get dashboard address
       if: ${{ inputs.run == 'true' }}
       id: dashboard
@@ -47,17 +59,19 @@ runs:
           echo "address=http://$DASHBOARD_ADDRESS" >> $GITHUB_OUTPUT
         fi
       shell: bash
+
     - name: Run Playwright tests
       if: ${{ inputs.run == 'true' }}
-      working-directory: ${{ github.action_path }}/../../..
+      working-directory: ${{ steps.repo-root.outputs.repo_root }}
       run: yarn playwright test
       shell: bash
       env:
         DASHBOARD_ADDRESS: ${{ steps.dashboard.outputs.address }}
+
     - uses: actions/upload-artifact@v4
       if: ${{ !cancelled() && inputs.run == 'true' }}
       with:
         name: ${{ inputs.test-identifier }}
-        path: ${{ github.action_path }}/../../../test-results/
+        path: ${{ steps.repo-root.outputs.repo_root }}/test-results/
         retention-days: 30
 

--- a/.github/actions/run-playwright/action.yml
+++ b/.github/actions/run-playwright/action.yml
@@ -12,10 +12,6 @@ inputs:
     default: "true"
     description: Whether to set up Playwright.
     required: false
-  node-version:
-    description: The Node.js version to use.
-    required: false
-    default: "22"
 
 runs:
   using: "composite"
@@ -35,7 +31,7 @@ runs:
       if: ${{ inputs.setup == 'true' }}
       uses: actions/setup-node@v4
       with:
-        node-version: ${{ inputs.node-version }}
+        node-version: ${{ matrix.node-version || '22' }}
 
     - name: Install dependencies
       if: ${{ inputs.setup == 'true' }}

--- a/.github/workflows/e2e-jimm-docker-keycloak.yml
+++ b/.github/workflows/e2e-jimm-docker-keycloak.yml
@@ -57,8 +57,8 @@ jobs:
       - name: Start JIMM (pull request)
         uses: ./jimm/.github/actions/test-server
         with:
-          jimm-version: dev
-          juju-channel: "3.6/edge"
+          jimm-version: v3.2.2
+          juju-channel: "3.6/stable"
           ghcr-pat: ${{ secrets.GITHUB_TOKEN }}
           dump-logs: true
       - name: Set the CLI admin's password
@@ -66,13 +66,13 @@ jobs:
           juju switch ${{ env.CONTROLLER_NAME }}
           echo '${{ inputs.admin-password }}' | juju change-user-password --no-prompt
       - name: Restart JIMM
-        run: docker restart jimm # Fixes a context cancelled issue when fetching models from the dashboard.
+        run: docker restart jimm-test # Fixes a context cancelled issue when fetching models from the dashboard.
       - name: Wait for JIMM container to be ready
         uses: nick-fields/retry@v3
         with:
           timeout_minutes: 1
           max_attempts: 2
-          command: while [ "$(docker inspect -f {{.State.Restarting}} jimm)" == "true" ]; do sleep 1; done
+          command: while [ "$(docker inspect -f {{.State.Restarting}} jimm-test)" == "true" ]; do sleep 1; done
       - name: Install jaas plugin
         run: sudo snap install jaas
       - name: Run tests

--- a/.github/workflows/e2e-jimm-docker-keycloak.yml
+++ b/.github/workflows/e2e-jimm-docker-keycloak.yml
@@ -82,7 +82,7 @@ jobs:
         env:
           JIMM_CONTROLLER_NAME: ${{ env.CONTROLLER_NAME }}
           CONTROLLER_NAME: jimm
-          DASHBOARD_ADDRESS: ${{ steps.docker-dashboard.outputs.address }}
+          DASHBOARD_ADDRESS: http://${{ steps.docker-dashboard.outputs.address }}
           AUTH_MODE: oidc
           AUTH_VARIANT: keycloak
           JUJU_ENV: jimm

--- a/e2e/helpers/auth/backends/Keycloak.ts
+++ b/e2e/helpers/auth/backends/Keycloak.ts
@@ -23,7 +23,6 @@ export class CreateKeycloakOIDCUser implements Action<KeycloakOIDCUser> {
   }
 
   async run(jujuCLI: JujuCLI) {
-    await jujuCLI.loginLocalCLIAdmin();
     // Give the keycloak user acccess to a file to store the login credentials in.
     await exec(
       'docker exec --user root keycloak sh -c "touch /kcadm.config && chown keycloak /kcadm.config"',
@@ -42,7 +41,6 @@ export class CreateKeycloakOIDCUser implements Action<KeycloakOIDCUser> {
   }
 
   async rollback(jujuCLI: JujuCLI) {
-    await jujuCLI.loginLocalCLIAdmin();
     const user = this.result();
     const userId = await exec(
       `docker exec keycloak sh -c "kcadm.sh get users -q exact=true -q username=${user.identityUsername} -r jimm --config /kcadm.config" | yq .[0].id`,


### PR DESCRIPTION
## Done

This PR makes some fixes to the `run-playwright` action. Each fix below corresponds to 1 commit.

1. Set the correct working-directory for steps that use `run` and need files from the repo. The default working-directory when executing an action is the original workflow's directory i.e. if we call `run-playwright` from a jimm workflow the current directory is the checked out jimm repo and commands like `yarn install` fail because `yarn.lock` is unavailable.
2. Related to the above, when running the `setup-node` action, if we specify `cache: "yarn"` we need to specify `cache-dependency-path` to point to the `yarn.lock` file which is not available in the current dir. Unfortunately when I tried to specify the path I encountered the error `Relative pathing '.' and '..' is not allowed` so I've removed the cache for the setup-node action.
3. Specify the node version because by default on canonical-self-hosted runners (in case someone uses those), the default is node 14 and that is incompatible with the juju-dashboard repo.
4. Removed `await jujuCLI.loginLocalCLIAdmin();` from the `CreateKeycloakOIDCUser` class because it was attempting login with `juju login -u 'admin' --no-prompt` which returned the error `ERROR cannot specify a username during login to a controller with OIDC, remove the username and try again`. We don't need to login in this class because we're using `docker exec` to create users. I'm not 100% sure why/how the that specific logic was being called because it should've been overridden by `KeycloakOIDCUser` class' `cliLogin` method but I'm not experienced enough in js/ts to say.
5. After running the tests for 2+ hours it failed on the artefact upload due to the relative path issue mentioned in point 2. So I've added a step to normalize the relative path. I tried to then re-add the `yarn` cache directive to the `setup-go` action but it failed again with `Some specified paths were not resolved, unable to cache dependencies.` so I left it removed.

See the action running in the JIMM repo at https://github.com/canonical/jimm/pull/1685 which is using this adjusted workflow from my fork. Unfortunately the workflow fails and the final logs show the following error repeated - "^ Error: page.goto: net::ERR_NAME_NOT_RESOLVED at http://https/permissions/users?enable-flag=rebac" so it looks like some URL is not being set correctly. I'll need some help to fix that.

## QA

See the workflow linked above.
