### PR TITLE
feat: enable rebac permissions checking

### DIFF
--- a/.github/actions/setup-machine-charm/action.yml
+++ b/.github/actions/setup-machine-charm/action.yml
@@ -64,6 +64,12 @@ runs:
       if: ${{ env.build_type != 'charm-release' }}
       run: juju deploy ${{ github.workspace }}/charms/machine-charm/juju-dashboard*.charm dashboard
       shell: bash
+    - name: Wait for charm to be ready for integration
+      uses: nick-fields/retry@v3
+      with:
+        timeout_minutes: 1
+        max_attempts: 5 # Retry the wait-for with a short timeout in case it gets stuck and times out. If it fails after multiple tries it's probably a real error.
+        command: juju wait-for application dashboard --timeout=1m --query='name=="dashboard" && status=="blocked"' # The charm will be blocked when it needs the relation to the controller.
     - name: Integrate charm
       run: juju integrate '${{ inputs.controller-app }}' dashboard
       shell: bash

--- a/e2e/helpers/auth/Users.ts
+++ b/e2e/helpers/auth/Users.ts
@@ -74,6 +74,7 @@ export abstract class User {
     page: Page,
     url: string,
     expectError?: boolean,
+    featureFlags?: string[],
   ): Promise<void>;
 
   /**

--- a/e2e/helpers/auth/backends/Candid.ts
+++ b/e2e/helpers/auth/backends/Candid.ts
@@ -80,8 +80,13 @@ export class CandidUser extends LocalUser {
     super(username, password);
   }
 
-  override async dashboardLogin(page: Page, url: string): Promise<void> {
-    await page.goto(addFeatureFlags(url));
+  override async dashboardLogin(
+    page: Page,
+    url: string,
+    _expectError?: boolean,
+    featureFlags?: string[],
+  ): Promise<void> {
+    await page.goto(addFeatureFlags(url, featureFlags));
     const popupPromise = page.waitForEvent("popup");
     await page.getByRole("link", { name: "Log in to the dashboard" }).click();
 

--- a/e2e/helpers/auth/backends/Keycloak.ts
+++ b/e2e/helpers/auth/backends/Keycloak.ts
@@ -45,8 +45,9 @@ export class KeycloakOIDC {
     user: Secret,
     url: string,
     expectError?: boolean,
+    featureFlags?: string[],
   ): Promise<void> {
-    await page.goto(addFeatureFlags(url));
+    await page.goto(addFeatureFlags(url, featureFlags));
     await page.getByRole("link", { name: "Log in to the dashboard" }).click();
     await page
       .getByRole("textbox", { name: "Username or email" })
@@ -59,7 +60,7 @@ export class KeycloakOIDC {
       await page.waitForURL("**/models");
       // The Keycloak OIDC flow always redirects back to /models so now we need to visit
       // the expected URL:
-      await page.goto(addFeatureFlags(url));
+      await page.goto(addFeatureFlags(url, featureFlags));
     }
   }
 }
@@ -84,6 +85,7 @@ export class KeycloakOIDCUser extends LocalUser {
     page: Page,
     url: string,
     expectError?: boolean,
+    featureFlags?: string[],
   ): Promise<void> {
     await KeycloakOIDC.dashboardLogin(
       page,
@@ -93,6 +95,7 @@ export class KeycloakOIDCUser extends LocalUser {
       },
       url,
       expectError,
+      featureFlags,
     );
   }
 

--- a/e2e/helpers/auth/backends/Local.ts
+++ b/e2e/helpers/auth/backends/Local.ts
@@ -18,8 +18,13 @@ export class LocalUser implements User {
     await page.getByRole("button", { name: "Log in to the dashboard" }).click();
   }
 
