### PR TITLE
chore(ci): update tics archive rules

### DIFF
--- a/.github/workflows/tiobe_archive.txt
+++ b/.github/workflows/tiobe_archive.txt
@@ -2,11 +2,17 @@
   "/src/"
 
 'TESTCODE_FILE' =>
-  "/src/test/" ||
+  "/src/testing/" ||
+  "/src/.+\.test\..+" ||
   "/src/[^/]+/.+\.test\..+" ||
   "/actions/src/[^/]+/.+\.test\..+"
 
 
 'GENERATED_FILE' =>
-  "/.github/actions/update-changelog"
-  // Add generated actions here.
+  "/.github/actions/update-changelog" ||
+  "/src/.+\.d\.ts"
+
+
+'INFRA_FILE' =>
+  "/.+\.config\..+"
+


### PR DESCRIPTION
## Done

- Set the correct test dir path (/src/testing/).
- Ignore test files that are at the root of the src dir (e.g. src/index.test.tsx).
- Ignore config files e.g. vite.config.ts.
- Ignore external type definition (.d.ts) files.

