### PR TITLE
chore(CI): allow manually running TICS

### DIFF
--- a/.github/workflows/tics-coverage.yml
+++ b/.github/workflows/tics-coverage.yml
@@ -2,6 +2,7 @@ name: Upload TICS report
 on:
   schedule:
     - cron: "0 22 * * 5"
+  workflow_dispatch:
 permissions: read-all
 
 jobs:


### PR DESCRIPTION
## Done

- Enable running the tics workflow manually.