-  async dashboardLogin(page: Page, url: string): Promise<void> {
-    await page.goto(addFeatureFlags(url));
+  async dashboardLogin(
+    page: Page,
+    url: string,
+    _expectError?: boolean,
+    featureFlags?: string[],
+  ): Promise<void> {
+    await page.goto(addFeatureFlags(url, featureFlags));
     await this.enterCredentials(page);
   }
 

--- a/e2e/helpers/auth/backends/OIDC.ts
+++ b/e2e/helpers/auth/backends/OIDC.ts
@@ -44,8 +44,9 @@ export class OIDC {
     user: Secret,
     url: string,
     expectError?: boolean,
+    featureFlags?: string[],
   ): Promise<void> {
-    await page.goto(addFeatureFlags(url));
+    await page.goto(addFeatureFlags(url, featureFlags));
     await page.getByRole("link", { name: "Log in to the dashboard" }).click();
     await page.getByRole("textbox", { name: "Email" }).fill(user.username);
     await page.getByRole("textbox", { name: "Password" }).fill(user.password);
@@ -56,7 +57,7 @@ export class OIDC {
       await page.waitForURL("**/models");
       // The OIDC flow always redirects back to /models so now we need to visit
       // the expected URL:
-      await page.goto(addFeatureFlags(url));
+      await page.goto(addFeatureFlags(url, featureFlags));
     }
   }
 }
@@ -70,6 +71,7 @@ export class OIDCUser extends LocalUser {
     page: Page,
     url: string,
     expectError?: boolean,
+    featureFlags?: string[],
   ): Promise<void> {
     await OIDC.dashboardLogin(
       page,
@@ -79,6 +81,7 @@ export class OIDCUser extends LocalUser {
       },
       url,
       expectError,
+      featureFlags,
     );
   }
 

--- a/e2e/jimm/rebac.spec.ts
+++ b/e2e/jimm/rebac.spec.ts
@@ -36,7 +36,7 @@ test.describe("ReBAC Admin", () => {
       );
       return newUser;
     });
-    await user.dashboardLogin(page, rebacURLS.users.index);
+    await user.dashboardLogin(page, rebacURLS.users.index, false, ["rebac"]);
     await expect(
       page.getByRole("link", { name: PrimaryNavLabel.PERMISSIONS }),
     ).toBeVisible();
