### PR TITLE
fix(ci): use `pull_request_target` for PR actions

### DIFF
--- a/.github/workflows/create-cut-pr.yml
+++ b/.github/workflows/create-cut-pr.yml
@@ -1,7 +1,7 @@
 name: Create cut PR
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
     branches:

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,7 +1,7 @@
 name: Create release PR
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
     branches:


### PR DESCRIPTION
For the actions that create a PR, use the `pull_request_target` event so that they can run with write permissions when triggered by pull requests that originate from a fork.