### PR TITLE
feat: coordinate destroy model between CLI and UI

### DIFF
--- a/src/pages/AddModel/AddModelStepper/AddModelStepper.test.tsx
+++ b/src/pages/AddModel/AddModelStepper/AddModelStepper.test.tsx
@@ -86,8 +86,7 @@ describe("AddModelStepper", () => {
     await userEvent.click(
       screen.getByText("Configuration & Constraints (optional)"),
     );
-    expect(handleStepClick).toHaveBeenCalledWith(1);
-    expect(handleStepClick).toHaveBeenCalledTimes(1);
+    expect(handleStepClick).toHaveBeenCalledExactlyOnceWith(1);
   });
 
   it("shows the required model name label and an error icon when model name is empty", () => {

--- a/src/store/juju/slice.ts
+++ b/src/store/juju/slice.ts
@@ -1,7 +1,6 @@
 import type { Charm } from "@canonical/jujulib/dist/api/facades/charms/CharmsV6";
 import type { ApplicationStatus } from "@canonical/jujulib/dist/api/facades/client/ClientV8";
 import type { CloudsResult } from "@canonical/jujulib/dist/api/facades/cloud/CloudV7";
-import type { DestroyModelParams } from "@canonical/jujulib/dist/api/facades/model-manager/ModelManagerV10";
 import type {
   ListSecretResult,
   SecretValueResult,
@@ -36,6 +35,7 @@ import type {
   ModelUpgrade,
   AddModel,
   BlockEntry,
+  ModelDestructionParams,
 } from "./types";
 import { getModelQualifier } from "./utils/models";
 
@@ -283,10 +283,8 @@ const slice = createSlice({
       state,
       action: PayloadAction<
         {
-          models: ({
-            modelUUID: string;
-            modelName: string;
-          } & DestroyModelParams)[];
+          models: ModelDestructionParams[];
+          cliTriggered?: boolean;
         } & WsControllerURLParam
       >,
     ) => {
@@ -296,7 +294,7 @@ const slice = createSlice({
             loading: false,
             errors: null,
             loaded: false,
-            modelName: modelName,
+            modelName,
           }),
       );
     },

--- a/src/store/juju/types.ts
+++ b/src/store/juju/types.ts
@@ -1,7 +1,10 @@
 import type { Charm } from "@canonical/jujulib/dist/api/facades/charms/CharmsV6";
 import type { ApplicationStatus } from "@canonical/jujulib/dist/api/facades/client/ClientV8";
 import type { CloudsResult } from "@canonical/jujulib/dist/api/facades/cloud/CloudV7";
-import type { ErrorResult } from "@canonical/jujulib/dist/api/facades/model-manager/ModelManagerV10";
+import type {
+  DestroyModelParams,
+  ErrorResult,
+} from "@canonical/jujulib/dist/api/facades/model-manager/ModelManagerV10";
 import type {
   ListSecretResult,
   SecretValueResult,
@@ -170,6 +173,11 @@ export type BlockEntry = {
 };
 
 export type BlockState = Record<string, BlockEntry>;
+
+export type ModelDestructionParams = {
+  modelUUID: string;
+  modelName: string;
+} & DestroyModelParams;
 
 export type JujuState = {
   auditEvents: AuditEventsState;

--- a/src/store/middleware/model-poller.test.ts
+++ b/src/store/middleware/model-poller.test.ts
@@ -1172,6 +1172,123 @@ describe("model poller", () => {
     );
   });
 
+  it("batches models already destroying outside the dashboard by controller", async () => {
+    vi.spyOn(jujuModule, "loginWithBakery").mockImplementation(async () => ({
+      conn,
+      intervalId,
+      juju,
+    }));
+    vi.spyOn(jujuModule, "fetchAndStoreModelStatus").mockResolvedValue();
+    vi.spyOn(jujuModule, "fetchModelInfo")
+      .mockResolvedValueOnce({
+        results: [
+          {
+            result: modelInfoFactory.build({
+              life: "dying",
+              name: "a model",
+              uuid: "abc123",
+            }),
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        results: [
+          {
+            result: modelInfoFactory.build({
+              life: "dying",
+              name: "another model",
+              uuid: "xyz456",
+            }),
+          },
+        ],
+      });
+
+    const middleware = await runMiddleware();
+    vi.spyOn(fakeStore, "getState").mockImplementation(() =>
+      rootStateFactory.build({
+        juju: jujuStateFactory.build({
+          models: {
+            abc123: {
+              name: "a model",
+              qualifier: "eggman@external",
+              type: "model",
+              uuid: "abc123",
+              wsControllerURL,
+            },
+            xyz456: {
+              name: "another model",
+              qualifier: "eggman@external",
+              type: "model",
+              uuid: "xyz456",
+              wsControllerURL,
+            },
+          },
+        }),
+        general: storeState.general,
+      }),
+    );
+
+    await middleware(next)(updateModelStatuses());
+    expect(fakeStore.dispatch).toHaveBeenCalledWith(
+      jujuActions.destroyModels({
+        models: [
+          {
+            "model-tag": "model-abc123",
+            modelUUID: "abc123",
+            modelName: "a model",
+          },
+          {
+            "model-tag": "model-xyz456",
+            modelUUID: "xyz456",
+            modelName: "another model",
+          },
+        ],
+        cliTriggered: true,
+        wsControllerURL,
+      }),
+    );
+  });
+
+  it("tracks completion for cli-triggered destroy models without calling destroy api", async () => {
+    vi.spyOn(jujuModule, "loginWithBakery").mockImplementation(async () => ({
+      conn,
+      intervalId,
+      juju,
+    }));
+    const fetchModelInfo = vi
+      .spyOn(jujuModule, "fetchModelInfo")
+      .mockResolvedValue({ results: [{ result: undefined }] });
+    const middleware = await runMiddleware();
+    const action = jujuActions.destroyModels({
+      wsControllerURL: "wss://example.com/api",
+      models: [
+        {
+          "model-tag": "model-123abc",
+          modelUUID: "123abc",
+          modelName: "model123",
+        },
+      ],
+      cliTriggered: true,
+    });
+
+    await middleware(next)(action);
+
+    expect(conn.facades.modelManager.destroyModels).not.toHaveBeenCalled();
+    expect(fakeStore.dispatch).toHaveBeenCalledWith(
+      jujuActions.updateDestroyModelsLoading({
+        modelUUIDs: ["123abc"],
+        wsControllerURL: "wss://example.com/api",
+      }),
+    );
+    expect(fetchModelInfo).toHaveBeenCalledWith(conn, ["123abc"]);
+    expect(fakeStore.dispatch).toHaveBeenCalledWith(
+      jujuActions.updateModelsDestroyed({
+        modelUUIDs: ["123abc"],
+        wsControllerURL: "wss://example.com/api",
+      }),
+    );
+  });
+
   it("handles no controller when destroying models", async () => {
     vi.spyOn(jujuModule, "loginWithBakery").mockImplementation(async () => ({
       error: Label.CONTROLLER_LOGIN_ERROR,

--- a/src/store/middleware/model-poller.test.ts
+++ b/src/store/middleware/model-poller.test.ts
@@ -26,6 +26,7 @@ import {
 import {
   controllerFactory,
   jujuStateFactory,
+  modelListInfoFactory,
 } from "testing/factories/juju/juju";
 import { createStore } from "testing/utils";
 import { AccessLevel } from "types";
@@ -1208,20 +1209,16 @@ describe("model poller", () => {
       rootStateFactory.build({
         juju: jujuStateFactory.build({
           models: {
-            abc123: {
-              name: "a model",
-              qualifier: "eggman@external",
-              type: "model",
+            abc123: modelListInfoFactory.build({
               uuid: "abc123",
-              wsControllerURL,
-            },
-            xyz456: {
-              name: "another model",
-              qualifier: "eggman@external",
-              type: "model",
+              name: "test-model",
+              qualifier: "user-eggman@external",
+            }),
+            xyz456: modelListInfoFactory.build({
               uuid: "xyz456",
-              wsControllerURL,
-            },
+              name: "test-model2",
+              qualifier: "user-eggman@external",
+            }),
           },
         }),
         general: storeState.general,

--- a/src/store/middleware/model-poller.ts
+++ b/src/store/middleware/model-poller.ts
@@ -20,8 +20,9 @@ import { updateModelStatuses } from "store/app/actions";
 import { actions as generalActions } from "store/general";
 import { isLoggedIn } from "store/general/selectors";
 import { actions as jujuActions } from "store/juju";
-import { getModelList } from "store/juju/selectors";
+import { getDestructionState, getModelList } from "store/juju/selectors";
 import { addControllerCloudRegion } from "store/juju/thunks";
+import type { ModelDestructionParams } from "store/juju/types";
 import type { RootState, Store } from "store/store";
 import { AccessLevel, isSpecificAction } from "types";
 import { getUserName, toErrorString } from "utils";
@@ -107,6 +108,8 @@ function runModelPoller(
       const modelList = Object.entries(getModelList(reduxStore.getState()));
       let errorCount = 0;
       let lastErrorWSController = null;
+      const cliTriggeredDestructions: Record<string, ModelDestructionParams[]> =
+        {};
       for (const [modelUUID, { wsControllerURL }] of modelList) {
         const conn = await connections.get(wsControllerURL);
         if (!conn || !isLoggedIn(reduxStore.getState(), wsControllerURL)) {
@@ -134,12 +137,26 @@ function runModelPoller(
               wsControllerURL,
             }),
           );
+          const updatedModelInfo = modelInfo.results[0]?.result;
+          if (
+            updatedModelInfo?.life === "dying" &&
+            !getDestructionState(reduxStore.getState())[modelUUID] // This makes sure we are not picking up a destruction already keyed into the store.
+          ) {
+            cliTriggeredDestructions[wsControllerURL] = [
+              ...(cliTriggeredDestructions[wsControllerURL] ?? []),
+              {
+                modelUUID,
+                modelName: updatedModelInfo.name,
+                "model-tag": `model-${modelUUID}`,
+              },
+            ];
+          }
           if (!isLoggedIn(reduxStore.getState(), wsControllerURL)) {
             // The user may have logged out while the previous call was in
             // progress.
             continue;
           }
-          if (modelInfo?.results[0].result?.["is-controller"]) {
+          if (updatedModelInfo?.["is-controller"]) {
             // If this is a controller model then update the
             // controller data with this model data.
             reduxStore
@@ -160,6 +177,18 @@ function runModelPoller(
         } catch (error) {
           errorCount += 1;
           lastErrorWSController = wsControllerURL;
+        }
+      }
+      // Trigger batch `destroyModels` action controller-wise.
+      if (Object.entries(cliTriggeredDestructions).length > 0) {
+        for (const wsControllerURL in cliTriggeredDestructions) {
+          reduxStore.dispatch(
+            jujuActions.destroyModels({
+              models: cliTriggeredDestructions[wsControllerURL],
+              cliTriggered: true,
+              wsControllerURL,
+            }),
+          );
         }
       }
 
@@ -390,7 +419,7 @@ function runModelPoller(
     ) {
       // Intercept destroyModel actions and fetch and store
       // the models via the controller connection.
-      const { wsControllerURL, models } = action.payload;
+      const { wsControllerURL, models, cliTriggered = false } = action.payload;
       // Immediately pass the action along so that it can be handled by the
       // reducer to update the loading state.
       next(action);
@@ -403,32 +432,37 @@ function runModelPoller(
       let remainingModels: string[] = [];
       const destroyModelErrors: DestroyModelErrors = [];
 
-      try {
-        const result = await conn.facades.modelManager?.destroyModels({
-          models,
-        });
-        result?.results.forEach((errorResult, index) => {
-          if (errorResult.error) {
-            destroyModelErrors.push([
-              models[index].modelUUID,
-              errorResult.error.message,
-            ]);
-          } else {
-            remainingModels.push(models[index].modelUUID);
-          }
-        });
-      } catch (error) {
-        logger.error("Could not destroy model", error);
-        const errorMessages = models.map(({ modelUUID }) => [
-          modelUUID,
-          "Something went wrong during the model destruction process",
-        ]);
+      // Check if the operation was triggered from the CLI. If yes, don't call the facade.
+      if (cliTriggered) {
+        remainingModels = models.map(({ modelUUID }) => modelUUID);
+      } else {
+        try {
+          const result = await conn.facades.modelManager?.destroyModels({
+            models,
+          });
+          result?.results.forEach((errorResult, index) => {
+            if (errorResult.error) {
+              destroyModelErrors.push([
+                models[index].modelUUID,
+                errorResult.error.message,
+              ]);
+            } else {
+              remainingModels.push(models[index].modelUUID);
+            }
+          });
+        } catch (error) {
+          logger.error("Could not destroy model", error);
+          const errorMessages = models.map(({ modelUUID }) => [
+            modelUUID,
+            "Something went wrong during the model destruction process",
+          ]);
 
-        reduxStore.dispatch(
-          jujuActions.destroyModelErrors({
-            errors: errorMessages,
-          }),
-        );
+          reduxStore.dispatch(
+            jujuActions.destroyModelErrors({
+              errors: errorMessages,
+            }),
+          );
+        }
       }
 
       // Dispatch partial errors, if any, and continue with successful destructions


### PR DESCRIPTION
## Done

- Added the capability to pick up destroy-model action triggered from the CLI

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Add one or more models and deploy a few applications in them to prolong the destruction process. Alternately, you could also lower the poll interval in the dashboard.
- Trigger destroy on them from the CLI (try to pace them close to each other so that the dashboard picks up all of them in the next poll cycle).
- See that the dashboard reflects the destroy state with appropriate notifications.

## Details

https://warthogs.atlassian.net/browse/JUJU-9340

## Screenshots


https://github.com/user-attachments/assets/7306e3a1-974b-4c50-aa71-5c049ed665c9