@@ -47,7 +47,9 @@ test.describe("ReBAC Admin", () => {
   });
 
   test("link is not displayed for non-admins", async ({ page }) => {
-    await nonAdminUser.dashboardLogin(page, urls.models.index);
+    await nonAdminUser.dashboardLogin(page, urls.models.index, false, [
+      "rebac",
+    ]);
     await expect(
       page
         .getByRole("banner")
@@ -56,7 +58,9 @@ test.describe("ReBAC Admin", () => {
   });
 
   test("can't be accessed by non-admins", async ({ page }) => {
-    await nonAdminUser.dashboardLogin(page, rebacURLS.users.index);
+    await nonAdminUser.dashboardLogin(page, rebacURLS.users.index, false, [
+      "rebac",
+    ]);
     await expect(
       page.getByRole("heading", {
         name: "Hmm, we can't seem to find that page...",

--- a/e2e/utils/addFeatureFlags.ts
+++ b/e2e/utils/addFeatureFlags.ts
@@ -1,11 +1,15 @@
-const flags = [["enable-flag", "rebac"]];
+// Flags that should be enabled for all tests should be added to this array.
+const defaultFlags: string[] = [];
 
 /**
  * Add required feature flags to a URL.
  */
-export const addFeatureFlags = (url: string): string => {
+export const addFeatureFlags = (url: string, flags: string[] = []): string => {
   const [path, search] = url.split("?");
   const params = new URLSearchParams(search);
-  flags.forEach(([flag, value]) => { params.append(flag, value); });
+  // Use a Set to dedupe.
+  Array.from(new Set([...defaultFlags, ...flags])).forEach((flag) => {
+    params.append("enable-flag", flag);
+  });
   return [path, params].join("?");
 };

--- a/src/components/PrimaryNav/PrimaryNav.test.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.test.tsx
@@ -382,7 +382,48 @@ it("should not show Permissions navigation button if the controller doesn't supp
   ).not.toBeInTheDocument();
 });
 
-it("should show Permissions navigation button if the controller supports it", () => {
+it("should not show Permissions navigation button if the feature flag is not enabled", () => {
+  const state = rootStateFactory.build({
+    general: generalStateFactory.build({
+      config: configFactory.build({
+        controllerAPIEndpoint: "wss://controller.example.com",
+        isJuju: false,
+      }),
+      controllerConnections: {
+        "wss://controller.example.com": {
+          user: authUserInfoFactory.build(),
+        },
+      },
+      controllerFeatures: controllerFeaturesStateFactory.build({
+        "wss://controller.example.com": controllerFeaturesFactory.build({
+          rebac: true,
+        }),
+      }),
+    }),
+    juju: jujuStateFactory.build({
+      rebac: {
+        allowed: [
+          rebacAllowedFactory.build({
+            tuple: relationshipTupleFactory.build({
+              object: "user-eggman@external",
+              relation: JIMMRelation.ADMINISTRATOR,
+              target_object: JIMMTarget.JIMM_CONTROLLER,
+            }),
+            allowed: true,
+            loaded: true,
+          }),
+        ],
+      },
+    }),
+  });
+  renderComponent(<PrimaryNav />, { state });
+  expect(
+    screen.queryByRole("link", { name: Label.PERMISSIONS }),
+  ).not.toBeInTheDocument();
+});
+
+it("should show Permissions navigation button if the controller supports it and the feature flag is enabled", () => {
+  localStorage.setItem("flags", JSON.stringify(["rebac"]));
   const state = rootStateFactory.build({
     general: generalStateFactory.build({
       config: configFactory.build({

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -30,7 +30,9 @@ import {
 } from "store/juju/selectors";
 import type { Controllers } from "store/juju/types";
 import { useAppSelector } from "store/store";
+import { FeatureFlags } from "types";
 import urls, { externalURLs, rebacURLS } from "urls";
+import isFeatureFlagEnabled from "utils/isFeatureFlagEnabled";
 
 import { Label } from "./types";
 
@@ -91,13 +93,15 @@ const PrimaryNav: FC = () => {
   const versionRequested = useRef(false);
   const crossModelQueriesEnabled = useAppSelector(isCrossModelQueriesEnabled);
   const rebacEnabled = useAppSelector(isReBACEnabled);
+  const rebacFlagEnabled = isFeatureFlagEnabled(FeatureFlags.REBAC);
   const { blocked: blockedModels } = useAppSelector(
     getGroupedModelStatusCounts,
   );
   const { permitted: isJIMMControllerAdmin } = useIsJIMMAdmin();
   const { permitted: auditLogsAllowed } = useAuditLogsPermitted();
   const controllersLink = useControllersLink();
-  const rebacAllowed = rebacEnabled && isJIMMControllerAdmin;
+  const rebacAllowed =
+    rebacEnabled && rebacFlagEnabled && isJIMMControllerAdmin;
 
   useEffect(() => {
     if (appVersion && !versionRequested.current) {

--- a/src/components/WebCLI/WebCLI.test.tsx
+++ b/src/components/WebCLI/WebCLI.test.tsx
@@ -49,7 +49,6 @@ describe("WebCLI", () => {
 
   afterEach(() => {
     bakerySpy.mockClear();
-    localStorage.clear();
     WS.clean();
   });
 

--- a/src/hooks/useAnalytics.test.ts
+++ b/src/hooks/useAnalytics.test.ts
@@ -13,10 +13,6 @@ describe("useAnalytics", () => {
     vi.spyOn(analyticsUtils, "default").mockImplementation(() => vi.fn());
   });
 
-  afterEach(() => {
-    localStorage.clear();
-  });
-
   it("does not send events if analytics are disabled", () => {
     const { result } = renderWrappedHook(() => useAnalytics(), {
       state: rootStateFactory.build({

--- a/src/hooks/useLocalStorage.test.ts
+++ b/src/hooks/useLocalStorage.test.ts
@@ -3,10 +3,6 @@ import { act, renderHook } from "@testing-library/react";
 import useLocalStorage from "./useLocalStorage";
 
 describe("useLocalStorage", () => {
-  afterEach(() => {
-    localStorage.clear();
-  });
-
   it("can set an initial value", () => {
     const { result } = renderHook(() =>
       useLocalStorage("test-key", "init-val"),

--- a/src/hooks/useModelAttributes.test.ts
+++ b/src/hooks/useModelAttributes.test.ts
@@ -8,10 +8,6 @@ import {
 import useModelAttributes from "./useModelAttributes";
 
 describe("useModelAttributes", () => {
-  afterEach(() => {
-    localStorage.clear();
-  });
-
   it("handles no model data", () => {
     const { result } = renderHook(() => useModelAttributes(null));
     expect(result.current).toMatchObject({

--- a/src/pages/AdvancedSearch/SearchForm/SearchForm.test.tsx
+++ b/src/pages/AdvancedSearch/SearchForm/SearchForm.test.tsx
@@ -38,10 +38,6 @@ describe("SearchForm", () => {
     });
   });
 
-  afterEach(() => {
-    localStorage.clear();
-  });
-
   it("should initialise the form with the query from the URL", async () => {
     renderComponent(<SearchForm />, { state, url: "/?q=.applications" });
     expect(screen.getByRole("textbox")).toHaveTextContent(".applications");

--- a/src/pages/Permissions/Permissions.test.tsx
+++ b/src/pages/Permissions/Permissions.test.tsx
@@ -31,6 +31,7 @@ describe("PermissionsPage", () => {
   let state: RootState;
 
   beforeEach(() => {
+    localStorage.setItem("flags", JSON.stringify(["rebac"]));
     mock.reset();
     mock.onGet(endpoints().whoami).reply(200, {
       data: {
@@ -79,6 +80,10 @@ describe("PermissionsPage", () => {
   });
 
   describe("it doesn't display ReBAC Admin", () => {
+    beforeEach(() => {
+      localStorage.setItem("flags", JSON.stringify([]));
+    });
+
     it("if the feature is disabled", () => {
       state.general.controllerFeatures = controllerFeaturesStateFactory.build({
         "wss://controller.example.com": controllerFeaturesFactory.build({
@@ -109,6 +114,11 @@ describe("PermissionsPage", () => {
       expect(
         screen.queryByText("Canonical ReBAC Admin"),
       ).not.toBeInTheDocument();
+      expect(screen.getByText(PageNotFoundLabel.NOT_FOUND)).toBeInTheDocument();
+    });
+
+    it("if the feature flag is disabled", () => {
+      renderComponent(<PermissionsPage />, { state });
       expect(screen.getByText(PageNotFoundLabel.NOT_FOUND)).toBeInTheDocument();
     });
   });

--- a/src/pages/Permissions/Permissions.tsx
+++ b/src/pages/Permissions/Permissions.tsx
@@ -12,7 +12,9 @@ import { endpoints } from "juju/jimm/api";
 import MainContent from "layout/MainContent";
 import { isReBACEnabled } from "store/general/selectors";
 import { useAppSelector } from "store/store";
+import { FeatureFlags } from "types";
 import { rebacURLS } from "urls";
+import isFeatureFlagEnabled from "utils/isFeatureFlagEnabled";
 
 import { Label, TestId } from "./types";
 
@@ -42,6 +44,7 @@ const navItems = [
 const PermissionsPage = (): JSX.Element => {
   const logout = useLogout();
   const rebacEnabled = useAppSelector(isReBACEnabled);
+  const rebacFlagEnabled = isFeatureFlagEnabled(FeatureFlags.REBAC);
   const { permitted, loading } = useIsJIMMAdmin();
 
   useRef(
@@ -66,7 +69,7 @@ const PermissionsPage = (): JSX.Element => {
 
   return (
     <CheckPermissions
-      allowed={rebacEnabled && permitted}
+      allowed={rebacEnabled && rebacFlagEnabled && permitted}
       data-testid={TestId.COMPONENT}
       loading={loading}
     >

--- a/src/store/middleware/model-poller.test.ts
+++ b/src/store/middleware/model-poller.test.ts
@@ -135,7 +135,6 @@ describe("model poller", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
-    localStorage.clear();
     vi.useRealTimers();
     // @ts-expect-error - Resetting singleton for each test run.
     delete Auth.instance;

--- a/src/store/middleware/model-poller.test.ts
+++ b/src/store/middleware/model-poller.test.ts
@@ -298,7 +298,6 @@ describe("model poller", () => {
   });
 
   it("disables the controller features if JIMM < 4", async () => {
-    localStorage.setItem("flags", JSON.stringify(["rebac"]));
     conn.facades.modelManager.listModels.mockResolvedValue({
       "user-models": [],
     });
@@ -327,38 +326,7 @@ describe("model poller", () => {
     );
   });
 
-  it("disables rebac features if JIMM >= 4 but feature flag is disabled", async () => {
-    localStorage.setItem("flags", JSON.stringify([]));
-    conn.facades.modelManager.listModels.mockResolvedValue({
-      "user-models": [],
-    });
-    conn.facades.jimM = {
-      checkRelation: vi.fn().mockImplementation(async () => ({
-        allowed: true,
-      })),
-      version: 4,
-    };
-    vi.spyOn(jujuModule, "loginWithBakery").mockImplementation(async () => ({
-      conn,
-      intervalId,
-      juju,
-    }));
-    await runMiddleware();
-    expect(next).not.toHaveBeenCalled();
-    expect(fakeStore.dispatch).toHaveBeenCalledWith(
-      generalActions.updateControllerFeatures({
-        wsControllerURL,
-        features: {
-          auditLogs: true,
-          crossModelQueries: true,
-          rebac: false,
-        },
-      }),
-    );
-  });
-
-  it("updates the controller features if JIMM >= 4 and feature flag enabled", async () => {
-    localStorage.setItem("flags", JSON.stringify(["rebac"]));
+  it("updates the controller features if JIMM >= 4", async () => {
     conn.facades.modelManager.listModels.mockResolvedValue({
       "user-models": [],
     });

--- a/src/store/middleware/model-poller.ts
+++ b/src/store/middleware/model-poller.ts
@@ -27,10 +27,9 @@ import {
 } from "store/general/selectors";
 import { actions as jujuActions } from "store/juju";
 import type { RootState, Store } from "store/store";
-import { isSpecificAction, FeatureFlags } from "types";
+import { isSpecificAction } from "types";
 import { toErrorString } from "utils";
 import analytics from "utils/analytics";
-import isFeatureFlagEnabled from "utils/isFeatureFlagEnabled";
 import { logger } from "utils/logger";
 
 export enum LoginError {
@@ -156,14 +155,13 @@ export const modelPollerMiddleware: Middleware<
           }),
         );
         const jimmVersion = conn.facades.jimM?.version ?? 0;
-        const rebacFlagEnabled = isFeatureFlagEnabled(FeatureFlags.REBAC);
         reduxStore.dispatch(
           generalActions.updateControllerFeatures({
             wsControllerURL,
             features: {
               auditLogs: jimmVersion >= 4,
               crossModelQueries: jimmVersion >= 4,
-              rebac: rebacFlagEnabled && jimmVersion >= 4,
+              rebac: jimmVersion >= 4,
             },
           }),
         );

--- a/src/testing/setup.ts
+++ b/src/testing/setup.ts
@@ -70,3 +70,7 @@ vi.mock("@canonical/jujulib", () => ({
 vi.mock("@canonical/jujulib/dist/api/versions", () => ({
   jujuUpdateAvailable: vi.fn(),
 }));
+
+afterEach(() => {
+  localStorage.clear();
+});

--- a/src/utils/analytics.test.ts
+++ b/src/utils/analytics.test.ts
@@ -22,10 +22,6 @@ describe("analytics", () => {
     pageviewSpy = vi.spyOn(ReactGA, "send");
   });
 
-  afterEach(() => {
-    localStorage.clear();
-  });
-
   it("does not send events if analytics are disabled", () => {
     analytics(
       false,

--- a/src/utils/isFeatureFlagEnabled.test.ts
+++ b/src/utils/isFeatureFlagEnabled.test.ts
@@ -1,10 +1,6 @@
 import isFeatureFlagEnabled from "./isFeatureFlagEnabled";
 
 describe("isFeatureFlagEnabled", () => {
-  afterEach(() => {
-    localStorage.clear();
-  });
-
   it("should return true when flag is present in local storage", () => {
     localStorage.setItem("flags", JSON.stringify(["featureA"]));
     expect(isFeatureFlagEnabled("featureA")).toEqual(true);


### PR DESCRIPTION
## Done

- Check rebac permissions when using JIMM without needing to enable the flag (ReBAC Admin is still behind the flag).

## QA

- Connect to JIMM and make sure you don't have the rebac feature flag enabled.
- Check that the Permissions item is not in the side nav.
- Check that permissions are checked (i.e. you have audit logs in the side nav, have model access buttons etc.)
- Enable the rebac flag and the permissions item should appear in the side nav.

## Details

https://warthogs.atlassian.net/browse/WD-28065
