### PR TITLE
feat: add state for a model upgrade

### DIFF
--- a/src/store/juju/actions.test.ts
+++ b/src/store/juju/actions.test.ts
@@ -516,4 +516,26 @@ describe("actions", () => {
       payload,
     });
   });
+
+  it("addModelUpgrade", () => {
+    const payload = {
+      modelUUID: "abc123",
+      currentVersion: "1.2.3",
+      upgradeVersion: "3.2.1",
+    };
+    expect(actions.addModelUpgrade(payload)).toStrictEqual({
+      type: "juju/addModelUpgrade",
+      payload,
+    });
+  });
+
+  it("removeModelUpgrade", () => {
+    const payload = {
+      modelUUID: "abc123",
+    };
+    expect(actions.removeModelUpgrade(payload)).toStrictEqual({
+      type: "juju/removeModelUpgrade",
+      payload,
+    });
+  });
 });

--- a/src/store/juju/reducers.test.ts
+++ b/src/store/juju/reducers.test.ts
@@ -27,6 +27,7 @@ import {
   commandHistoryItem,
   cloudInfoStateFactory,
   userCredentialsStateFactory,
+  modelUpgradeFactory,
 } from "testing/factories/juju/juju";
 
 import { actions, reducer } from "./slice";
@@ -1762,6 +1763,52 @@ describe("reducers", () => {
           commandHistoryItem.build({ command: "status" }),
         ],
       }),
+    });
+  });
+
+  it("addModelUpgrade", () => {
+    const state = jujuStateFactory.build({
+      modelUpgrade: {},
+    });
+    expect(
+      reducer(
+        state,
+        actions.addModelUpgrade({
+          modelUUID: "abc123",
+          currentVersion: "1.2.3",
+          upgradeVersion: "3.2.1",
+        }),
+      ),
+    ).toStrictEqual({
+      ...state,
+      modelUpgrade: {
+        abc123: {
+          currentVersion: "1.2.3",
+          upgradeVersion: "3.2.1",
+        },
+      },
+    });
+  });
+
+  it("removeModelUpgrade", () => {
+    const state = jujuStateFactory.build({
+      modelUpgrade: {
+        abc123: modelUpgradeFactory.build(),
+        def456: modelUpgradeFactory.build(),
+      },
+    });
+    expect(
+      reducer(
+        state,
+        actions.removeModelUpgrade({
+          modelUUID: "abc123",
+        }),
+      ),
+    ).toStrictEqual({
+      ...state,
+      modelUpgrade: {
+        def456: modelUpgradeFactory.build(),
+      },
     });
   });
 

--- a/src/store/juju/selectors.test.ts
+++ b/src/store/juju/selectors.test.ts
@@ -40,6 +40,7 @@ import {
   commandHistoryItem,
   cloudInfoStateFactory,
   userCredentialsStateFactory,
+  modelUpgradeFactory,
 } from "testing/factories/juju/juju";
 
 import {
@@ -139,6 +140,7 @@ import {
   getSupportedJujuVersions,
   getCloudInfoState,
   getUserCredentialsState,
+  getModelUpgrade,
 } from "./selectors";
 
 describe("selectors", () => {
@@ -3309,5 +3311,19 @@ describe("getUserCredentialsState", () => {
       loaded: false,
       loading: false,
     });
+  });
+});
+
+describe("getModelUpgrade", () => {
+  it("gets model upgrade state by UUID", () => {
+    const upgrade = modelUpgradeFactory.build();
+    const state = rootStateFactory.build({
+      juju: jujuStateFactory.build({
+        modelUpgrade: {
+          abc123: upgrade,
+        },
+      }),
+    });
+    expect(getModelUpgrade(state, "abc123")).toStrictEqual(upgrade);
   });
 });

--- a/src/store/juju/selectors.ts
+++ b/src/store/juju/selectors.ts
@@ -1380,3 +1380,12 @@ export const getSupportedJujuVersions = createSelector(
       data: null,
     },
 );
+
+/**
+  Get a model upgrade by UUID.
+*/
+export const getModelUpgrade = createSelector(
+  [slice, (_, uuid: null | string = null): null | string => uuid],
+  (state, uuid) =>
+    uuid && uuid in state.modelUpgrade ? state.modelUpgrade[uuid] : null,
+);

