### PR TITLE
fix(ci): minor release workflow tweaks

### DIFF
--- a/.github/actions/send-notification/action.yml
+++ b/.github/actions/send-notification/action.yml
@@ -30,7 +30,7 @@ runs:
       if: inputs.message != ''
       run: |
         # URI encode the mesage using JQ
-        message="$(echo -n "$message" | jq -sRr @uri)"
+        message="$(echo -n "${{ inputs.message }}" | jq -sRr @uri)"
 
         curl -X POST \
             "${{ inputs.webhook-url }}?room=${{ inputs.channel }}&custom_message=$message"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
 
     outputs:
+      should-run: ${{ steps.check.outputs.should-run }}
       version: ${{ steps.params.outputs.version }}
       channel: ${{ steps.params.outputs.channel }}
       promote-channel: ${{ steps.params.outputs.promote-channel }}
@@ -32,19 +33,22 @@ jobs:
       - uses: actions/checkout@v4
       - name: Only run on `release/x.y.z[-suffix]` branches
         if: github.event_name == 'pull_request'
+        id: check
         run: |
           # Unfortunately, this step is required since GitHub doesn't allow glob filtering on
           # the head branch of a PR.
           if [ -z $(echo '${{ github.head_ref }}' | grep -P '^release/\d+\.\d+\.\d+') ]; then
-              echo 'Not running on a full release branch. Cancelling workflow.'
-
-              gh run cancel ${{ github.run_id }}
-              gh run watch ${{ github.run_id }}
+              echo 'Not running on a full release branch. Exiting workflow.'
+              exit 0
+          else
+              echo 'Running on release branch, continuing workflow.'
+              echo 'should-run=true' | tee -a "$GITHUB_OUTPUT"
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Determine release Charmhub parameters
         id: params
+        if: steps.check.outputs.should-run
         run: |
           version=$(jq -r .version package.json)
           track=$(echo "$version" | grep -Po '^\d+\.\d+')
@@ -76,6 +80,8 @@ jobs:
     runs-on: ubuntu-22.04
 
     needs: [pre-release]
+
+    if: needs.pre-pelease.outputs.should-run
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Done

- use correct variable for custom message in `send-notification` action
- instead of cancelling workflow run with github CLI, use a variable to prevent later steps running (required due to PRs from forks only having `read` permissions)
