### PR TITLE
fix: transparent side panel

### DIFF
--- a/src/components/Panel/_panel.scss
+++ b/src/components/Panel/_panel.scss
@@ -2,6 +2,7 @@
   display: flex;
   flex: 1;
   flex-direction: column;
+  height: auto;
 
   .p-panel__content {
     display: flex;


### PR DESCRIPTION
## Done

- Fixed transparent panel background
- The issue was due to a fixed `height` rule coming from `react-components` that needed to be overridden

## QA

- Add a model
- Deploy an application with many actions (like postgresql)
- Open the actions panel and try clicking on different actions
- Scroll to the bottom on each selection to check that the panel stays opaque

## Details

https://warthogs.atlassian.net/browse/WD-29950
Fixes https://github.com/canonical/juju-dashboard/issues/2128

## Screenshots
The issue:
<img width="855" height="429" alt="Screenshot 2025-10-14 at 10 25 25 PM" src="https://github.com/user-attachments/assets/4cddee80-aef3-4689-a63e-05dfd8519c74" />

The cause:
<img width="654" height="504" alt="Screenshot 2025-10-14 at 10 30 27 PM" src="https://github.com/user-attachments/assets/21dc73c3-c294-480c-80bd-790223544f14" />

