### PR TITLE
fix: log error config error

### DIFF
--- a/charms/k8s-charm/src/config.py
+++ b/charms/k8s-charm/src/config.py
@@ -1,6 +1,10 @@
+import logging
 import os
 from pathlib import Path
 from jinja2 import Environment, FileSystemLoader
+
+
+logger = logging.getLogger(__name__)
 
 
 def to_bool(boolean_variable) -> bool:
@@ -63,15 +67,23 @@ class Config:
 if __name__ == "__main__":
     controller_url = os.environ.get("DASHBOARD_CONTROLLER_URL")
     if controller_url is None:
-        raise Exception("DASHBOARD_CONTROLLER_URL environment variable not provided")
-    dashboard_root = getattr(os.environ, "DASHBOARD_ROOT", "/srv")
-    config = Config(
-        config_dir=os.environ.get("DASHBOARD_CONFIG_DIR", "/srv"),
-        controller_url=controller_url,
-        identity_provider_url=os.environ.get("DASHBOARD_IDENTITY_PROVIDER_URL", None),
-        is_juju=to_bool(os.environ.get("DASHBOARD_IS_JUJU", True)),
-        analytics_enabled=to_bool(os.environ.get("DASHBOARD_ANALYTICS_ENABLED", True)),
-        dashboard_root=dashboard_root,
-        port=int(os.environ.get("DASHBOARD_PORT", 8080)),
-    )
-    config.write()
+        logger.debug(
+            "DASHBOARD_CONTROLLER_URL environment variable not provided. "
+            "Generating configs will be skipped."
+        )
+    else:
+        dashboard_root = getattr(os.environ, "DASHBOARD_ROOT", "/srv")
+        config = Config(
+            config_dir=os.environ.get("DASHBOARD_CONFIG_DIR", "/srv"),
+            controller_url=controller_url,
+            identity_provider_url=os.environ.get(
+                "DASHBOARD_IDENTITY_PROVIDER_URL", None
+            ),
+            is_juju=to_bool(os.environ.get("DASHBOARD_IS_JUJU", True)),
+            analytics_enabled=to_bool(
+                os.environ.get("DASHBOARD_ANALYTICS_ENABLED", True)
+            ),
+            dashboard_root=dashboard_root,
+            port=int(os.environ.get("DASHBOARD_PORT", 8080)),
+        )
+        config.write()

--- a/charms/machine-charm/src/config.py
+++ b/charms/machine-charm/src/config.py
@@ -1,7 +1,10 @@
+import logging
 import os
 from pathlib import Path
-
 from jinja2 import Environment, FileSystemLoader
+
+
+logger = logging.getLogger(__name__)
 
 
 def to_bool(boolean_variable) -> bool:
@@ -64,15 +67,23 @@ class Config:
 if __name__ == "__main__":
     controller_url = os.environ.get("DASHBOARD_CONTROLLER_URL")
     if controller_url is None:
-        raise Exception("DASHBOARD_CONTROLLER_URL environment variable not provided")
-    dashboard_root = getattr(os.environ, "DASHBOARD_ROOT", "/srv")
-    config = Config(
-        config_dir=os.environ.get("DASHBOARD_CONFIG_DIR", "/srv"),
-        controller_url=controller_url,
-        identity_provider_url=os.environ.get("DASHBOARD_IDENTITY_PROVIDER_URL", None),
-        is_juju=to_bool(os.environ.get("DASHBOARD_IS_JUJU", True)),
-        analytics_enabled=to_bool(os.environ.get("DASHBOARD_ANALYTICS_ENABLED", True)),
-        dashboard_root=dashboard_root,
-        port=int(os.environ.get("DASHBOARD_PORT", 8080)),
-    )
-    config.write()
+        logger.debug(
+            "DASHBOARD_CONTROLLER_URL environment variable not provided. "
+            "Generating configs will be skipped."
+        )
+    else:
+        dashboard_root = getattr(os.environ, "DASHBOARD_ROOT", "/srv")
+        config = Config(
+            config_dir=os.environ.get("DASHBOARD_CONFIG_DIR", "/srv"),
+            controller_url=controller_url,
+            identity_provider_url=os.environ.get(
+                "DASHBOARD_IDENTITY_PROVIDER_URL", None
+            ),
+            is_juju=to_bool(os.environ.get("DASHBOARD_IS_JUJU", True)),
+            analytics_enabled=to_bool(
+                os.environ.get("DASHBOARD_ANALYTICS_ENABLED", True)
+            ),
+            dashboard_root=dashboard_root,
+            port=int(os.environ.get("DASHBOARD_PORT", 8080)),
+        )
+        config.write()


### PR DESCRIPTION
## Done

- Log error instead of exiting when initial charm config is run. When deployed by a charm this config will be done later by the charm code so it's expected to fail the initial config (the env vars are only provided when running the docker image with docker compose).

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- [Add additional steps]

## Details

Fixes the issue here: https://github.com/canonical/juju-dashboard/actions/runs/17535094432/job/49797121189#step:12:382.