### PR TITLE
fix: Deleted models are not updated

### DIFF
--- a/src/store/juju/reducers.test.ts
+++ b/src/store/juju/reducers.test.ts
@@ -74,7 +74,7 @@ describe("reducers", () => {
     );
   });
 
-  it("updateModelList", () => {
+  it("updateModelList adds list of models to empty state", () => {
     const state = jujuStateFactory.build({ modelsLoaded: false });
     expect(
       reducer(
@@ -106,6 +106,68 @@ describe("reducers", () => {
           type: "model",
           wsControllerURL: "wss://example.com",
         }),
+      },
+      modelsLoaded: true,
+    });
+  });
+
+  it("updateModelList removes a model and its associated model data", () => {
+    const state = jujuStateFactory.build({
+      models: {
+        abc123: modelListInfoFactory.build({
+          uuid: "abc123",
+          name: "a model",
+          ownerTag: "user-eggman@external",
+          type: "model",
+          wsControllerURL: "wss://example.com",
+        }),
+        xyz345: modelListInfoFactory.build({
+          uuid: "xyz345",
+          name: "another model",
+          ownerTag: "user-eggman@external",
+          type: "model",
+          wsControllerURL: "wss://example.com",
+        }),
+      },
+      modelData: {
+        abc123: model,
+        xyz345: { ...model, uuid: "xyz345" },
+      },
+      modelsLoaded: true,
+    });
+    expect(
+      reducer(
+        state,
+        actions.updateModelList({
+          models: {
+            "user-models": [
+              {
+                model: {
+                  uuid: "abc123",
+                  name: "a model",
+                  "owner-tag": "user-eggman@external",
+                  type: "model",
+                },
+                "last-connection": "today",
+              },
+            ],
+          },
+          wsControllerURL: "wss://example.com",
+        }),
+      ),
+    ).toStrictEqual({
+      ...state,
+      models: {
+        abc123: modelListInfoFactory.build({
+          uuid: "abc123",
+          name: "a model",
+          ownerTag: "user-eggman@external",
+          type: "model",
+          wsControllerURL: "wss://example.com",
+        }),
+      },
+      modelData: {
+        abc123: model,
       },
       modelsLoaded: true,
     });

--- a/src/store/juju/slice.ts
+++ b/src/store/juju/slice.ts
@@ -142,18 +142,24 @@ const slice = createSlice({
       state,
       action: PayloadAction<{ models: UserModelList } & WsControllerURLParam>,
     ) => {
-      const modelList = state.models;
+      const modelList: JujuState["models"] = {};
+      const modelDataList: JujuState["modelData"] = {};
       const userModels = action.payload.models["user-models"] ?? [];
       userModels.forEach((model) => {
-        modelList[model.model.uuid] = {
+        const uuid = model.model.uuid;
+        modelList[uuid] = {
           name: model.model.name,
           ownerTag: model.model["owner-tag"],
           type: model.model.type,
-          uuid: model.model.uuid,
+          uuid,
           wsControllerURL: action.payload.wsControllerURL,
         };
+        if (state.modelData[uuid] !== undefined) {
+          modelDataList[uuid] = state.modelData[uuid];
+        }
       });
       state.models = modelList;
+      state.modelData = modelDataList;
       state.modelsLoaded = true;
     },
     updateModelStatus: (

--- a/src/store/juju/slice.ts
+++ b/src/store/juju/slice.ts
@@ -142,6 +142,7 @@ const slice = createSlice({
       state,
       action: PayloadAction<{ models: UserModelList } & WsControllerURLParam>,
     ) => {
+      // Rebuild the models and modelData lists to keep the state synchronized between additions and removals.
       const modelList: JujuState["models"] = {};
       const modelDataList: JujuState["modelData"] = {};
       const userModels = action.payload.models["user-models"] ?? [];


### PR DESCRIPTION
## Done

- Fixed the bug where a deleted model still appeared in the models list until the dashboard was reloaded

## QA

- Add one model
- Verify that it is available on the dashboard's models list page
- Delete it
- Without reloading the dashboard, check with the network tab that the deleted model is removed as soon as the `listModels` endpoint is polled next
- Do the same with more than one model added
- Do the same with multiple models deleted at once

## Details

https://warthogs.atlassian.net/browse/WD-26700
