### PR TITLE
chore(lint): sort unions and intersections

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,12 +6,13 @@ import { FlatCompat } from "@eslint/eslintrc";
 import js from "@eslint/js";
 import stylistic from "@stylistic/eslint-plugin";
 import tsParser from "@typescript-eslint/parser";
+import vitest from "@vitest/eslint-plugin";
 import _import from "eslint-plugin-import";
+import perfectionist from "eslint-plugin-perfectionist";
 import prettier from "eslint-plugin-prettier";
 import promise from "eslint-plugin-promise";
 import react from "eslint-plugin-react";
 import reactRefresh from "eslint-plugin-react-refresh";
-import vitest from "@vitest/eslint-plugin";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -43,6 +44,7 @@ export default [
       react: fixupPluginRules(react),
       import: fixupPluginRules(_import),
       "@stylistic": stylistic,
+      perfectionist,
     },
     languageOptions: {
       globals: {
@@ -136,6 +138,8 @@ export default [
         "error",
         { allowShortCircuit: true },
       ],
+      "perfectionist/sort-intersection-types": "error",
+      "perfectionist/sort-union-types": "error",
     },
   },
 ];

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "eslint-config-prettier": "10.1.1",
     "eslint-plugin-import": "2.31.0",
     "eslint-plugin-jsx-a11y": "6.10.2",
+    "eslint-plugin-perfectionist": "4.15.0",
     "eslint-plugin-prettier": "5.2.5",
     "eslint-plugin-promise": "7.2.1",
     "eslint-plugin-react": "7.37.4",