--- a/src/store/juju/slice.ts
+++ b/src/store/juju/slice.ts
@@ -33,6 +33,7 @@ import type {
   ReBACAllowed,
   HistoryItem,
   SourceData,
+  ModelUpgrade,
 } from "./types";
 import { getModelQualifier } from "./utils/models";
 
@@ -130,6 +131,7 @@ const slice = createSlice({
     modelData: {},
     modelFeatures: {},
     modelListLoading: {},
+    modelUpgrade: {},
     charms: [],
     rebac: {
       allowed: [],
@@ -773,6 +775,33 @@ const slice = createSlice({
       value.loading = payload.update.loading ?? value.loading;
       value.data = payload.update.data ?? value.data;
       value.error = payload.update.error ?? value.error;
+    },
+    addModelUpgrade: (
+      state,
+      {
+        payload: { modelUUID, currentVersion, upgradeVersion },
+      }: PayloadAction<
+        {
+          modelUUID: string;
+        } & ModelUpgrade
+      >,
+    ) => {
+      state.modelUpgrade[modelUUID] = {
+        currentVersion,
+        upgradeVersion,
+      };
+    },
+    removeModelUpgrade: (
+      state,
+      {
+        payload: { modelUUID },
+      }: PayloadAction<{
+        modelUUID: string;
+      }>,
+    ) => {
+      if (modelUUID in state.modelUpgrade) {
+        delete state.modelUpgrade[modelUUID];
+      }
     },
   },
 });

--- a/src/store/juju/types.ts
+++ b/src/store/juju/types.ts
@@ -112,6 +112,13 @@ export type ModelFeatures = {
 
 export type ModelFeaturesState = Record<string, ModelFeatures>;
 
+export type ModelUpgrade = {
+  currentVersion: string;
+  upgradeVersion: string;
+};
+
+export type ModelUpgradeState = Record<string, ModelUpgrade>;
+
 export type ReBACAllowed = {
   tuple: RelationshipTuple;
   allowed?: boolean | null;
@@ -145,6 +152,7 @@ export type JujuState = {
   modelListLoading: Record<string, boolean>;
   modelData: ModelDataList;
   modelFeatures: ModelFeaturesState;
+  modelUpgrade: ModelUpgradeState;
   charms: Charm[];
   rebac: ReBACState;
   secrets: SecretsState;

--- a/src/store/middleware/check-auth.ts
+++ b/src/store/middleware/check-auth.ts
@@ -104,6 +104,8 @@ export const checkAuthMiddleware: Middleware<
       jujuActions.checkRelations.type,
       jujuActions.removeCheckRelations.type,
       jujuActions.addCommandHistory.type,
+      jujuActions.addModelUpgrade.type,
+      jujuActions.removeModelUpgrade.type,
     ];
 
     const thunkAllowlist = [

--- a/src/testing/factories/juju/juju.ts
+++ b/src/testing/factories/juju/juju.ts
@@ -15,6 +15,7 @@ import type {
   ModelFeaturesState,
   ModelListInfo,
   ModelSecrets,
+  ModelUpgrade,
   ReBACState,
   SecretsState,
   UserCredentialsState,
@@ -135,6 +136,11 @@ export const modelFeaturesStateFactory = Factory.define<ModelFeaturesState>(
   () => ({}),
 );
 
+export const modelUpgradeFactory = Factory.define<ModelUpgrade>(() => ({
+  currentVersion: "1.2.3",
+  upgradeVersion: "3.2.1",
+}));
+
 export const rebacState = Factory.define<ReBACState>(() => ({
   allowed: [],
   relationships: [],
@@ -159,6 +165,7 @@ export const jujuStateFactory = Factory.define<JujuState>(() => ({
   modelData: {},
   modelFeatures: {},
   modelListLoading: {},
+  modelUpgrade: {},
   charms: [],
   rebac: rebacState.build(),
   secrets: {},


### PR DESCRIPTION
## Done

- Added redux state, factory and selector for when an upgrade is in progress. It stores both the current version and the version in that it is upgrading to so that the upgrade can be displayed in the model list.

## Details

https://warthogs.atlassian.net/browse/JUJU-9590
