### PR TITLE
chore(lint): disable booleans for prefer-nullish-coalescing

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -102,6 +102,7 @@ export default [
         {
           ignorePrimitives: {
             string: true,
+            boolean: true,
           },
         },
       ],


### PR DESCRIPTION
## Done

- disable booleans for prefer-nullish-coalescing otherwise optional booleans are required to use nullish coalescing, but `isA ?? isB` is not the same thing as `isA || isB`.