--- a/src/components/AccessButton/AccessButton.tsx
+++ b/src/components/AccessButton/AccessButton.tsx
@@ -16,8 +16,8 @@ const AccessButton = ({
 }: Props) => {
   const isJuju = useAppSelector(getIsJuju);
   const [, setPanelQs] = useQueryParams<{
-    model: string | null;
-    panel: string | null;
+    model: null | string;
+    panel: null | string;
   }>({
     model: null,
     panel: null,

--- a/src/components/AccessButton/types.ts
+++ b/src/components/AccessButton/types.ts
@@ -4,5 +4,5 @@ import type { PropsWithChildren } from "react";
 export type Props = {
   displayIcon?: boolean;
   modelName?: string;
-} & PropsWithChildren &
-  Partial<ButtonProps>;
+} & Partial<ButtonProps> &
+  PropsWithChildren;

--- a/src/components/Aside/Aside.tsx
+++ b/src/components/Aside/Aside.tsx
@@ -12,7 +12,7 @@ import { useEffect, type PropsWithChildren } from "react";
 export type Props = PropsWithSpread<
   {
     className?: string;
-    width?: "wide" | "narrow";
+    width?: "narrow" | "wide";
     pinned?: boolean;
     loading?: boolean;
     panelProps?: PanelProps;

--- a/src/components/AuditLogsTable/AuditLogsTableActions/AuditLogsTableActions.tsx
+++ b/src/components/AuditLogsTable/AuditLogsTableActions/AuditLogsTableActions.tsx
@@ -10,8 +10,8 @@ import { Label } from "./types";
 
 const AuditLogsTableActions = () => {
   const [, setQueryParams] = useQueryParams<{
-    panel: string | null;
-    page: string | null;
+    panel: null | string;
+    page: null | string;
   }>({
     panel: null,
     page: DEFAULT_PAGE,

--- a/src/components/AuditLogsTable/AuditLogsTableFilters/AuditLogsTableFilters.tsx
+++ b/src/components/AuditLogsTable/AuditLogsTableFilters/AuditLogsTableFilters.tsx
@@ -8,11 +8,11 @@ import type { SetParams } from "hooks/useQueryParams";
 import { DEFAULT_AUDIT_LOG_FILTERS } from "./consts";
 
 export type AuditLogFilters = {
-  after: string | null;
-  before: string | null;
-  user: string | null;
-  model: string | null;
-  method: string | null;
+  after: null | string;
+  before: null | string;
+  user: null | string;
+  model: null | string;
+  method: null | string;
 };
 
 const generateFilters = (
@@ -37,7 +37,7 @@ const generateFilters = (
 
 const AuditLogsTableFilters = () => {
   const [queryParams, setQueryParams] = useQueryParams<
-    AuditLogFilters & { page: string | null }
+    { page: null | string } & AuditLogFilters
   >({ ...DEFAULT_AUDIT_LOG_FILTERS, page: null });
   // Extract just the filters so that they can be looped over.
   const { page: _page, ...filters } = queryParams;

--- a/src/components/AuditLogsTable/AuditLogsTablePagination/AuditLogsTablePagination.tsx
+++ b/src/components/AuditLogsTable/AuditLogsTablePagination/AuditLogsTablePagination.tsx
@@ -44,8 +44,8 @@ const AuditLogsTablePagination = ({
   const auditLogsLoaded = useAppSelector(getAuditEventsLoaded);
   const auditLogsLoading = useAppSelector(getAuditEventsLoading);
   const [queryParams, setQueryParams] = useQueryParams<{
-    panel: string | null;
-    page: string | null;
+    panel: null | string;
+    page: null | string;
   }>({
     panel: null,
     page: DEFAULT_PAGE,

--- a/src/components/AutocompleteInput/AutocompleteInput.tsx
+++ b/src/components/AutocompleteInput/AutocompleteInput.tsx
@@ -16,7 +16,7 @@ type AutocompleteOption = PropsWithSpread<
 
 type Props = PropsWithSpread<
   {
-    options?: (string | AutocompleteOption)[] | null;
+    options?: (AutocompleteOption | string)[] | null;
   },
   InputProps
 >;

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -7,7 +7,7 @@ import { Label } from "./types";
 type Props = {
   isActive: boolean;
   children: ReactNode;
-  variant: "positive" | "caution" | "negative";
+  variant: "caution" | "negative" | "positive";
 };
 
 export default function Banner({

--- a/src/components/ChipGroup/ChipGroup.tsx
+++ b/src/components/ChipGroup/ChipGroup.tsx
@@ -4,13 +4,13 @@ import type { Chip } from "./types";
 
 type Props = {
   chips?: Chip | null;
-  className?: string | null;
-  descriptor?: string | null;
+  className?: null | string;
+  descriptor?: null | string;
 };
 
 const ChipGroup = ({ chips, className, descriptor }: Props) => {
-  const getLabelType = (labelDescriptor?: string | null) => {
-    let label: string | null = null;
+  const getLabelType = (labelDescriptor?: null | string) => {
+    let label: null | string = null;
     switch (labelDescriptor) {
       case "localApps":
         label = "Local applications";

--- a/src/components/ContentReveal/ContentReveal.tsx
+++ b/src/components/ContentReveal/ContentReveal.tsx
@@ -2,7 +2,7 @@ import type { JSX, ReactNode } from "react";
 import { useState } from "react";
 
 type Props = {
-  title: string | ReactNode;
+  title: ReactNode | string;
   children: JSX.Element;
   openByDefault?: boolean;
 };

--- a/src/components/DevBar/widgets/controller.tsx
+++ b/src/components/DevBar/widgets/controller.tsx
@@ -33,7 +33,7 @@ export default {
       getControllerConnection(state, wsControllerURL),
     );
 
-    const [hint, setHint] = useState<string | null>(null);
+    const [hint, setHint] = useState<null | string>(null);
     const [items, setItems] = useState<Record<string, React.ReactNode>>({});
 
     useEffect(() => {

--- a/src/components/DevBar/widgets/juju-user.tsx
+++ b/src/components/DevBar/widgets/juju-user.tsx
@@ -97,7 +97,7 @@ export default {
 
 function useAutoLogin(
   enabled: boolean,
-  wsControllerURL: string | null,
+  wsControllerURL: null | string,
   credential: { user: string; password: string },
 ) {
   const dispatch = useAppDispatch();

--- a/src/components/DevBar/widgets/types.ts
+++ b/src/components/DevBar/widgets/types.ts
@@ -1,6 +1,6 @@
 import type React from "react";
 
 export type Widget = {
-  Title: React.FC | null;
+  Title: null | React.FC;
   Widget: React.FC;
 };

--- a/src/components/DivButton/DivButton.tsx
+++ b/src/components/DivButton/DivButton.tsx
@@ -3,13 +3,13 @@ import classnames from "classnames";
 import type { HTMLProps, PropsWithChildren } from "react";
 import { useRef } from "react";
 
-type Props = PropsWithSpread<
-  {
-    onClick: (event: React.MouseEvent | React.KeyboardEvent) => void;
-  },
-  HTMLProps<HTMLDivElement>
-> &
-  PropsWithChildren;
+type Props = PropsWithChildren &
+  PropsWithSpread<
+    {
+      onClick: (event: React.KeyboardEvent | React.MouseEvent) => void;
+    },
+    HTMLProps<HTMLDivElement>
+  >;
 
 /**
  This component can be used where a button can't be, e.g. when an interactive

--- a/src/components/EntityIdentifier/EntityIdentifier.tsx
+++ b/src/components/EntityIdentifier/EntityIdentifier.tsx
@@ -2,7 +2,7 @@ import CharmIcon from "components/CharmIcon/CharmIcon";
 import TruncatedTooltip from "components/TruncatedTooltip";
 
 type Props = {
-  charmId?: string | null;
+  charmId?: null | string;
   name: string;
   subordinate?: boolean;
 };

--- a/src/components/FormikFormData/types.ts
+++ b/src/components/FormikFormData/types.ts
@@ -4,4 +4,4 @@ import type { FormikErrors } from "formik";
 export type SetFieldValue<V> = (
   fieldName: string,
   value: ValueOf<V>,
-) => Promise<void | FormikErrors<V>>;
+) => Promise<FormikErrors<V> | void>;

--- a/src/components/JujuCLI/JujuCLI.tsx
+++ b/src/components/JujuCLI/JujuCLI.tsx
@@ -137,7 +137,7 @@ const JujuCLI = () => {
     });
   }
 
-  const tableLinks = useMemo<TableLinks | null>(
+  const tableLinks = useMemo<null | TableLinks>(
     () =>
       modelInfo
         ? {

--- a/src/components/LogIn/LogIn.tsx
+++ b/src/components/LogIn/LogIn.tsx
@@ -120,7 +120,7 @@ export default function LogIn() {
   @param loginError The error message from the store.
   @returns A component for the error message.
 */
-function generateErrorMessage(loginError: string | null = null) {
+function generateErrorMessage(loginError: null | string = null) {
   if (loginError === null || !loginError) {
     return null;
   }

--- a/src/components/LogIn/UserPassForm/UserPassForm.tsx
+++ b/src/components/LogIn/UserPassForm/UserPassForm.tsx
@@ -17,7 +17,7 @@ const UserPassForm = () => {
   const wsControllerURL = useAppSelector(getWSControllerURL);
 
   function handleSubmit(
-    ev: FormEvent<HTMLFormElement & { elements: LoginElements }>,
+    ev: FormEvent<{ elements: LoginElements } & HTMLFormElement>,
   ) {
     ev.preventDefault();
     const elements = ev.currentTarget.elements;

--- a/src/components/LogIn/UserPassForm/login.ts
+++ b/src/components/LogIn/UserPassForm/login.ts
@@ -10,7 +10,7 @@ import { Label } from "../types";
 
 export function login(
   dispatch: AppDispatch,
-  wsControllerURL: string | null,
+  wsControllerURL: null | string,
   { user, password }: { user: string; password: string },
 ) {
   dispatch(actions.cleanupLoginErrors());

--- a/src/components/Logo/Logo.tsx
+++ b/src/components/Logo/Logo.tsx
@@ -11,7 +11,7 @@ type Props<C> = PropsWithSpread<
     className?: string;
     dark?: boolean;
     isJuju?: boolean;
-    component?: ElementType | ComponentType<C>;
+    component?: ComponentType<C> | ElementType;
   },
   C
 >;

--- a/src/components/ModelActions/ModelActions.tsx
+++ b/src/components/ModelActions/ModelActions.tsx
@@ -11,8 +11,8 @@ import { Label, type Props } from "./types";
 
 const ModelActions = ({ modelName, modelUUID }: Props) => {
   const [, setPanelQs] = useQueryParams<{
-    model: string | null;
-    panel: string | null;
+    model: null | string;
+    panel: null | string;
   }>({
     model: null,
     panel: null,

--- a/src/components/ModelActions/types.ts
+++ b/src/components/ModelActions/types.ts
@@ -4,8 +4,8 @@ import type { PropsWithChildren } from "react";
 export type Props = {
   modelName: string;
   modelUUID: string;
-} & PropsWithChildren &
-  Partial<ButtonProps>;
+} & Partial<ButtonProps> &
+  PropsWithChildren;
 
 export enum Label {
   ACCESS = "Manage access",

--- a/src/components/ModelDetailsLink/ModelDetailsLink.tsx
+++ b/src/components/ModelDetailsLink/ModelDetailsLink.tsx
@@ -12,19 +12,19 @@ type BaseProps = {
   view?: ModelTab;
 } & React.PropsWithChildren;
 
-type NameProps = BaseProps & {
+type NameProps = {
   modelName: string;
-  ownerTag?: string | null;
+  ownerTag?: null | string;
   replaceLabel?: never;
   uuid?: never;
-};
+} & BaseProps;
 
-export type UUIDProps = BaseProps & {
+export type UUIDProps = {
   modelName?: never;
   ownerTag?: never;
   replaceLabel?: boolean;
   uuid: string;
-};
+} & BaseProps;
 
 export type Props = PropsWithSpread<
   NameProps | UUIDProps,

--- a/src/components/ModelTableList/CloudCell/CloudCell.tsx
+++ b/src/components/ModelTableList/CloudCell/CloudCell.tsx
@@ -12,8 +12,8 @@ type Props = {
 
 const CloudCell = ({ model }: Props) => {
   const provider = model?.info?.["provider-type"];
-  let src: string | null = null;
-  let alt: string | null = null;
+  let src: null | string = null;
+  let alt: null | string = null;
   switch (provider) {
     case "ec2":
       src = awsLogo;

--- a/src/components/ModelTableList/shared.tsx
+++ b/src/components/ModelTableList/shared.tsx
@@ -23,7 +23,7 @@ export const getControllerName = (
   controllers?: Controllers | null,
 ) => {
   const controllerUUID = getControllerUUID(model);
-  let controllerName: string | null = null;
+  let controllerName: null | string = null;
   Object.entries(controllers ?? {}).some(
     (controller) =>
       !!controller[1].some((controllerData) => {
@@ -73,7 +73,7 @@ export type TableHeaderOptions = {
 export const generateTableHeaders = (
   label: string,
   count: number,
-  options: TableHeaderOptions | null = null,
+  options: null | TableHeaderOptions = null,
 ) => {
   const rows = [
     {

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -164,7 +164,7 @@ const PrimaryNav = () => {
 
   return (
     <>
-      <SideNavigation<NavLinkProps | HTMLProps<HTMLAnchorElement>>
+      <SideNavigation<HTMLProps<HTMLAnchorElement> | NavLinkProps>
         dark={DARK_THEME}
         items={[{ items: navigation }, { items: extraNav }]}
         className="p-primary-nav"

--- a/src/components/RadioInputBox/OptionInputs/DescriptionSummary/DescriptionSummary.tsx
+++ b/src/components/RadioInputBox/OptionInputs/DescriptionSummary/DescriptionSummary.tsx
@@ -1,5 +1,5 @@
 type Props = {
-  description?: string | null;
+  description?: null | string;
 };
 
 export default function DescriptionSummary({ description = null }: Props) {

--- a/src/components/RadioInputBox/RadioInputBox.tsx
+++ b/src/components/RadioInputBox/RadioInputBox.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from "react";
 type Props = {
   name: string;
   description: string;
-  selectedInput?: string | null;
+  selectedInput?: null | string;
   onSelect: (inputName: string) => void;
   children: ReactNode;
 };

--- a/src/components/RelationIcon/RelationIcon.tsx
+++ b/src/components/RelationIcon/RelationIcon.tsx
@@ -6,8 +6,8 @@ import type { WatcherModelData } from "juju/types";
 type Props = {
   applicationName: string;
   applications:
-    | WatcherModelData["applications"]
-    | Record<string, ApplicationStatus>;
+    | Record<string, ApplicationStatus>
+    | WatcherModelData["applications"];
 };
 
 const RelationIcon = ({ applicationName, applications }: Props) => {

--- a/src/components/Routes/types.ts
+++ b/src/components/Routes/types.ts
@@ -17,6 +17,6 @@ export type ModelIndexRoute = {
 /**
  * Parameters available at `/models/:userName/:modelName/app/:appName` (`urls.model.app.index`).
  */
-export type ModelAppRoute = ModelIndexRoute & {
+export type ModelAppRoute = {
   appName: string;
-};
+} & ModelIndexRoute;

--- a/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/src/components/SegmentedControl/SegmentedControl.tsx
@@ -6,8 +6,8 @@ import type { ComponentType, ElementType, HTMLProps, JSX } from "react";
 type Props<P = ButtonProps> = PropsWithSpread<
   {
     buttons: ({ key: string } & P)[];
-    buttonComponent?: ElementType | ComponentType<P>;
-    activeButton?: string | null;
+    buttonComponent?: ComponentType<P> | ElementType;
+    activeButton?: null | string;
   },
   HTMLProps<HTMLDivElement>
 >;

--- a/src/components/ShareCard/ShareCard.tsx
+++ b/src/components/ShareCard/ShareCard.tsx
@@ -11,7 +11,7 @@ import { Label } from "./types";
 
 type Props = {
   userName: string;
-  lastConnected: string | null;
+  lastConnected: null | string;
   access: string;
   isOwner: boolean;
   removeUser: (userName: string) => void;
@@ -44,7 +44,7 @@ export default function ShareCard({
     };
   }, [showStatus]);
 
-  const getStatusIconClassNames = (status: string | null) => {
+  const getStatusIconClassNames = (status: null | string) => {
     let classNames = "";
     switch (status) {
       case "Updating":

--- a/src/components/Status/Status.tsx
+++ b/src/components/Status/Status.tsx
@@ -4,11 +4,11 @@ import type { PropsWithChildren } from "react";
 
 type Props = {
   status?: string;
-  count?: number | null;
+  count?: null | number;
   inline?: boolean;
   useIcon?: boolean;
   actionsLogs?: boolean;
-  className?: string | null;
+  className?: null | string;
 } & PropsWithChildren;
 
 const Status = ({

--- a/src/components/ToastCard/ToastCard.tsx
+++ b/src/components/ToastCard/ToastCard.tsx
@@ -14,7 +14,7 @@ export type ToastInstance = {
 
 type Props = {
   toastInstance: ToastInstance;
-  type: "positive" | "caution" | "negative";
+  type: "caution" | "negative" | "positive";
   undo?: () => void;
 } & PropsWithChildren;
 
@@ -24,7 +24,7 @@ export default function ToastCard({
   type,
   undo,
 }: Props) {
-  let iconName: string | null = null;
+  let iconName: null | string = null;
   switch (type) {
     case "positive":
       iconName = "success";

--- a/src/components/Topology/Topology.tsx
+++ b/src/components/Topology/Topology.tsx
@@ -14,15 +14,15 @@ import { generateIconPath } from "store/juju/utils/models";
 type Props = {
   annotations: AnnotationData | null;
   applications: ApplicationData | null;
-  relations: RelationData | null;
+  relations: null | RelationData;
   width: number;
   height: number;
 };
 
-type Application = ApplicationInfo & {
+type Application = {
   name: string;
   annotations: AnnotationData[0];
-};
+} & ApplicationInfo;
 
 /**
   Returns whether the application is a subordinate.
@@ -40,8 +40,8 @@ const isSubordinate = (app: Application) =>
   @returns The deltas for x and y in the keys { deltaX, deltaY }.
 */
 const computePositionDelta = (annotations: AnnotationData | null) => {
-  let deltaX: number | null = null;
-  let deltaY: number | null = null;
+  let deltaX: null | number = null;
+  let deltaY: null | number = null;
 
   if (!annotations) {
     return { deltaX, deltaY };
@@ -97,8 +97,8 @@ const computeMaxXY = (annotations: AnnotationData | null) => {
   @returns The position value with the delta applied.
 */
 const applyDelta = (
-  position: number | string | null = null,
-  delta: number | string | null = null,
+  position: null | number | string = null,
+  delta: null | number | string = null,
 ) =>
   (typeof position === "number"
     ? position

--- a/src/components/TruncatedTooltip/TruncatedTooltip.tsx
+++ b/src/components/TruncatedTooltip/TruncatedTooltip.tsx
@@ -13,10 +13,10 @@ type Props = {
   tooltipClassName?: TooltipProps["tooltipClassName"];
   positionElementClassName?: TooltipProps["positionElementClassName"];
   wrapperClassName?: string;
-  element?: ElementType | ComponentType;
+  element?: ComponentType | ElementType;
   elementProps?: HTMLProps<HTMLElement>;
-} & TooltipProps &
-  PropsWithChildren;
+} & PropsWithChildren &
+  TooltipProps;
 
 /**
    This tooltip has a special power, it only appears if the content is truncated.

--- a/src/components/WebCLI/Output/OutputCommand/types.ts
+++ b/src/components/WebCLI/Output/OutputCommand/types.ts
@@ -3,6 +3,6 @@ import type { HistoryItem } from "store/juju/types";
 import type { ProcessOutput, TableLinks } from "../../Output/types";
 
 export type Props = {
-  processOutput?: ProcessOutput | null;
-  tableLinks?: TableLinks | null;
+  processOutput?: null | ProcessOutput;
+  tableLinks?: null | TableLinks;
 } & HistoryItem;

--- a/src/components/WebCLI/Output/types.ts
+++ b/src/components/WebCLI/Output/types.ts
@@ -26,10 +26,10 @@ export type Column = {
 
 export type TableLinksLink =
   | {
-      link: string;
+      externalLink: string;
     }
   | {
-      externalLink: string;
+      link: string;
     };
 
 type TableLinksGenerateLink = (column: Column, row: Column[]) => TableLinksLink;
@@ -60,8 +60,8 @@ export type Props = {
   content: HistoryItem[];
   helpMessage: ReactNode;
   loading?: boolean;
-  processOutput?: ProcessOutput | null;
-  tableLinks?: TableLinks | null;
+  processOutput?: null | ProcessOutput;
+  tableLinks?: null | TableLinks;
   showHelp: boolean;
   setShouldShowHelp: (showHelp: boolean) => void;
 };

--- a/src/components/WebCLI/WebCLI.tsx
+++ b/src/components/WebCLI/WebCLI.tsx
@@ -27,7 +27,7 @@ type Props = {
   history?: CommandHistory;
   modelUUID: string;
   onCommandSent: (command?: string) => void;
-  activeUser?: string | null;
+  activeUser?: null | string;
   onHistoryChange?: (modelUUID: string, historyItem: HistoryItem) => void;
   /**
    * When overriding this function then ANSI codes need to be manually handled.
@@ -62,7 +62,7 @@ const WebCLI = ({
   const [inlineErrors, setInlineError, hasInlineError] = useInlineErrors();
   const inputRef = useRef<HTMLInputElement>(null);
   const [output, setOutput] = useState<CommandHistory>(history || {});
-  const lastCommand = useRef<string | null>(null);
+  const lastCommand = useRef<null | string>(null);
   const [cliHistory, setCLIHistory] = useLocalStorage<string[]>(
     "cliHistory",
     [],
@@ -242,7 +242,7 @@ const WebCLI = ({
     }
   };
 
-  const showHelp = (event: React.MouseEvent | React.KeyboardEvent) => {
+  const showHelp = (event: React.KeyboardEvent | React.MouseEvent) => {
     // Only trigger the help from the space or enter keys (or mouse clicks).
     if ("key" in event && !["Enter", " "].includes(event.key)) {
       return;

--- a/src/components/WebCLI/connection.ts
+++ b/src/components/WebCLI/connection.ts
@@ -21,7 +21,7 @@ class Connection {
   #wsOnOpen: () => void;
   #wsOnClose: () => void;
   #wsOnError: (error: Event | string) => void;
-  #ws: WebSocket | null = null;
+  #ws: null | WebSocket = null;
 
   constructor(options: Options) {
     this.#messageCallback = options.messageCallback;

--- a/src/components/hooks.ts
+++ b/src/components/hooks.ts
@@ -20,7 +20,7 @@ import getUserName from "utils/getUserName";
 
 type NameProps = {
   modelName: string;
-  ownerTag?: string | null;
+  ownerTag?: null | string;
   uuid?: never;
 };
 
@@ -98,7 +98,7 @@ export const useStatusView = (statusView: StatusView) => {
 export const useCleanupOnUnmount = <P>(
   cleanupAction: ActionCreatorWithPayload<P>,
   cleanupEnabled: boolean = false,
-  payload: P | null = null,
+  payload: null | P = null,
 ) => {
   const dispatch = useDispatch();
   const cleanupPayload = useRef<(() => void) | null>(null);

--- a/src/components/secrets/SecretForm/SecretForm.tsx
+++ b/src/components/secrets/SecretForm/SecretForm.tsx
@@ -37,8 +37,8 @@ import { TestId, type FormFields } from "./types";
 
 type Props = {
   formId: string;
-  onSuccess: (secret: string | null) => void;
-  secretURI?: string | null;
+  onSuccess: (secret: null | string) => void;
+  secretURI?: null | string;
   setSaving: (saving: boolean) => void;
   update?: boolean;
 };
@@ -83,7 +83,7 @@ const SecretForm = ({
   const wsControllerURL =
     useAppSelector((state) => getModelByUUID(state, modelUUID))
       ?.wsControllerURL ?? null;
-  const [inlineError, setInlineError] = useState<string | null>(null);
+  const [inlineError, setInlineError] = useState<null | string>(null);
   const existingContent = useAppSelector((state) =>
     getSecretsContent(state, modelUUID),
   );
@@ -185,7 +185,7 @@ const SecretForm = ({
                   } as CreateSecretArg,
                 ])
             )
-              .then((response: StringResults | ErrorResults) => {
+              .then((response: ErrorResults | StringResults) => {
                 const result = response.results?.[0];
                 if (result?.error) {
                   throw new Error(result.error.message);

--- a/src/hooks/useCanConfigureModel.ts
+++ b/src/hooks/useCanConfigureModel.ts
@@ -10,7 +10,7 @@ import { canAdministerModel } from "store/juju/utils/models";
 import { useAppSelector } from "store/store";
 
 const useCheckJujuPermissions = (
-  modelUUID?: string | null,
+  modelUUID?: null | string,
   enabled: boolean = false,
 ) => {
   const activeUser = useAppSelector((state) => getActiveUser(state, modelUUID));
@@ -24,7 +24,7 @@ const useCheckJujuPermissions = (
 };
 
 const useCheckJIMMPermissions = (
-  modelUUID?: string | null,
+  modelUUID?: null | string,
   enabled: boolean = false,
   cleanup: boolean = false,
 ) => {
@@ -44,7 +44,7 @@ const useCheckJIMMPermissions = (
 
 export const useCanConfigureModelWithUUID = (
   cleanup?: boolean,
-  modelUUID: string | null = null,
+  modelUUID: null | string = null,
 ) => {
   const isJuju = useAppSelector(getIsJuju);
   const jujuPermissions = useCheckJujuPermissions(modelUUID, isJuju);
@@ -54,8 +54,8 @@ export const useCanConfigureModelWithUUID = (
 
 const useCanConfigureModel = (
   cleanup?: boolean,
-  modelName: string | null = null,
-  userName: string | null = null,
+  modelName: null | string = null,
+  userName: null | string = null,
 ) => {
   const params = useParams<EntityDetailsRoute>();
   userName = userName ?? params.userName ?? null;

--- a/src/hooks/useModelAccess.ts
+++ b/src/hooks/useModelAccess.ts
@@ -34,7 +34,7 @@ const getHighestAccess = (relations: ReBACAllowed[]) => {
 };
 
 const useModelAccess = (
-  modelUUID: string | null = null,
+  modelUUID: null | string = null,
   cleanup: boolean = false,
 ) => {
   const isJuju = useAppSelector(getIsJuju);

--- a/src/hooks/useModelStatus.ts
+++ b/src/hooks/useModelStatus.ts
@@ -5,8 +5,8 @@ import { getModelUUID, getModelStatus } from "store/juju/selectors";
 import { useAppSelector } from "store/store";
 
 // Return model status data based on model name in URL
-export default function useModelStatus(modelUUID: string | null = null) {
-  let modelName: string | null;
+export default function useModelStatus(modelUUID: null | string = null) {
+  let modelName: null | string;
   ({ modelName = null } = useParams());
 
   // if model name cannot be derived from URL params, fallback and check for

--- a/src/hooks/useQueryParams.test.tsx
+++ b/src/hooks/useQueryParams.test.tsx
@@ -11,7 +11,7 @@ describe("useQueryParams", () => {
 
   it("can return default string params", () => {
     const { result } = renderWrappedHook(() =>
-      useQueryParams<{ panel: string | null }>({ panel: "config" }),
+      useQueryParams<{ panel: null | string }>({ panel: "config" }),
     );
     const [searchParams] = result.current;
     expect(searchParams.panel).toBe("config");
@@ -27,7 +27,7 @@ describe("useQueryParams", () => {
 
   it("can return string params from the URL", () => {
     const { result } = renderWrappedHook(
-      () => useQueryParams<{ panel: string | null }>({ panel: null }),
+      () => useQueryParams<{ panel: null | string }>({ panel: null }),
       { url: "?panel=config" },
     );
     const [searchParams] = result.current;
@@ -56,7 +56,7 @@ describe("useQueryParams", () => {
 
   it("can set string params", () => {
     const { result, router } = renderWrappedHook(() =>
-      useQueryParams<{ panel: string | null }>({ panel: null }),
+      useQueryParams<{ panel: null | string }>({ panel: null }),
     );
     let [searchParams] = result.current;
     const [, setSearchParams] = result.current;
@@ -85,7 +85,7 @@ describe("useQueryParams", () => {
   it("can clear a param", () => {
     const { result, router } = renderWrappedHook(
       () =>
-        useQueryParams<{ panel: string | null; other: string | null }>({
+        useQueryParams<{ panel: null | string; other: null | string }>({
           panel: null,
           other: null,
         }),
@@ -102,7 +102,7 @@ describe("useQueryParams", () => {
 
   it("can clear all params", () => {
     const { result, router } = renderWrappedHook(
-      () => useQueryParams<{ panel: string | null }>({ panel: null }),
+      () => useQueryParams<{ panel: null | string }>({ panel: null }),
       { url: "?panel=config" },
     );
     let [searchParams] = result.current;
@@ -116,7 +116,7 @@ describe("useQueryParams", () => {
 
   it("should sanitize existing query params value", () => {
     const { result } = renderWrappedHook(
-      () => useQueryParams<{ xss: string | null }>({ xss: null }),
+      () => useQueryParams<{ xss: null | string }>({ xss: null }),
       { url: "?xss=<img src=x onerror=alert(1)//>" },
     );
     const [searchParams] = result.current;
@@ -127,7 +127,7 @@ describe("useQueryParams", () => {
     const { result, router } = renderWrappedHook(
       () =>
         useQueryParams<{
-          panel: string | null;
+          panel: null | string;
         }>({
           panel: null,
         }),
@@ -148,7 +148,7 @@ describe("useQueryParams", () => {
 
   it("should sanitize query params value after changing it", () => {
     const { result } = renderWrappedHook(() =>
-      useQueryParams<{ xss: string | null }>({ xss: null }),
+      useQueryParams<{ xss: null | string }>({ xss: null }),
     );
     let [searchParams] = result.current;
     expect(searchParams.xss).toStrictEqual(null);

--- a/src/hooks/useQueryParams.ts
+++ b/src/hooks/useQueryParams.ts
@@ -7,7 +7,7 @@ import { useSearchParams } from "react-router";
 import { logger } from "utils/logger";
 
 export type SetParams<P> = (
-  params?: Partial<P> | null,
+  params?: null | Partial<P>,
   options?: NavigateOptions,
 ) => void;
 
@@ -21,7 +21,7 @@ export const useQueryParams = <P extends QueryParams>(
   const [searchParams, setSearchParams] = useSearchParams();
 
   const setParam = useCallback(
-    (newParams?: Partial<P> | null, options?: NavigateOptions) => {
+    (newParams?: null | Partial<P>, options?: NavigateOptions) => {
       if (!newParams) {
         // If this is call with no params then clear all.
         Array.from(searchParams.keys()).forEach((key) =>

--- a/src/hooks/useWindowTitle.ts
+++ b/src/hooks/useWindowTitle.ts
@@ -4,7 +4,7 @@ import { useEffect } from "react";
  * Set the browser window title.
  * @param title - The title to set.
  */
-export default function useWindowTitle(title: string | null = null) {
+export default function useWindowTitle(title: null | string = null) {
   const titlePart = title !== null && title ? `${title} | ` : "";
   useEffect(() => {
     document.title = `${titlePart}Juju Dashboard`;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -38,7 +38,7 @@ if (
 
 const addressRegex = new RegExp(/^ws[s]?:\/\/(\S+)\//);
 export const getControllerAPIEndpointErrors = (
-  controllerAPIEndpoint: string | null = null,
+  controllerAPIEndpoint: null | string = null,
 ) => {
   if (controllerAPIEndpoint === null || !controllerAPIEndpoint) {
     return "controllerAPIEndpoint is not set.";
@@ -95,7 +95,7 @@ function bootstrap() {
 
   logger.setDefaultLevel(logLevel);
 
-  let error: string | null = null;
+  let error: null | string = null;
   if (!config) {
     error = Label.NO_CONFIG;
   }

--- a/src/juju/api-hooks/actions.ts
+++ b/src/juju/api-hooks/actions.ts
@@ -14,8 +14,8 @@ export enum Label {
 }
 
 export const useGetActionsForApplication = (
-  userName: string | null = null,
-  modelName: string | null = null,
+  userName: null | string = null,
+  modelName: null | string = null,
 ) => {
   const handler = useCallback(
     (connection: ConnectionWithFacades, appName: string) => {
@@ -32,8 +32,8 @@ export const useGetActionsForApplication = (
 };
 
 export const useExecuteActionOnUnits = (
-  userName: string | null = null,
-  modelName: string | null = null,
+  userName: null | string = null,
+  modelName: null | string = null,
 ) => {
   const handler = useCallback(
     (
@@ -63,8 +63,8 @@ export const useExecuteActionOnUnits = (
 };
 
 export const useQueryOperationsList = (
-  userName: string | null = null,
-  modelName: string | null = null,
+  userName: null | string = null,
+  modelName: null | string = null,
 ) => {
   const handler = useCallback(
     (
@@ -91,8 +91,8 @@ export const useQueryOperationsList = (
 };
 
 export const useQueryActionsList = (
-  userName: string | null = null,
-  modelName: string | null = null,
+  userName: null | string = null,
+  modelName: null | string = null,
 ) => {
   const handler = useCallback(
     (connection: ConnectionWithFacades, queryArgs: Entities) => {

--- a/src/juju/api-hooks/application.ts
+++ b/src/juju/api-hooks/application.ts
@@ -11,8 +11,8 @@ export enum Label {
 }
 
 export const useGetApplicationConfig = (
-  userName: string | null = null,
-  modelName: string | null = null,
+  userName: null | string = null,
+  modelName: null | string = null,
 ) => {
   const handler = useCallback(
     (connection: ConnectionWithFacades, appName: string) => {
@@ -30,8 +30,8 @@ export const useGetApplicationConfig = (
 };
 
 export const useSetApplicationConfig = (
-  userName: string | null = null,
-  modelName: string | null = null,
+  userName: null | string = null,
+  modelName: null | string = null,
 ) => {
   const handler = useCallback(
     (connection: ConnectionWithFacades, appName: string, config: Config) => {

--- a/src/juju/api-hooks/common.ts
+++ b/src/juju/api-hooks/common.ts
@@ -25,7 +25,7 @@ type CallHandler<R, A extends unknown[]> =
   | ((connection: ConnectionWithFacades, ...args: A) => Promise<R>)
   | ((connection: ConnectionWithFacades) => Promise<R>);
 
-export const useModelConnectionCallback = (modelUUID: string | null = null) => {
+export const useModelConnectionCallback = (modelUUID: null | string = null) => {
   const wsControllerURL =
     useAppSelector((state) => getModelByUUID(state, modelUUID))
       ?.wsControllerURL ?? null;
@@ -64,8 +64,8 @@ export const useModelConnectionCallback = (modelUUID: string | null = null) => {
 
 export const useCallWithConnectionPromise = <R, A extends unknown[]>(
   handler: CallHandler<R, A>,
-  userName: string | null,
-  modelName: string | null,
+  userName: null | string,
+  modelName: null | string,
 ) => {
   const modelUUID = useAppSelector((state) =>
     getModelUUIDFromList(state, modelName, userName),
@@ -93,8 +93,8 @@ export const useCallWithConnection = <R, A extends unknown[]>(
   handler: CallHandler<R, A>,
   onSuccess: (response: R) => void,
   onError: (error: string) => void,
-  userName: string | null = null,
-  modelName: string | null = null,
+  userName: null | string = null,
+  modelName: null | string = null,
 ) => {
   const callbackHandler = useCallback(
     (connection: ConnectionWithFacades, ...args: A) => {

--- a/src/juju/api-hooks/permissions.test.tsx
+++ b/src/juju/api-hooks/permissions.test.tsx
@@ -900,7 +900,7 @@ describe("useCheckRelations", () => {
     const [store, actions] = createStore(state, { trackActions: true });
     const { rerender } = renderHook<
       {
-        permissions?: ReBACAllowed[] | null;
+        permissions?: null | ReBACAllowed[];
         loading: boolean;
         loaded: boolean;
       },

--- a/src/juju/api-hooks/permissions.ts
+++ b/src/juju/api-hooks/permissions.ts
@@ -27,7 +27,7 @@ import {
 import { useAppSelector } from "store/store";
 
 export const useReBAC = <A, C>(
-  fetchAction: ActionCreatorWithPayload<A & { wsControllerURL: string }>,
+  fetchAction: ActionCreatorWithPayload<{ wsControllerURL: string } & A>,
   cleanupAction: ActionCreatorWithPayload<C>,
   loading: boolean,
   loaded: boolean,
@@ -89,7 +89,7 @@ export const useReBAC = <A, C>(
 };
 
 export const useCheckPermissions = (
-  tuple?: RelationshipTuple | null,
+  tuple?: null | RelationshipTuple,
   cleanup?: boolean,
 ) => {
   const permitted = useAppSelector((state) => hasReBACPermission(state, tuple));
@@ -160,7 +160,7 @@ export const useAuditLogsPermitted = (cleanup?: boolean) => {
 
 export const useCheckRelations = (
   requestId: string,
-  tuples?: RelationshipTuple[] | null,
+  tuples?: null | RelationshipTuple[],
   cleanup?: boolean,
 ) => {
   const loaded = useAppSelector((state) =>

--- a/src/juju/api-hooks/secrets.ts
+++ b/src/juju/api-hooks/secrets.ts
@@ -22,8 +22,8 @@ export enum Label {
 }
 
 export const useListSecrets = (
-  userName: string | null = null,
-  modelName: string | null = null,
+  userName: null | string = null,
+  modelName: null | string = null,
 ) => {
   const dispatch = useAppDispatch();
   const modelUUID = useAppSelector((state) =>
@@ -88,8 +88,8 @@ export const useListSecrets = (
 };
 
 export const useGetSecretContent = (
-  userName: string | null = null,
-  modelName: string | null = null,
+  userName: null | string = null,
+  modelName: null | string = null,
 ) => {
   const dispatch = useAppDispatch();
   const modelUUID = useAppSelector((state) =>
@@ -170,8 +170,8 @@ export const useGetSecretContent = (
 };
 
 export const useCreateSecrets = (
-  userName: string | null = null,
-  modelName: string | null = null,
+  userName: null | string = null,
+  modelName: null | string = null,
 ) => {
   const handleCreate = useCallback(
     (connection: ConnectionWithFacades, secrets: CreateSecretArgs["args"]) => {
@@ -188,8 +188,8 @@ export const useCreateSecrets = (
 };
 
 export const useUpdateSecrets = (
-  userName: string | null = null,
-  modelName: string | null = null,
+  userName: null | string = null,
+  modelName: null | string = null,
 ) => {
   const handler = useCallback(
     (
@@ -207,8 +207,8 @@ export const useUpdateSecrets = (
 };
 
 export const useRemoveSecrets = (
-  userName: string | null = null,
-  modelName: string | null = null,
+  userName: null | string = null,
+  modelName: null | string = null,
 ) => {
   const handler = useCallback(
     (
@@ -231,8 +231,8 @@ export const useRemoveSecrets = (
 };
 
 export const useGrantSecret = (
-  userName: string | null = null,
-  modelName: string | null = null,
+  userName: null | string = null,
+  modelName: null | string = null,
 ) => {
   const handler = useCallback(
     (
@@ -259,8 +259,8 @@ export const useGrantSecret = (
 };
 
 export const useRevokeSecret = (
-  userName: string | null = null,
-  modelName: string | null = null,
+  userName: null | string = null,
+  modelName: null | string = null,
 ) => {
   const handler = useCallback(
     (

--- a/src/juju/api.ts
+++ b/src/juju/api.ts
@@ -149,9 +149,9 @@ export async function loginWithBakery(
   return { conn, juju, intervalId };
 }
 
-export type LoginResponse = Awaited<ReturnType<typeof connectAndLogin>> & {
+export type LoginResponse = {
   conn?: ConnectionWithFacades;
-};
+} & Awaited<ReturnType<typeof connectAndLogin>>;
 
 /**
   Connects and logs in to the supplied modelURL. If the connection takes longer

--- a/src/juju/jimm/JIMMV3.ts
+++ b/src/juju/jimm/JIMMV3.ts
@@ -21,7 +21,7 @@ export type ControllerInfo = {
 // https://github.com/canonical/jimm/blob/1da76ed2d8dba741f5880f32c073f85f7d518904/api/params/params.go#L92
 export type AuditEvent<P = unknown, E = unknown> = {
   "conversation-id": string;
-  errors?: Record<string, E> | null;
+  errors?: null | Record<string, E>;
   "facade-method"?: string;
   "facade-name"?: string;
   "facade-version"?: number;
@@ -29,7 +29,7 @@ export type AuditEvent<P = unknown, E = unknown> = {
   "message-id": number;
   model?: string;
   "object-id"?: string;
-  params?: Record<string, P> | null;
+  params?: null | Record<string, P>;
   time: string;
   "user-tag": string;
 };

--- a/src/juju/types.ts
+++ b/src/juju/types.ts
@@ -66,10 +66,10 @@ export type AllWatcherDelta =
     ]
   | [DeltaEntityTypes.APPLICATION, DeltaChangeTypes, ApplicationChangeDelta]
   | [DeltaEntityTypes.CHARM, DeltaChangeTypes, CharmChangeDelta]
-  | [DeltaEntityTypes.UNIT, DeltaChangeTypes, UnitChangeDelta]
   | [DeltaEntityTypes.MACHINE, DeltaChangeTypes, MachineChangeDelta]
   | [DeltaEntityTypes.MODEL, DeltaChangeTypes.CHANGE, ModelChangeDelta]
-  | [DeltaEntityTypes.RELATION, DeltaChangeTypes, RelationChangeDelta];
+  | [DeltaEntityTypes.RELATION, DeltaChangeTypes, RelationChangeDelta]
+  | [DeltaEntityTypes.UNIT, DeltaChangeTypes, UnitChangeDelta];
 
 export enum DeltaEntityTypes {
   ACTION = "action",
@@ -132,19 +132,19 @@ interface AnnotatedApplicationInfo extends ApplicationChangeDelta {
 }
 
 export type ApplicationInfo =
-  | AnnotatedApplicationInfo
-  // It's possible the unit count is returned before the application info in
-  // which case only the unit count will exist in the store.
   | {
       "unit-count": number;
-    };
+    }
+  // It's possible the unit count is returned before the application info in
+  // which case only the unit count will exist in the store.
+  | AnnotatedApplicationInfo;
 
 // Shared Types
 
 type IPAddress = string;
 type UnitId = string;
 type NumberAsString = string;
-type Life = "alive" | "dead" | "dying" | "";
+type Life = "" | "alive" | "dead" | "dying";
 type ISO8601Date = string;
 type DeprecatedString = string;
 export interface Status {
@@ -158,7 +158,7 @@ export interface Status {
   data?: { [key: string]: unknown };
   err?: string;
 }
-type Config = { [key: string]: string | boolean };
+type Config = { [key: string]: boolean | string };
 type LXDProfile = {
   config?: Config;
   description?: string;
@@ -228,7 +228,7 @@ export interface MachineChangeDelta {
   life: Life;
   "model-uuid": string;
   series: string;
-  "supported-containers": ["none" | "lxd" | "kvm"] | null;
+  "supported-containers": ["kvm" | "lxd" | "none"] | null;
   "supported-containers-known": boolean;
   "wants-vote": boolean;
 }
@@ -240,7 +240,7 @@ export interface MachineAgentStatus extends Status {
 export interface AddressData {
   value: IPAddress;
   type: "ipv4" | "ipv6";
-  scope: "public" | "local-cloud" | "local-fan" | "local-machine";
+  scope: "local-cloud" | "local-fan" | "local-machine" | "public";
 }
 
 export interface HardwareCharacteristics {
@@ -265,17 +265,17 @@ type Pre32ModelChangeDelta = {
   sla: ModelSLAInfo;
 };
 
-type Post32ModelChangeDelta = Pre32ModelChangeDelta & {
+type Post32ModelChangeDelta = {
   cloud: string;
   "cloud-region": string;
   type: string;
   version: string;
-};
+} & Pre32ModelChangeDelta;
 
-export type ModelChangeDelta = Pre32ModelChangeDelta | Post32ModelChangeDelta;
+export type ModelChangeDelta = Post32ModelChangeDelta | Pre32ModelChangeDelta;
 
 export interface ModelAgentStatus extends Status {
-  current: "available" | "busy" | "";
+  current: "" | "available" | "busy";
 }
 
 export interface RelationChangeDelta {
@@ -287,11 +287,11 @@ export interface RelationChangeDelta {
 
 export interface EndpointRelation {
   name: string;
-  role: "peer" | "requirer" | "provider";
+  role: "peer" | "provider" | "requirer";
   interface: string;
   optional: boolean;
   limit: number;
-  scope: "global" | "container";
+  scope: "container" | "global";
 }
 
 export interface Endpoint {
@@ -354,9 +354,9 @@ export type FullStatusAnnotations = Record<
   AnnotationsGetResult["annotations"]
 >;
 
-export type FullStatusWithAnnotations = FullStatus & {
+export type FullStatusWithAnnotations = {
   annotations?: FullStatusAnnotations;
-};
+} & FullStatus;
 
 export type Facades = {
   action?: ActionV7;
@@ -373,6 +373,6 @@ export type Facades = {
   jimM?: InstanceType<typeof JIMMV4>;
 };
 
-export type ConnectionWithFacades = Connection & {
+export type ConnectionWithFacades = {
   facades: Facades;
-};
+} & Connection;

--- a/src/layout/BaseLayout/BaseLayout.tsx
+++ b/src/layout/BaseLayout/BaseLayout.tsx
@@ -24,7 +24,7 @@ const BaseLayout = () => {
   const location = useLocation();
   const isOffline = useOffline();
   const isJuju = useAppSelector(getIsJuju);
-  const [status, setStatus] = useState<StatusView | null>(null);
+  const [status, setStatus] = useState<null | StatusView>(null);
   const sendAnalytics = useAnalytics();
 
   useFeatureFlags();

--- a/src/layout/BaseLayout/types.ts
+++ b/src/layout/BaseLayout/types.ts
@@ -5,5 +5,5 @@ export enum Label {
 }
 
 export type BaseLayoutContext = {
-  setStatus: (status: StatusView | null) => void;
+  setStatus: (status: null | StatusView) => void;
 };

--- a/src/layout/Status/types.ts
+++ b/src/layout/Status/types.ts
@@ -3,5 +3,5 @@ export enum StatusView {
 }
 
 export type Props = {
-  status?: StatusView | null;
+  status?: null | StatusView;
 };

--- a/src/pages/AdvancedSearch/CodeSnippetBlock/CodeSnippetBlock.tsx
+++ b/src/pages/AdvancedSearch/CodeSnippetBlock/CodeSnippetBlock.tsx
@@ -19,7 +19,7 @@ import Value from "./Value";
 type Props = {
   className: string;
   title: string;
-  code: CrossModelQueryResponse["results"] | CrossModelQueryResponse["errors"];
+  code: CrossModelQueryResponse["errors"] | CrossModelQueryResponse["results"];
 };
 
 const DEFAULT_THEME_COLOUR = "#00000099";

--- a/src/pages/AdvancedSearch/CodeSnippetBlock/Label/utils.ts
+++ b/src/pages/AdvancedSearch/CodeSnippetBlock/Label/utils.ts
@@ -1,7 +1,7 @@
 import { ModelTab } from "urls";
 
 export const getTab = (
-  key: "applications" | "offers" | "machines" | "relations",
+  key: "applications" | "machines" | "offers" | "relations",
 ) => {
   switch (key) {
     case "applications":

--- a/src/pages/AdvancedSearch/CodeSnippetBlock/Value/Value.tsx
+++ b/src/pages/AdvancedSearch/CodeSnippetBlock/Value/Value.tsx
@@ -13,7 +13,7 @@ type Props = {
   valueAsString: unknown;
   value: unknown;
   keyPath: KeyPath;
-  code: CrossModelQueryResponse["results"] | CrossModelQueryResponse["errors"];
+  code: CrossModelQueryResponse["errors"] | CrossModelQueryResponse["results"];
 };
 
 // Use a key path to get the parent object that contains the current item from the results data.
@@ -30,7 +30,7 @@ const getCurrentObject = (
     .reverse()
     // This reduce follows the keypath by returning the next child until it
     // finally reaches the end.
-    .reduce<object | null>((current, key) => {
+    .reduce<null | object>((current, key) => {
       // Check that the current item in the path is a valid object.
       if (current && typeof current === "object" && key in current) {
         const inner = current[key as keyof typeof current];

--- a/src/pages/AdvancedSearch/ResultsModelLink/ResultsModelLink.tsx
+++ b/src/pages/AdvancedSearch/ResultsModelLink/ResultsModelLink.tsx
@@ -8,7 +8,7 @@ import type {
 } from "components/ModelDetailsLink/ModelDetailsLink";
 
 type Props = PropsWithSpread<
-  UUIDProps & PropsWithChildren,
+  PropsWithChildren & UUIDProps,
   ModelDetailsLinkProps
 >;
 

--- a/src/pages/ControllersIndex/ControllersIndex.tsx
+++ b/src/pages/ControllersIndex/ControllersIndex.tsx
@@ -33,13 +33,13 @@ import { breakLines } from "utils";
 import ControllersOverview from "./ControllerOverview";
 import { Label, TestId } from "./types";
 
-type AnnotatedController = Controller & {
+type AnnotatedController = {
   models: number;
   machines: number;
   applications: number;
   units: number;
   wsControllerURL: string;
-};
+} & Controller;
 
 const ControllersIndex = () => {
   const controllersCount = useAppSelector(getControllersCount);
@@ -154,7 +154,7 @@ const ControllersIndex = () => {
     controller: AnnotatedController,
     authenticated: boolean,
   ) => {
-    let cloud: string | null = "unknown";
+    let cloud: null | string = "unknown";
     if ("cloud-tag" in controller && Boolean(controller["cloud-tag"])) {
       cloud = controller["cloud-tag"] ?? null;
     } else if (
@@ -210,7 +210,7 @@ const ControllersIndex = () => {
       { content: controller.units },
       { content: "" },
     ];
-    let version: string | null = null;
+    let version: null | string = null;
     if ("agent-version" in controller && controller["agent-version"]) {
       version = controller["agent-version"];
     }

--- a/src/pages/EntityDetails/App/App.tsx
+++ b/src/pages/EntityDetails/App/App.tsx
@@ -165,10 +165,10 @@ export default function App(): JSX.Element {
   const [query, setQuery] = useQueryParams<{
     tableView: string;
     activeView: string;
-    charm: string | null;
-    entity: string | null;
-    modelUUID: string | null;
-    panel: string | null;
+    charm: null | string;
+    entity: null | string;
+    modelUUID: null | string;
+    panel: null | string;
     units: string[];
   }>({
     tableView: "units",

--- a/src/pages/EntityDetails/EntityDetails.tsx
+++ b/src/pages/EntityDetails/EntityDetails.tsx
@@ -29,7 +29,7 @@ import ModelTabs from "./Model/ModelTabs";
 import { Label, TestId } from "./types";
 
 type Props = {
-  modelWatcherError?: string | null;
+  modelWatcherError?: null | string;
 };
 
 const getEntityType = (params: Partial<EntityDetailsRoute>) => {

--- a/src/pages/EntityDetails/Model/ApplicationsTab/ApplicationsTab.tsx
+++ b/src/pages/EntityDetails/Model/ApplicationsTab/ApplicationsTab.tsx
@@ -21,10 +21,10 @@ import SearchResults from "./SearchResults/SearchResults";
 
 export default function ApplicationsTab() {
   const [queryParams] = useQueryParams<{
-    entity: string | null;
-    panel: string | null;
+    entity: null | string;
+    panel: null | string;
     activeView: string;
-    filterQuery: string | null;
+    filterQuery: null | string;
   }>({
     panel: null,
     entity: null,

--- a/src/pages/EntityDetails/Model/ApplicationsTab/ContentRevealTitle/ContentRevealTitle.tsx
+++ b/src/pages/EntityDetails/Model/ApplicationsTab/ContentRevealTitle/ContentRevealTitle.tsx
@@ -4,7 +4,7 @@ import { pluralize } from "store/juju/utils/models";
 
 type Props = {
   count: number;
-  subject: "Offer" | "Local application" | "Remote application";
+  subject: "Local application" | "Offer" | "Remote application";
   chips: Chip | null;
 };
 

--- a/src/pages/EntityDetails/Model/ApplicationsTab/LocalAppsTable/AppSearchBox/AppSearchBox.tsx
+++ b/src/pages/EntityDetails/Model/ApplicationsTab/LocalAppsTable/AppSearchBox/AppSearchBox.tsx
@@ -9,7 +9,7 @@ const AppSearchBox = () => {
   const dispatch = useDispatch();
   const [query, setQuery] = useQueryParams<{
     filterQuery: string;
-    filterType: string | null;
+    filterType: null | string;
   }>({
     filterQuery: "",
     filterType: null,

--- a/src/pages/EntityDetails/Model/ApplicationsTab/LocalAppsTable/LocalAppsTable.tsx
+++ b/src/pages/EntityDetails/Model/ApplicationsTab/LocalAppsTable/LocalAppsTable.tsx
@@ -42,10 +42,10 @@ const LocalAppsTable = ({ applications = null }: Props) => {
   const selectedApplications = useAppSelector(getSelectedApplications);
   const canConfigureModel = useCanConfigureModel();
   const [queryParams, setQueryParams] = useQueryParams<{
-    entity: string | null;
-    panel: string | null;
+    entity: null | string;
+    panel: null | string;
     activeView: string;
-    filterQuery: string | null;
+    filterQuery: null | string;
   }>({
     panel: null,
     entity: null,

--- a/src/pages/EntityDetails/Model/Logs/ActionLogs/ActionLogs.tsx
+++ b/src/pages/EntityDetails/Model/Logs/ActionLogs/ActionLogs.tsx
@@ -51,9 +51,9 @@ type RowCells = {
   status: ReactNode;
 };
 
-type TableRow = RowCells & {
+type TableRow = {
   subRows: RowCells[];
-};
+} & RowCells;
 
 type ApplicationData = {
   charm: string;
@@ -66,8 +66,8 @@ enum InlineErrors {
 function generateAppIcon(
   application: ApplicationData | undefined,
   appName: string,
-  userName: string | null = null,
-  modelName: string | null = null,
+  userName: null | string = null,
+  modelName: null | string = null,
 ) {
   // If the user has executed actions with an application and then removed
   // that application it'll no longer be in the model data so in this
@@ -91,7 +91,7 @@ function generateAppIcon(
   return <>{appName}</>;
 }
 
-const compare = (numA: string | number, numB: string | number) =>
+const compare = (numA: number | string, numB: number | string) =>
   numA === numB ? 0 : numA > numB ? 1 : -1;
 
 const tableSort = (column: string, rowA: Row<RowCells>, rowB: Row<RowCells>) =>
@@ -105,7 +105,7 @@ const generateApplicationRow = (
   modelStatusData: ModelData | null,
   userName: string,
   modelName: string,
-): TableRow | null => {
+): null | TableRow => {
   // The action name is being defined like this because the action name is
   // only contained in the actions array and not on the operation level.
   // Even though at the current time an operation is the same action

--- a/src/pages/EntityDetails/Model/Logs/Logs.tsx
+++ b/src/pages/EntityDetails/Model/Logs/Logs.tsx
@@ -19,8 +19,8 @@ const Logs = () => {
   const isJuju = useAppSelector(getIsJuju);
   const { permitted: auditLogsAllowed } = useAuditLogsPermitted();
   const [{ tableView }, setQueryParams] = useQueryParams<{
-    activeView: string | null;
-    panel: string | null;
+    activeView: null | string;
+    panel: null | string;
     tableView: string;
   }>({
     activeView: null,

--- a/src/pages/EntityDetails/Model/Model.tsx
+++ b/src/pages/EntityDetails/Model/Model.tsx
@@ -61,7 +61,7 @@ const shouldShow = (segment: string, activeView: string) => {
 
 const generateCloudAndRegion = (
   cloudTag: string,
-  region: string | null = null,
+  region: null | string = null,
 ) => {
   if (cloudTag && region !== null && region) {
     return `${extractCloudName(cloudTag)} / ${region}`;
@@ -75,8 +75,8 @@ const Model = () => {
   const { userName = null, modelName = null } = useParams<EntityDetailsRoute>();
 
   const [query] = useQueryParams<{
-    entity: string | null;
-    panel: string | null;
+    entity: null | string;
+    panel: null | string;
     activeView: string;
   }>({
     panel: null,

--- a/src/pages/EntityDetails/Model/Secrets/Secrets.tsx
+++ b/src/pages/EntityDetails/Model/Secrets/Secrets.tsx
@@ -37,7 +37,7 @@ const Secrets = () => {
   const canManageSecrets = useCanManageSecrets();
 
   const [, setQuery] = useQueryParams<{
-    panel: string | null;
+    panel: null | string;
   }>({
     panel: null,
   });

--- a/src/pages/EntityDetails/Model/Secrets/SecretsTable/SecretsTable.tsx
+++ b/src/pages/EntityDetails/Model/Secrets/SecretsTable/SecretsTable.tsx
@@ -43,8 +43,8 @@ const SecretsTable = () => {
     getSecretsLoading(state, modelUUID),
   );
   const [, setQuery] = useQueryParams<{
-    panel: string | null;
-    secret: string | null;
+    panel: null | string;
+    secret: null | string;
   }>({
     panel: null,
     secret: null,

--- a/src/pages/EntityDetails/counts.ts
+++ b/src/pages/EntityDetails/counts.ts
@@ -40,8 +40,8 @@ const generateSecondaryCounts = <M extends ModelData>(
 };
 
 export function generateUnitCounts(
-  units: UnitData | null,
-  applicationName: string | null = null,
+  units: null | UnitData,
+  applicationName: null | string = null,
 ) {
   const counts = {};
   if (units && applicationName !== null && applicationName) {
@@ -59,8 +59,8 @@ export function generateUnitCounts(
 
 export function generateMachineCounts(
   machines: MachineData | null,
-  units: UnitData | null,
-  applicationName: string | null = null,
+  units: null | UnitData,
+  applicationName: null | string = null,
 ) {
   const counts = {};
   if (machines && units && applicationName !== null && applicationName) {
@@ -86,7 +86,7 @@ export function generateMachineCounts(
   @param modelStatusData The modelStatusData from the redux store.
 */
 export const renderCounts = (
-  countType: "localApps" | "relations" | "offers" | "remoteApps",
+  countType: "localApps" | "offers" | "relations" | "remoteApps",
   modelStatusData?: ModelData | null,
 ) => {
   if (!modelStatusData) return null;

--- a/src/pages/ModelDetails/ModelDetails.tsx
+++ b/src/pages/ModelDetails/ModelDetails.tsx
@@ -27,13 +27,13 @@ export default function ModelDetails() {
   const modelUUID = useAppSelector((state) =>
     getModelUUIDFromList(state, modelName, userName),
   );
-  const [modelWatcherError, setModelWatcherError] = useState<string | null>(
+  const [modelWatcherError, setModelWatcherError] = useState<null | string>(
     null,
   );
 
   useEffect(() => {
     let conn: ConnectionWithFacades | null = null;
-    let pingerIntervalId: number | null = null;
+    let pingerIntervalId: null | number = null;
     let watcherHandle: AllWatcherId | null = null;
 
     async function loadFullData() {

--- a/src/panels/ActionsPanel/ActionsPanel.tsx
+++ b/src/panels/ActionsPanel/ActionsPanel.tsx
@@ -31,7 +31,7 @@ import { enableSubmit, onValuesChange } from "./utils";
 type SetSelectedAction = (actionName: string) => void;
 
 type ActionsQueryParams = {
-  panel?: string | null;
+  panel?: null | string;
   units?: string[];
 };
 
@@ -51,9 +51,9 @@ export default function ActionsPanel(): JSX.Element {
     modelName,
   );
   const [selectedAction, setSelectedAction]: [
-    string | null,
+    null | string,
     SetSelectedAction,
-  ] = useState<string | null>(null);
+  ] = useState<null | string>(null);
   const [inlineErrors, setInlineErrors, hasInlineError] = useInlineErrors({
     [InlineErrors.GET_ACTION]: (error) => (
       // If get actions for application fails, we add a button for

--- a/src/panels/ActionsPanel/CharmActionsPanel/CharmActionsPanel.tsx
+++ b/src/panels/ActionsPanel/CharmActionsPanel/CharmActionsPanel.tsx
@@ -36,7 +36,7 @@ export default function CharmActionsPanel({
 }: Props): JSX.Element {
   const [disableSubmit, setDisableSubmit] = useState<boolean>(true);
   const [confirmType, setConfirmType] = useState<ConfirmTypes>(null);
-  const [selectedAction, setSelectedAction] = useState<string | null>(null);
+  const [selectedAction, setSelectedAction] = useState<null | string>(null);
   const actionOptionsValues = useRef<ActionOptionValues>({});
 
   const selectedApplications = useAppSelector((state) =>

--- a/src/panels/ActionsPanel/utils.ts
+++ b/src/panels/ActionsPanel/utils.ts
@@ -36,7 +36,7 @@ export function onValuesChange(
 }
 
 export function enableSubmit(
-  selectedAction: string | null,
+  selectedAction: null | string,
   selectedUnits: string[],
   actionData: ActionData,
   optionsValues: MutableRefObject<ActionOptionValues>,

--- a/src/panels/AuditLogsFilterPanel/AuditLogsFilterPanel.tsx
+++ b/src/panels/AuditLogsFilterPanel/AuditLogsFilterPanel.tsx
@@ -15,14 +15,14 @@ import { Label, TestId, type FormFields } from "./types";
 const AuditLogsFilterPanel = (): JSX.Element => {
   const formId = useId();
   const [, , handleRemovePanelQueryParams] = usePanelQueryParams<{
-    panel: string | null;
+    panel: null | string;
   }>({
     panel: null,
   });
   // These params are handled separately from the values in usePanelQueryParams
   // as they shouldn't be cleared when the panel closes.
   const [queryParams, setQueryParams] = useQueryParams<
-    AuditLogFilters & { page: string | null; panel: string | null }
+    { page: null | string; panel: null | string } & AuditLogFilters
   >({
     ...DEFAULT_AUDIT_LOG_FILTERS,
     page: null,
@@ -74,7 +74,7 @@ const AuditLogsFilterPanel = (): JSX.Element => {
             // useQueryParams hook will remove null or undefined values, but
             // keeps the queryParam if it is an empty string).
             const filtersWithNull = Object.entries(values).reduce<
-              Record<keyof FormFields, string | null>
+              Record<keyof FormFields, null | string>
             >(
               (filterList, [filterName, filterValue]) => {
                 filterList[filterName as keyof FormFields] = filterValue

--- a/src/panels/CharmsAndActionsPanel/CharmsAndActionsPanel.tsx
+++ b/src/panels/CharmsAndActionsPanel/CharmsAndActionsPanel.tsx
@@ -23,11 +23,11 @@ enum InlineErrors {
 }
 
 type CharmsAndActionsQueryParams = {
-  panel: string | null;
+  panel: null | string;
 };
 
 const CharmsAndActionsPanel = () => {
-  const [charmURL, setCharmURL] = useState<string | null>();
+  const [charmURL, setCharmURL] = useState<null | string>();
   const defaultQueryParams: CharmsAndActionsQueryParams = {
     panel: null,
   };

--- a/src/panels/CharmsPanel/CharmsPanel.tsx
+++ b/src/panels/CharmsPanel/CharmsPanel.tsx
@@ -12,7 +12,7 @@ import CharmApplicationsDetails from "./CharmApplicationsDetails";
 import { Label } from "./types";
 
 type Props = {
-  onCharmURLChange: (charmURL: string | null) => void;
+  onCharmURLChange: (charmURL: null | string) => void;
   onRemovePanelQueryParams: () => void;
   isLoading: boolean;
   inlineErrors: ReactNode[];
@@ -24,7 +24,7 @@ export default function CharmsPanel({
   onRemovePanelQueryParams,
   inlineErrors,
 }: Props): JSX.Element {
-  const [selectedCharm, setSelectedCharm] = useState<string | null>(null);
+  const [selectedCharm, setSelectedCharm] = useState<null | string>(null);
   const charms = useAppSelector(getCharms);
 
   const handleSubmit: FormEventHandler = (ev) => {

--- a/src/panels/ConfigPanel/ConfigField/ConfigField.tsx
+++ b/src/panels/ConfigPanel/ConfigField/ConfigField.tsx
@@ -24,9 +24,9 @@ export type ConfigProps = {
   validate?: (config: ConfigData) => void;
 };
 
-type Props<V extends ConfigValue> = ConfigProps & {
+type Props<V extends ConfigValue> = {
   input: (value: V) => ReactNode;
-};
+} & ConfigProps;
 
 const ConfigField = <V extends ConfigValue>({
   config,
@@ -44,7 +44,7 @@ const ConfigField = <V extends ConfigValue>({
   const [showDescription, setShowDescription] = useState(false);
   const descriptionRef = useRef<HTMLDivElement>(null);
   const [maxDescriptionHeight, setMaxDescriptionHeight] = useState<
-    string | null
+    null | string
   >(null);
   const previousValue = useRef<Props<V>["config"]["newValue"]>(null);
   const valueChanged = config.newValue !== previousValue.current;

--- a/src/panels/ConfigPanel/ConfigPanel.tsx
+++ b/src/panels/ConfigPanel/ConfigPanel.tsx
@@ -151,7 +151,7 @@ export default function ConfigPanel(): JSX.Element {
     updateConfig(newConfig);
   }
 
-  function setError(name: string, error?: string | null) {
+  function setError(name: string, error?: null | string) {
     const newConfig = cloneDeep(config);
     newConfig[name].error = error;
     setConfig(newConfig);
@@ -374,7 +374,7 @@ function generateConfigElementList(
   selectedConfig: ConfigData | undefined,
   setSelectedConfig: SetSelectedConfig,
   setNewValue: SetNewValue,
-  setError: (name: string, error?: string | null) => void,
+  setError: (name: string, error?: null | string) => void,
   secrets?: ListSecretResult[] | null,
 ) {
   const elements = Object.keys(configs).map((key) => {

--- a/src/panels/ConfigPanel/types.ts
+++ b/src/panels/ConfigPanel/types.ts
@@ -1,11 +1,11 @@
 import type { ConfirmTypes as DefaultConfirmTypes } from "panels/types";
 
-export type ConfigValue = string | number | boolean | undefined;
+export type ConfigValue = boolean | number | string | undefined;
 
 export type ConfigOption<V, T> = {
   default?: V;
   description: string;
-  error?: string | null;
+  error?: null | string;
   name: string;
   newValue?: V;
   source: "default" | "user";
@@ -14,9 +14,9 @@ export type ConfigOption<V, T> = {
 };
 
 export type ConfigData =
-  | ConfigOption<string, "string" | "secret">
-  | ConfigOption<number, "int" | "float">
-  | ConfigOption<boolean, "boolean">;
+  | ConfigOption<boolean, "boolean">
+  | ConfigOption<number, "float" | "int">
+  | ConfigOption<string, "secret" | "string">;
 
 export type Config = {
   [key: string]: ConfigData;
@@ -44,11 +44,11 @@ export enum ConfigConfirmType {
   GRANT = "grant",
 }
 
-export type ConfirmTypes = DefaultConfirmTypes | ConfigConfirmType;
+export type ConfirmTypes = ConfigConfirmType | DefaultConfirmTypes;
 
 export type ConfigQueryParams = {
-  panel: string | null;
-  charm: string | null;
-  entity: string | null;
-  modelUUID: string | null;
+  panel: null | string;
+  charm: null | string;
+  entity: null | string;
+  modelUUID: null | string;
 };

--- a/src/panels/GrantSecretPanel/GrantSecretPanel.tsx
+++ b/src/panels/GrantSecretPanel/GrantSecretPanel.tsx
@@ -56,8 +56,8 @@ const GrantSecretPanel = () => {
   const formId = useId();
   const groupId = useId();
   const [queryParams, , handleRemovePanelQueryParams] = usePanelQueryParams<{
-    panel: string | null;
-    secret: string | null;
+    panel: null | string;
+    secret: null | string;
   }>({
     panel: null,
     secret: null,
@@ -66,7 +66,7 @@ const GrantSecretPanel = () => {
   const secret = useAppSelector((state) =>
     getSecretByURI(state, modelUUID, secretURI),
   );
-  const [inlineError, setInlineError] = useState<string | null>(null);
+  const [inlineError, setInlineError] = useState<null | string>(null);
   const [saving, setSaving] = useState(false);
   const grantSecret = useGrantSecret(userName, modelName);
   const revokeSecret = useRevokeSecret(userName, modelName);

--- a/src/panels/PanelInlineErrors/PanelInlineErrors.tsx
+++ b/src/panels/PanelInlineErrors/PanelInlineErrors.tsx
@@ -4,7 +4,7 @@ import type { JSX, ReactNode } from "react";
 import ScrollOnRender from "components/ScrollOnRender";
 
 type Props = {
-  inlineErrors: ReactNode[] | null;
+  inlineErrors: null | ReactNode[];
   scrollArea?: HTMLElement | null;
 };
 

--- a/src/panels/Panels.tsx
+++ b/src/panels/Panels.tsx
@@ -13,7 +13,7 @@ import GrantSecretPanel from "./GrantSecretPanel";
 import RemoveSecretPanel from "./RemoveSecretPanel";
 
 export default function Panels() {
-  const [panelQs] = useQueryParams<{ panel: string | null }>({
+  const [panelQs] = useQueryParams<{ panel: null | string }>({
     panel: null,
   });
   const canManageSecrets = useCanManageSecrets();

--- a/src/panels/RemoveSecretPanel/Fields/Fields.tsx
+++ b/src/panels/RemoveSecretPanel/Fields/Fields.tsx
@@ -22,7 +22,7 @@ import { Label } from "./types";
 type Props = {
   hideConfirm: () => void;
   handleRemoveSecret: (values: FormFields) => void;
-  secretURI?: string | null;
+  secretURI?: null | string;
   showConfirm: boolean;
 };
 

--- a/src/panels/RemoveSecretPanel/RemoveSecretPanel.tsx
+++ b/src/panels/RemoveSecretPanel/RemoveSecretPanel.tsx
@@ -28,8 +28,8 @@ const RemoveSecretPanel = () => {
   const scrollArea = useRef<HTMLDivElement>(null);
   const formId = useId();
   const [queryParams, , handleRemovePanelQueryParams] = usePanelQueryParams<{
-    panel: string | null;
-    secret: string | null;
+    panel: null | string;
+    secret: null | string;
   }>({
     panel: null,
     secret: null,
@@ -41,7 +41,7 @@ const RemoveSecretPanel = () => {
   const latestRevision = useAppSelector((state) =>
     getSecretLatestRevision(state, modelUUID, secretURI),
   );
-  const [inlineError, setInlineError] = useState<string | null>(null);
+  const [inlineError, setInlineError] = useState<null | string>(null);
   const [saving, setSaving] = useState(false);
   const [showConfirm, setShowConfirm] = useState(false);
   const removeSecrets = useRemoveSecrets(userName, modelName);

--- a/src/panels/SecretFormPanel/SecretFormPanel.tsx
+++ b/src/panels/SecretFormPanel/SecretFormPanel.tsx
@@ -15,8 +15,8 @@ const SecretFormPanel = ({ update = false }: Props) => {
   const scrollArea = useRef<HTMLDivElement>(null);
   const formId = useId();
   const [queryParams, , handleRemovePanelQueryParams] = usePanelQueryParams<{
-    panel: string | null;
-    secret: string | null;
+    panel: null | string;
+    secret: null | string;
   }>({
     panel: null,
     secret: null,

--- a/src/panels/ShareModelPanel/ShareModel.tsx
+++ b/src/panels/ShareModelPanel/ShareModel.tsx
@@ -25,7 +25,7 @@ import { Label, TestId } from "./types";
 type User = {
   user: string;
   "display-name": string;
-  "last-connection": string | null;
+  "last-connection": null | string;
   access: string;
 };
 
@@ -35,11 +35,11 @@ type UsersAccess = {
 
 type UserAccess = {
   username: string;
-  access: string | null;
+  access: null | string;
 };
 
 type ShareModelQueryParams = {
-  panel: string | null;
+  panel: null | string;
 };
 
 export default function ShareModel() {
@@ -88,7 +88,7 @@ export default function ShareModel() {
   const users = modelStatusData?.info?.users;
 
   useEffect(() => {
-    const clonedUserAccess: UsersAccess | null = cloneDeep(usersAccess);
+    const clonedUserAccess: null | UsersAccess = cloneDeep(usersAccess);
 
     users?.forEach((user: User) => {
       const displayName = user["user"];
@@ -169,7 +169,7 @@ export default function ShareModel() {
       permissionTo,
       permissionFrom,
     );
-    let error: string | null = response?.results?.[0]?.error?.message ?? null;
+    let error: null | string = response?.results?.[0]?.error?.message ?? null;
     // ignore this error as it means that it's a success
     if (
       error !== null &&

--- a/src/store/general/types.ts
+++ b/src/store/general/types.ts
@@ -4,7 +4,7 @@ export type Config = {
   analyticsEnabled: boolean;
   baseAppURL: string;
   // Support for 2.9 configuration.
-  baseControllerURL?: string | null;
+  baseControllerURL?: null | string;
   controllerAPIEndpoint: string;
   identityProviderURL: string;
   isJuju: boolean;
@@ -37,13 +37,13 @@ export type Login = {
 };
 
 export type GeneralState = {
-  appVersion: string | null;
+  appVersion: null | string;
   config: Config | null;
-  connectionError?: string | null;
+  connectionError?: null | string;
   controllerConnections: ControllerConnections | null;
   controllerFeatures: ControllerFeaturesState | null;
   credentials: Credentials | null;
   login: Login | null;
-  pingerIntervalIds: PingerIntervalIds | null;
-  visitURLs: string[] | null;
+  pingerIntervalIds: null | PingerIntervalIds;
+  visitURLs: null | string[];
 };

--- a/src/store/juju/selectors.ts
+++ b/src/store/juju/selectors.ts
@@ -94,7 +94,7 @@ const getUniqueAuditEventValues = <K extends keyof AuditEvent>(
   modifier?: (value: AuditEvent[K]) => string,
 ) => {
   // Use a set to get unique values.
-  const values = new Set<string | AuditEvent[K]>();
+  const values = new Set<AuditEvent[K] | string>();
   auditEvents
     ?.filter(({ [key]: value }) => typeof value !== "undefined")
     .forEach(({ [key]: value }) =>
@@ -182,7 +182,7 @@ export const getSecretsState = createSelector(
 );
 
 export const getModelSecretsState = createSelector(
-  [getSecretsState, (_state: RootState, modelUUID: string | null) => modelUUID],
+  [getSecretsState, (_state: RootState, modelUUID: null | string) => modelUUID],
   (secrets, modelUUID) =>
     modelUUID !== null && modelUUID ? secrets[modelUUID] : null,
 );
@@ -210,7 +210,7 @@ export const getSecretsLoading = createSelector(
 export const getSecretByURI = createSelector(
   [
     getModelSecrets,
-    (_state: RootState, _modelUUID: string, secretURI?: string | null) =>
+    (_state: RootState, _modelUUID: string, secretURI?: null | string) =>
       secretURI,
   ],
   (secrets, secretURI) =>
@@ -336,13 +336,13 @@ export const getFullModelNames = createSelector(
   Get a model by UUID.
 */
 export const getModelByUUID = createSelector(
-  [getModelList, (_, uuid: string | null = null) => uuid],
+  [getModelList, (_, uuid: null | string = null) => uuid],
   (modelList, uuid) =>
     uuid !== null && uuid in modelList ? modelList[uuid] : null,
 );
 
 export const getModelDataByUUID = createSelector(
-  [getModelData, (_, modelUUID: string | null = null) => modelUUID],
+  [getModelData, (_, modelUUID: null | string = null) => modelUUID],
   (modelData, modelUUID) =>
     modelUUID != null && modelUUID in modelData ? modelData[modelUUID] : null,
 );
@@ -522,7 +522,7 @@ export const getModelWatcherDataByUUID = createSelector(
 
 export const getModelInfo = createSelector(
   getModelWatcherDataByUUID,
-  (modelWatcherData): WatcherModelInfo | null => {
+  (modelWatcherData): null | WatcherModelInfo => {
     if (modelWatcherData) {
       return modelWatcherData.model;
     }
@@ -534,8 +534,8 @@ export const getModelInfo = createSelector(
 export const getModelUUIDFromList = createSelector(
   [
     getModelList,
-    (_state: RootState, modelName: string | null = null) => modelName,
-    (_state: RootState, _modelName, ownerName: string | null = null) =>
+    (_state: RootState, modelName: null | string = null) => modelName,
+    (_state: RootState, _modelName, ownerName: null | string = null) =>
       ownerName,
   ],
   (modelList: ModelsList, modelName, ownerName) => {
@@ -582,7 +582,7 @@ export const getModelApplications = createSelector(
 
 export const getModelUnits = createSelector(
   getModelWatcherDataByUUID,
-  (modelWatcherData): UnitData | null => {
+  (modelWatcherData): null | UnitData => {
     if (modelWatcherData) {
       return modelWatcherData.units;
     }
@@ -592,7 +592,7 @@ export const getModelUnits = createSelector(
 
 export const getModelRelations = createSelector(
   getModelWatcherDataByUUID,
-  (modelWatcherData): RelationData | null => {
+  (modelWatcherData): null | RelationData => {
     if (modelWatcherData) {
       return modelWatcherData.relations;
     }
@@ -630,7 +630,7 @@ export interface StatusData {
 */
 export const getAllModelApplicationStatus = createSelector(
   getModelUnits,
-  (units): StatusData | null => {
+  (units): null | StatusData => {
     if (!units) {
       return null;
     }
@@ -772,7 +772,7 @@ export const getFilteredModelData = createSelector(
   @returns The memoized selector to return a modelUUID.
 */
 export const getModelUUID = createSelector(
-  [getModelData, (_state: RootState, name?: string | null) => name ?? null],
+  [getModelData, (_state: RootState, name?: null | string) => name ?? null],
   (modelData, name) => {
     let owner = null;
     let modelName = null;
@@ -810,7 +810,7 @@ export const getModelUUIDs = createSelector([getModelData], (modelData) =>
 export const getModelStatus = createSelector(
   [
     getModelData,
-    (_state: RootState, modelUUID: string | null = null) => modelUUID,
+    (_state: RootState, modelUUID: null | string = null) => modelUUID,
   ],
   (modelData, modelUUID) =>
     modelUUID !== null && modelUUID ? (modelData?.[modelUUID] ?? null) : null,
@@ -1006,13 +1006,13 @@ export const getControllerDataByUUID = createSelector(
 export const getModelControllerDataByUUID = createSelector(
   [
     getControllerData,
-    (_state: RootState, controllerUUID: string | null = null) => controllerUUID,
+    (_state: RootState, controllerUUID: null | string = null) => controllerUUID,
   ],
   (controllerData, controllerUUID) => {
     if (!controllerData || controllerUUID === null || !controllerUUID) {
       return null;
     }
-    let modelController: (Controllers[0][0] & { url?: string }) | null = null;
+    let modelController: ({ url?: string } & Controllers[0][0]) | null = null;
     let controllerURL;
     for (const controller of Object.entries(controllerData)) {
       // Loop through the sub controllers for each primary controller.
@@ -1054,7 +1054,7 @@ export const getCharms = createSelector(slice, (sliceState) => {
  * @returns A list of applications that are selected.
  */
 export const getSelectedApplications = createSelector(
-  [slice, (_state: RootState, charmURL: string | null = null) => charmURL],
+  [slice, (_state: RootState, charmURL: null | string = null) => charmURL],
   (sliceState, charmURL) => {
     if (charmURL === null || !charmURL) {
       return sliceState.selectedApplications;
@@ -1080,7 +1080,7 @@ export const getSelectedCharm = createSelector(
 export const isKubernetesModel = createSelector(
   [
     getModelDataByUUID,
-    (state, uuid: string | null = null) =>
+    (state, uuid: null | string = null) =>
       uuid !== null && uuid ? getModelInfo(state, uuid) : null,
   ],
   (modelData, modelInfo) =>
@@ -1096,7 +1096,7 @@ export const getReBACAllowedState = createSelector(
 export const getReBACPermission = createSelector(
   [
     getReBACAllowedState,
-    (_state: RootState, tuple?: RelationshipTuple | null) => tuple,
+    (_state: RootState, tuple?: null | RelationshipTuple) => tuple,
   ],
   (allowed, tuple) =>
     allowed.find((relation) => fastDeepEqual(relation.tuple, tuple)),
@@ -1105,7 +1105,7 @@ export const getReBACPermission = createSelector(
 export const getReBACPermissions = createSelector(
   [
     getReBACAllowedState,
-    (_state: RootState, tuples?: RelationshipTuple[] | null) => tuples,
+    (_state: RootState, tuples?: null | RelationshipTuple[]) => tuples,
   ],
   (allowed, tuples) =>
     tuples
@@ -1119,7 +1119,7 @@ export const getReBACPermissions = createSelector(
 
 export const getReBACPermissionLoading = createSelector(
   [
-    (state, tuple?: RelationshipTuple | null) =>
+    (state, tuple?: null | RelationshipTuple) =>
       getReBACPermission(state, tuple),
   ],
   (permission) => {
@@ -1129,7 +1129,7 @@ export const getReBACPermissionLoading = createSelector(
 
 export const getReBACPermissionLoaded = createSelector(
   [
-    (state, tuple?: RelationshipTuple | null) =>
+    (state, tuple?: null | RelationshipTuple) =>
       getReBACPermission(state, tuple),
   ],
   (permission) => {
@@ -1139,7 +1139,7 @@ export const getReBACPermissionLoaded = createSelector(
 
 export const getReBACPermissionErrors = createSelector(
   [
-    (state, tuple?: RelationshipTuple | null) =>
+    (state, tuple?: null | RelationshipTuple) =>
       getReBACPermission(state, tuple),
   ],
   (permission) => {
@@ -1149,7 +1149,7 @@ export const getReBACPermissionErrors = createSelector(
 
 export const hasReBACPermission = createSelector(
   [
-    (state, tuple?: RelationshipTuple | null) =>
+    (state, tuple?: null | RelationshipTuple) =>
       getReBACPermission(state, tuple),
   ],
   (permission) => {

--- a/src/store/juju/slice.ts
+++ b/src/store/juju/slice.ts
@@ -212,7 +212,7 @@ const slice = createSlice({
     updateModelsError: (
       state,
       action: PayloadAction<
-        { modelsError: string | null } & WsControllerURLParam
+        { modelsError: null | string } & WsControllerURLParam
       >,
     ) => {
       state.modelsError = action.payload.modelsError;
@@ -252,7 +252,7 @@ const slice = createSlice({
     },
     updateAuditEventsErrors: (
       state,
-      { payload }: PayloadAction<string | null>,
+      { payload }: PayloadAction<null | string>,
     ) => {
       state.auditEvents.errors = payload;
     },

--- a/src/store/juju/types.ts
+++ b/src/store/juju/types.ts
@@ -35,21 +35,18 @@ export type LocalController = {
   version?: string;
 };
 
-export type Controller = (ControllerInfo | LocalController) &
-  ControllerAnnotations;
+export type Controller = ControllerAnnotations &
+  (ControllerInfo | LocalController);
 
 export type Controllers = Record<string, Controller[]>;
 
 // There is some model data that we don't want to store from the full status because it changes
 // too often causing needless re-renders and is currently irrelevant
 // like controllerTimestamp.
-export type ModelData = Omit<
-  FullStatusWithAnnotations,
-  "branches" | "controller-timestamp"
-> & {
+export type ModelData = {
   info?: ModelInfo;
   uuid: string;
-};
+} & Omit<FullStatusWithAnnotations, "branches" | "controller-timestamp">;
 
 export type ModelDataList = Record<string, ModelData>;
 
@@ -65,23 +62,21 @@ export type ModelsList = {
   [uuid: string]: ModelListInfo;
 };
 
-export type AuditEventsState = GenericItemsState<AuditEvent, string | null> & {
+export type AuditEventsState = {
   limit: number;
-};
+} & GenericItemsState<AuditEvent, null | string>;
 
-export type CrossModelQueryState = GenericState<
-  CrossModelQueryResponse["errors"] | string
-> & {
+export type CrossModelQueryState = {
   results: CrossModelQueryResponse["results"] | null;
-};
+} & GenericState<CrossModelQueryResponse["errors"] | string>;
 
-export type SecretsContent = GenericState<string> & {
-  content?: SecretValueResult["data"] | null;
-};
+export type SecretsContent = {
+  content?: null | SecretValueResult["data"];
+} & GenericState<string>;
 
-export type ModelSecrets = GenericItemsState<ListSecretResult, string> & {
+export type ModelSecrets = {
   content?: SecretsContent;
-};
+} & GenericItemsState<ListSecretResult, string>;
 
 export type SecretsState = Record<string, ModelSecrets>;
 
@@ -92,14 +87,14 @@ export type ModelFeatures = {
 
 export type ModelFeaturesState = Record<string, ModelFeatures>;
 
-export type ReBACAllowed = GenericState<string> & {
+export type ReBACAllowed = {
   tuple: RelationshipTuple;
   allowed?: boolean | null;
-};
+} & GenericState<string>;
 
-export type ReBACRelationship = GenericState<string[]> & {
+export type ReBACRelationship = {
   requestId: string;
-};
+} & GenericState<string[]>;
 
 export type ReBACState = {
   allowed: ReBACAllowed[];
@@ -119,7 +114,7 @@ export type JujuState = {
   commandHistory: CommandHistory;
   controllers: Controllers | null;
   models: ModelsList;
-  modelsError: string | null;
+  modelsError: null | string;
   modelsLoaded: boolean;
   modelData: ModelDataList;
   modelFeatures: ModelFeaturesState;

--- a/src/store/juju/utils/models.ts
+++ b/src/store/juju/utils/models.ts
@@ -223,7 +223,7 @@ export const extractCloudName = (tag = "") => {
   @param cloudTag The cloudTag identifier returns from the API
   @returns The simplified cloud string
 */
-export const extractCredentialName = (tag: string | null = null) => {
+export const extractCredentialName = (tag: null | string = null) => {
   // @ is not there in local boostraps
   // cloudcred-localhost_admin_localhost
   if (tag === null || !tag) {

--- a/src/store/middleware/check-auth.ts
+++ b/src/store/middleware/check-auth.ts
@@ -16,7 +16,7 @@ import type { RootState, Store } from "store/store";
 import { isPayloadAction } from "types";
 import { logger } from "utils/logger";
 
-function error(name: string, wsControllerURL?: string | null) {
+function error(name: string, wsControllerURL?: null | string) {
   // Not shown in UI. Logged for debugging purposes.
   logger.error(
     "Unable to perform action: ",

--- a/src/store/middleware/model-poller.ts
+++ b/src/store/middleware/model-poller.ts
@@ -71,7 +71,7 @@ export const modelPollerMiddleware: Middleware<
         let conn: ConnectionWithFacades | undefined;
         let juju: Client | undefined;
         let error: unknown = null;
-        let intervalId: number | null = null;
+        let intervalId: null | number = null;
         reduxStore.dispatch(generalActions.updateLoginLoading(true));
         const continueConnection = await Auth.instance.beforeControllerConnect({
           wsControllerURL,

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -1,6 +1,6 @@
-export type GenericItemsState<I, E> = GenericState<E> & {
+export type GenericItemsState<I, E> = {
   items: I[] | null;
-};
+} & GenericState<E>;
 
 export type GenericState<E> = {
   errors: E | null;

--- a/src/tables/tableHeaders.tsx
+++ b/src/tables/tableHeaders.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from "react";
 export type Header = HeaderRow[];
 
 type HeaderRow = {
-  content: string | ReactNode;
+  content: ReactNode | string;
   sortKey?: string;
   className?: string;
 };

--- a/src/tables/tableRows.tsx
+++ b/src/tables/tableRows.tsx
@@ -39,12 +39,12 @@ export type ModelParams = {
 };
 
 export type Query = {
-  panel?: string | null;
-  entity?: string | null;
-  activeView?: string | null;
+  panel?: null | string;
+  entity?: null | string;
+  activeView?: null | string;
 };
 
-const generateAddress = (address: string | null = null) =>
+const generateAddress = (address: null | string = null) =>
   address !== null ? (
     <div className="u-flex u-flex--gap-small">
       <TruncatedTooltip
@@ -75,7 +75,7 @@ const generateAddress = (address: string | null = null) =>
 
 export function generateLocalApplicationRows(
   applications: ApplicationData | null,
-  applicationStatuses: StatusData | null,
+  applicationStatuses: null | StatusData,
   modelParams: ModelParams,
   query?: Query,
 ) {
@@ -252,7 +252,7 @@ const generateUnitURL = (modelParams: ModelParams, unitId: string) => {
 };
 
 export function generateUnitRows(
-  units: UnitData | null,
+  units: null | UnitData,
   modelParams: ModelParams,
   showCheckbox = false,
   hideMachines = false,
@@ -269,9 +269,9 @@ export function generateUnitRows(
   }
 
   const clonedUnits: {
-    [unitName: string]: UnitData[0] & {
+    [unitName: string]: {
       subordinates?: { [unitId: string]: UnitData[0] };
-    };
+    } & UnitData[0];
   } = cloneDeep(units);
 
   // Restructure the unit list data to allow for the proper subordinate
@@ -292,7 +292,7 @@ export function generateUnitRows(
     }
   });
 
-  const unitRows: (MainTableRow & { "data-unit": string })[] = [];
+  const unitRows: ({ "data-unit": string } & MainTableRow)[] = [];
   Object.keys(clonedUnits).forEach((unitId) => {
     const unit = clonedUnits[unitId];
     const workload = unit["workload-status"].current || "-";
@@ -459,9 +459,9 @@ export function generateUnitRows(
 
 export function generateMachineRows(
   machines: MachineData | null,
-  units: UnitData | null,
+  units: null | UnitData,
   modelParams: ModelParams,
-  selectedEntity?: string | null,
+  selectedEntity?: null | string,
 ) {
   if (!machines) {
     return [];
@@ -469,7 +469,7 @@ export function generateMachineRows(
 
   const generateMachineApps = (
     machineId: string,
-    machineUnits: UnitData | null,
+    machineUnits: null | UnitData,
   ) => {
     const appsOnMachine: [string, string][] = [];
     machineUnits &&
@@ -566,7 +566,7 @@ export function generateMachineRows(
 }
 
 export function generateRelationRows(
-  relationData: RelationData | null,
+  relationData: null | RelationData,
   applications: ApplicationData | null,
 ) {
   if (!relationData) {

--- a/src/testing/utils.tsx
+++ b/src/testing/utils.tsx
@@ -44,7 +44,7 @@ type Options = {
   path?: string;
   routeChildren?: RouteObject[];
   initialProps?: Record<string, unknown>;
-} & (OptionsWithStore | OptionsWithState);
+} & (OptionsWithState | OptionsWithStore);
 
 export type ComponentProps = {
   path: string;
@@ -75,7 +75,7 @@ export const changeURL = (url: string) => window.happyDOM.setURL(url);
 
 export const wrapComponent = (
   component: ReactNode,
-  options?: Options | null,
+  options?: null | Options,
 ) => {
   const store =
     options && "store" in options
@@ -125,7 +125,7 @@ export const wrapComponent = (
 
 export const renderComponent = (
   component: ReactNode,
-  options?: Options | null,
+  options?: null | Options,
 ) => {
   const { router, Component, store, Wrapper } = wrapComponent(
     component,
@@ -140,13 +140,13 @@ export const renderComponent = (
 
 export const renderWrappedHook = <Result, Props>(
   hook: (initialProps: Props) => Result,
-  options?: Options | null,
+  options?: null | Options,
 ): {
-  router: Router | null;
-  store: OptionsWithStore["store"] | null;
+  router: null | Router;
+  store: null | OptionsWithStore["store"];
 } & RenderHookResult<Result, Props> => {
-  let router: Router | null = null;
-  let store: OptionsWithStore["store"] | null = null;
+  let router: null | Router = null;
+  let store: null | OptionsWithStore["store"] = null;
   const result = renderHook(hook, {
     queries,
     wrapper: ({ children }: PropsWithChildren) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,5 +39,5 @@ export enum FeatureFlags {
 }
 
 export type Nullable<T> = {
-  [P in keyof T]: T[P] | null;
+  [P in keyof T]: null | T[P];
 };

--- a/src/urls.ts
+++ b/src/urls.ts
@@ -11,7 +11,7 @@ export enum ModelTab {
 }
 
 export type AppTab = "machines" | "units";
-export type ModelsGroupedBy = "status" | "cloud" | "owner";
+export type ModelsGroupedBy = "cloud" | "owner" | "status";
 
 const urls = {
   index: "/",

--- a/src/utils/breakLines.ts
+++ b/src/utils/breakLines.ts
@@ -3,7 +3,7 @@
  * that is inserted into a <pre> block.
  */
 const breakLines = (
-  text?: string | null,
+  text?: null | string,
   breakAtSpaces = true,
   lineLength = 52,
 ): string => {

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -5,7 +5,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
-    "allowJs": true,
+    "allowJs": false,
     "strict": true
   },
   "include": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2166,6 +2166,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/project-service@npm:8.43.0":
+  version: 8.43.0
+  resolution: "@typescript-eslint/project-service@npm:8.43.0"
+  dependencies:
+    "@typescript-eslint/tsconfig-utils": "npm:^8.43.0"
+    "@typescript-eslint/types": "npm:^8.43.0"
+    debug: "npm:^4.3.4"
+  peerDependencies:
+    typescript: ">=4.8.4 <6.0.0"
+  checksum: 10c0/c9058b5fbf9642c35a303641e4ff2d0df1ddac337275bab84b56167f1019fbcb7e69959239fed82e53c747f58d6ee4c1859cf5b018803cba1b1aab430439d728
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/scope-manager@npm:8.28.0":
   version: 8.28.0
   resolution: "@typescript-eslint/scope-manager@npm:8.28.0"
@@ -2186,12 +2199,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/scope-manager@npm:8.43.0":
+  version: 8.43.0
+  resolution: "@typescript-eslint/scope-manager@npm:8.43.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.43.0"
+    "@typescript-eslint/visitor-keys": "npm:8.43.0"
+  checksum: 10c0/f87b3c3a5d3ad18326945288fa5b9b9fa662d87f466dc159e1514e00e359e830b80557f213acb3d23d5d600826b4cc4cfa5d2d479f8aba1b9834df19a640a779
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/tsconfig-utils@npm:8.42.0, @typescript-eslint/tsconfig-utils@npm:^8.42.0":
   version: 8.42.0
   resolution: "@typescript-eslint/tsconfig-utils@npm:8.42.0"
   peerDependencies:
     typescript: ">=4.8.4 <6.0.0"
   checksum: 10c0/03882eeee279fafa2cb4ee3154742417fd29395b3bfe3f867d9d4cb9cb68d1200c885c35b96dd558a1aff8561ac3700cff8ca7680a5cf34e5e0e136a6ee3c30c
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/tsconfig-utils@npm:8.43.0, @typescript-eslint/tsconfig-utils@npm:^8.43.0":
+  version: 8.43.0
+  resolution: "@typescript-eslint/tsconfig-utils@npm:8.43.0"
+  peerDependencies:
+    typescript: ">=4.8.4 <6.0.0"
+  checksum: 10c0/b3a472368ad31e31e58ef019f6afec7387f5885e3fd423c71f3910b6d6b767324fde8bd60bec2e7505cc130317ece7fbc91314c44cdfea74ff76b5039bf26d52
   languageName: node
   linkType: hard
 
@@ -2221,6 +2253,13 @@ __metadata:
   version: 8.42.0
   resolution: "@typescript-eslint/types@npm:8.42.0"
   checksum: 10c0/d585dff5005328282cc59f9402e886a3db64727906ad3e68b49d7ef73bc07bef3ed569287ba826ebaa07b69be42a72232a38529951d64c28cebd83db0892cd33
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/types@npm:8.43.0, @typescript-eslint/types@npm:^8.43.0":
+  version: 8.43.0
+  resolution: "@typescript-eslint/types@npm:8.43.0"
+  checksum: 10c0/60d19b695affce128fe1076ebe4cff7e05d38dd50155d653fc9e995eafa56c299fd49ad4d9d2997f118a75fb57e3ca18001623bc3ef3fa0111f863079203e4b2
   languageName: node
   linkType: hard
 
@@ -2269,6 +2308,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/typescript-estree@npm:8.43.0":
+  version: 8.43.0
+  resolution: "@typescript-eslint/typescript-estree@npm:8.43.0"
+  dependencies:
+    "@typescript-eslint/project-service": "npm:8.43.0"
+    "@typescript-eslint/tsconfig-utils": "npm:8.43.0"
+    "@typescript-eslint/types": "npm:8.43.0"
+    "@typescript-eslint/visitor-keys": "npm:8.43.0"
+    debug: "npm:^4.3.4"
+    fast-glob: "npm:^3.3.2"
+    is-glob: "npm:^4.0.3"
+    minimatch: "npm:^9.0.4"
+    semver: "npm:^7.6.0"
+    ts-api-utils: "npm:^2.1.0"
+  peerDependencies:
+    typescript: ">=4.8.4 <6.0.0"
+  checksum: 10c0/184ba925067d7fbcb377450195a89511f030a49d080e27058fa78078a069d86c1936b1a82ce6f19ff24c30c4de8b779deb050c36b06db5372c95fc7e5be7115a
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/utils@npm:8.28.0":
   version: 8.28.0
   resolution: "@typescript-eslint/utils@npm:8.28.0"
@@ -2299,6 +2358,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/utils@npm:^8.34.1":
+  version: 8.43.0
+  resolution: "@typescript-eslint/utils@npm:8.43.0"
+  dependencies:
+    "@eslint-community/eslint-utils": "npm:^4.7.0"
+    "@typescript-eslint/scope-manager": "npm:8.43.0"
+    "@typescript-eslint/types": "npm:8.43.0"
+    "@typescript-eslint/typescript-estree": "npm:8.43.0"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0
+    typescript: ">=4.8.4 <6.0.0"
+  checksum: 10c0/42fc8c60551361d80b5c53b303ba8cd20cf914665168416ad0a278cd44aae587311af9e4461f92ed28b5f36091d275a0e9974482d5e9ba95fc00108a537cdd36
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/visitor-keys@npm:8.28.0":
   version: 8.28.0
   resolution: "@typescript-eslint/visitor-keys@npm:8.28.0"
@@ -2316,6 +2390,16 @@ __metadata:
     "@typescript-eslint/types": "npm:8.42.0"
     eslint-visitor-keys: "npm:^4.2.1"
   checksum: 10c0/22c942f2a100d71c08f952b976446e824ddf227d4ac02b7016e12d4a33804ab06072d570695baed3565d0a08a1d3fa6ff3ccf97a122d63e65780f871d597f1b1
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:8.43.0":
+  version: 8.43.0
+  resolution: "@typescript-eslint/visitor-keys@npm:8.43.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.43.0"
+    eslint-visitor-keys: "npm:^4.2.1"
+  checksum: 10c0/5d576eaf7bea41933ba726f4b24410bd3fc2521ef286967c3dc630c6a90fabff2a2d7c4d12cb841d3f946d2e5e6fb2605e7edd84e3360308fe379dbf2b8dc2fa
   languageName: node
   linkType: hard
 
@@ -5042,6 +5126,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-perfectionist@npm:4.15.0":
+  version: 4.15.0
+  resolution: "eslint-plugin-perfectionist@npm:4.15.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:^8.34.1"
+    "@typescript-eslint/utils": "npm:^8.34.1"
+    natural-orderby: "npm:^5.0.0"
+  peerDependencies:
+    eslint: ">=8.45.0"
+  checksum: 10c0/e6fd86a083be063580bde3947e885b6f3a18b8c47a77874a64d0e22a54e6bafcb356bcc5f0c00634ea7ee1c8744757b3e6f2dc478f01e4874090ffc1aea9efa6
+  languageName: node
+  linkType: hard
+
 "eslint-plugin-prettier@npm:5.2.5":
   version: 5.2.5
   resolution: "eslint-plugin-prettier@npm:5.2.5"
@@ -7455,6 +7552,7 @@ __metadata:
     eslint-config-prettier: "npm:10.1.1"
     eslint-plugin-import: "npm:2.31.0"
     eslint-plugin-jsx-a11y: "npm:6.10.2"
+    eslint-plugin-perfectionist: "npm:4.15.0"
     eslint-plugin-prettier: "npm:5.2.5"
     eslint-plugin-promise: "npm:7.2.1"
     eslint-plugin-react: "npm:7.37.4"
@@ -8076,6 +8174,13 @@ __metadata:
   version: 1.4.0
   resolution: "natural-compare@npm:1.4.0"
   checksum: 10c0/f5f9a7974bfb28a91afafa254b197f0f22c684d4a1731763dda960d2c8e375b36c7d690e0d9dc8fba774c537af14a7e979129bca23d88d052fbeb9466955e447
+  languageName: node
+  linkType: hard
+
+"natural-orderby@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "natural-orderby@npm:5.0.0"
+  checksum: 10c0/d4e8b3bf16636eedc0c99a4cd551cd371732dd8c9766f19c8e153946553d82c12527eab182b8e79d640681aa6cb718273b53662ccf88127d4726307b6e645b2b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Done

- Add perfectionist plugin (TICS uses the `sort-type-constituents` rule but the [eslint docs](https://typescript-eslint.io/rules/sort-type-constituents/) say to use the perfectionist plugin instead) and add rules for sorting intersections and unions.
- Fix issues with `--fix`.
