### PR TITLE
fix: correct the controller donut chart

### DIFF
--- a/src/components/DonutChart/DonutChart.tsx
+++ b/src/components/DonutChart/DonutChart.tsx
@@ -47,7 +47,7 @@ const DonutChart: FC<Props> = ({
       .domain(Object.keys(data))
       .range(
         !isDisabled
-          ? ["is-blocked", "is-alert", "is-running"]
+          ? ["is-alert", "is-blocked", "is-running"]
           : ["is-disabled"],
       );
 

--- a/src/pages/ControllersIndex/ControllerChart/_controller-chart.scss
+++ b/src/pages/ControllersIndex/ControllerChart/_controller-chart.scss
@@ -1,6 +1,6 @@
 .p-chart {
   .is-disabled {
-    fill: rgba($color-mid-light, 0.33);
+    fill: rgba($color-positive, 0.33);
   }
 
   .is-blocked {
@@ -12,7 +12,7 @@
   }
 
   .is-running {
-    fill: $color-mid-light;
+    fill: $color-positive;
   }
 
   @media (min-width: $breakpoint-large) {
@@ -65,7 +65,7 @@
     }
 
     &.is-running::before {
-      background-color: $color-mid-light;
+      background-color: $color-positive;
     }
   }
 }


### PR DESCRIPTION
## Done

- Changed the Donut Chart on controllers tab to show green for running status
- Fixed the wrong color mapping for alert vs blocked status on the chart

## QA

- Navigate to controllers tab
- Verify that the colors on the chart map correctly to the values

## Details

Fixes https://warthogs.atlassian.net/browse/WD-27053
Fixes https://github.com/canonical/juju-dashboard/issues/2023

## Screenshots

BEFORE:
<img width="940" height="198" alt="Screenshot 2025-09-18 at 11 53 58 PM" src="https://github.com/user-attachments/assets/ec5b16b6-ae0c-497d-be21-c489ae23d310" />

AFTER:
<img width="926" height="190" alt="Screenshot 2025-09-18 at 11 55 00 PM" src="https://github.com/user-attachments/assets/ee70c72d-99f0-41e7-b943-9725218852f7" />

