### PR TITLE
feat(connection): use connectionList to specify multiple connections

### DIFF
--- a/src/store/middleware/connection/middleware.test.ts
+++ b/src/store/middleware/connection/middleware.test.ts
@@ -17,7 +17,7 @@ type ConnectionManager = (typeof connectionManagerModule)["ConnectionManager"];
 type ConnectionManagerInstance = InstanceType<ConnectionManager>;
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-function createAction(withConnection?: boolean) {
+function createAction(withConnection?: boolean, connectionList?: string[]) {
   return {
     type: "some-action",
     payload: {
@@ -25,6 +25,7 @@ function createAction(withConnection?: boolean) {
     },
     meta: {
       withConnection,
+      connectionList,
     },
   };
 }
@@ -75,7 +76,9 @@ describe("connectionMiddleware", () => {
       action = createAction(true);
     });
 
-    it("fetches connection from `wsControllerURL`", async ({ expect }) => {
+    it("fetches connection from `wsControllerURL` by default", async ({
+      expect,
+    }) => {
       middleware(action);
       await vi.runOnlyPendingTimersAsync();
       expect(getMock).toHaveBeenCalledExactlyOnceWith("wss://example.com/");
@@ -98,7 +101,9 @@ describe("connectionMiddleware", () => {
       expect(next).toHaveBeenCalledExactlyOnceWith(
         expect.objectContaining({
           meta: expect.objectContaining({
-            connection,
+            connections: {
+              wsControllerURL: connection,
+            },
           }),
         }),
       );
@@ -118,6 +123,40 @@ describe("connectionMiddleware", () => {
         action,
       );
     });
+  });
+
+  it("fetches connections from `connections` key", async ({ expect }) => {
+    const connection1 = {} as ConnectionWithFacades;
+    const connection2 = {} as ConnectionWithFacades;
+    getMock
+      .mockResolvedValueOnce(connection1)
+      .mockResolvedValueOnce(connection2);
+
+    const action = {
+      type: "some-action",
+      payload: {
+        modelUrl: "wss://model.com",
+        controllerUrl: "wss://controller.com",
+        otherKey: "something",
+      },
+      meta: {
+        withConnection: true,
+        connectionList: ["modelUrl", "controllerUrl"],
+      },
+    };
+    middleware(action);
+    await vi.runOnlyPendingTimersAsync();
+    expect(getMock).toHaveBeenCalledTimes(2);
+    expect(next).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        meta: expect.objectContaining({
+          connections: {
+            modelUrl: connection1,
+            controllerUrl: connection2,
+          },
+        }),
+      }),
+    );
   });
 
   it.for([

--- a/src/store/middleware/connection/middleware.ts
+++ b/src/store/middleware/connection/middleware.ts
@@ -38,24 +38,25 @@ function hasConnectionURL<P extends Record<string, unknown>>(
 /**
  * Guard to ensure that the given object has a `connections` key with provided connection keys.
  */
-export function hasConnections<K extends readonly string[]>(
-  object: Record<string, unknown>,
-  connectionKeys: K,
-): object is { connections: Record<K[number], ConnectionWithFacades> } & Record<
+export function hasConnections<K extends string>(
+  meta: Record<string, unknown>,
+  connectionKeys: K[],
+): meta is { connections: Record<K, ConnectionWithFacades> } & Record<
   string,
   unknown
 > {
-  return (
-    "connections" in object &&
-    typeof object.connections === "object" &&
-    object.connections !== null &&
-    connectionKeys.every(
-      (key) =>
-        // @ts-expect-error - Doesn't pick up check due to closure
-        key in object.connections &&
-        // @ts-expect-error - Doesn't pick up check due to closure
-        object.connections[key] instanceof Connection,
+  if (
+    !(
+      "connections" in meta &&
+      typeof meta.connections === "object" &&
+      meta.connections !== null
     )
+  ) {
+    return false;
+  }
+  const connections = meta.connections as Record<string, unknown>;
+  return connectionKeys.every(
+    (key) => key in connections && connections[key] instanceof Connection,
   );
 }
 

--- a/src/store/middleware/connection/middleware.ts
+++ b/src/store/middleware/connection/middleware.ts
@@ -16,7 +16,7 @@ import {
 } from "store/general/selectors";
 import type { AuthCredential } from "store/general/types";
 import type { RootState, Store } from "store/store";
-import { isPayloadAction } from "types";
+import { isMetaAction, isPayloadAction } from "types";
 import analytics from "utils/analytics";
 import { logger } from "utils/logger";
 
@@ -26,21 +26,37 @@ export const MISSING_WS_CONTROLLER_URL_ERROR =
   "Action passed to connection middleware with `meta.withConnection: true`, but missing `payload.wsControllerURL`";
 
 /**
- * Guard to test of an action has `wsControllerURL` in the payload.
+ * Guard to test of an action has a connection URL in the payload.
  */
-function hasWsControllerURL<P extends object = Record<string, unknown>>(
+function hasConnectionURL<P extends Record<string, unknown>>(
   action: PayloadAction<P>,
-): action is PayloadAction<{ wsControllerURL: string } & P> {
-  return (
-    "wsControllerURL" in action.payload &&
-    typeof action.payload.wsControllerURL === "string"
-  );
+  key: string,
+): action is PayloadAction<{ [key]: string } & P> {
+  return key in action.payload && typeof action.payload[key] === "string";
 }
 
-export function hasConnection(
+/**
+ * Guard to ensure that the given object has a `connections` key with provided connection keys.
+ */
+export function hasConnections<K extends readonly string[]>(
   object: Record<string, unknown>,
-): object is { connection: ConnectionWithFacades } & Record<string, unknown> {
-  return "connection" in object && object.connection instanceof Connection;
+  connectionKeys: K,
+): object is { connections: Record<K[number], ConnectionWithFacades> } & Record<
+  string,
+  unknown
+> {
+  return (
+    "connections" in object &&
+    typeof object.connections === "object" &&
+    object.connections !== null &&
+    connectionKeys.every(
+      (key) =>
+        // @ts-expect-error - Doesn't pick up check due to closure
+        key in object.connections &&
+        // @ts-expect-error - Doesn't pick up check due to closure
+        object.connections[key] instanceof Connection,
+    )
+  );
 }
 
 /**
@@ -145,29 +161,48 @@ export function createConnectionMiddleware(): {
         return;
       }
 
-      if (!isAction(action) || !isPayloadAction(action)) {
+      if (
+        !isAction(action) ||
+        !isPayloadAction(action) ||
+        !isMetaAction(action)
+      ) {
         return next(action);
       }
 
       const withConnection =
-        "meta" in action &&
-        typeof action.meta === "object" &&
-        action.meta &&
         "withConnection" in action.meta &&
         typeof action.meta.withConnection === "boolean" &&
         action.meta.withConnection;
 
       if (withConnection) {
-        if (hasWsControllerURL(action)) {
-          // Action has the `withConnection` property, so attach the connection to it.
-          const connection = await connections.get(
-            action.payload.wsControllerURL,
-          );
-          action.meta = Object.assign(action.meta ?? {}, { connection });
-        } else {
-          // Warn that `withConnection` won't do anything unless there's a `wsControllerURL`.
-          logger.warn(MISSING_WS_CONTROLLER_URL_ERROR, action);
+        const connectionList = Array.isArray(action.meta.connectionList)
+          ? action.meta.connectionList
+          : ["wsControllerURL"];
+        const actionConnections: Record<
+          (typeof connectionList)[number],
+          ConnectionWithFacades
+        > = {};
+
+        for (const connectionKey of connectionList) {
+          if (typeof connectionKey !== "string") {
+            continue;
+          }
+
+          if (hasConnectionURL(action, connectionKey)) {
+            // Action has the `withConnection` property, so attach the connection to it.
+            const connection = await connections.get(
+              action.payload[connectionKey],
+            );
+            actionConnections[connectionKey] = connection;
+          } else {
+            // Warn that `withConnection` won't do anything unless there's a matching connection key.
+            logger.warn(MISSING_WS_CONTROLLER_URL_ERROR, action);
+          }
         }
+
+        action.meta = Object.assign(action.meta ?? {}, {
+          connections: actionConnections,
+        });
       }
 
       return next(action);

--- a/src/store/middleware/source/jimm-supported-versions.ts
+++ b/src/store/middleware/source/jimm-supported-versions.ts
@@ -12,7 +12,7 @@ export default createSourceMiddleware<
 >(
   "jimm-supported-versions",
   ({ wsControllerURL: _, meta }) => {
-    if (!hasConnections(meta, ["wsControllerURL"] as const)) {
+    if (!hasConnections(meta, ["wsControllerURL"])) {
       throw new Error("connection not provided");
     }
 

--- a/src/store/middleware/source/jimm-supported-versions.ts
+++ b/src/store/middleware/source/jimm-supported-versions.ts
@@ -3,7 +3,7 @@ import type { VersionElem } from "juju/jimm/JIMMV4";
 import { supportedJujuVersions } from "juju/jimm/api";
 import { actions as jujuActions } from "store/juju";
 
-import { hasConnection } from "../connection/middleware";
+import { hasConnections } from "../connection/middleware";
 import { createSourceMiddleware } from "../source-middleware";
 
 export default createSourceMiddleware<
@@ -12,11 +12,11 @@ export default createSourceMiddleware<
 >(
   "jimm-supported-versions",
   ({ wsControllerURL: _, meta }) => {
-    if (!hasConnection(meta)) {
+    if (!hasConnections(meta, ["wsControllerURL"] as const)) {
       throw new Error("connection not provided");
     }
 
-    const { connection } = meta;
+    const connection = meta.connections.wsControllerURL;
 
     return createPollingSource(
       async () => {

--- a/src/store/middleware/source/migration-targets.ts
+++ b/src/store/middleware/source/migration-targets.ts
@@ -11,7 +11,7 @@ export default createSourceMiddleware<
 >(
   "migration-targets",
   ({ wsControllerURL: _, modelUUID: modelUUID, meta }) => {
-    if (!hasConnections(meta, ["wsControllerURL"] as const)) {
+    if (!hasConnections(meta, ["wsControllerURL"])) {
       throw new Error("connection not provided");
     }
 

--- a/src/store/middleware/source/migration-targets.ts
+++ b/src/store/middleware/source/migration-targets.ts
@@ -2,7 +2,7 @@ import { createPollingSource } from "data/pollingSource";
 import { listMigrationTargets } from "juju/jimm/api";
 import { actions as jujuActions } from "store/juju";
 
-import { hasConnection } from "../connection/middleware";
+import { hasConnections } from "../connection/middleware";
 import { createSourceMiddleware } from "../source-middleware";
 
 export default createSourceMiddleware<
@@ -11,11 +11,11 @@ export default createSourceMiddleware<
 >(
   "migration-targets",
   ({ wsControllerURL: _, modelUUID: modelUUID, meta }) => {
-    if (!hasConnection(meta)) {
+    if (!hasConnections(meta, ["wsControllerURL"] as const)) {
       throw new Error("connection not provided");
     }
 
-    const { connection } = meta;
+    const connection = meta.connections.wsControllerURL;
 
     return createPollingSource(
       async () => {

--- a/src/store/middleware/source/model-list.ts
+++ b/src/store/middleware/source/model-list.ts
@@ -4,7 +4,7 @@ import * as appActions from "store/app/actions";
 import { actions as jujuActions } from "store/juju";
 import { logger } from "utils/logger";
 
-import { hasConnection } from "../connection/middleware";
+import { hasConnections } from "../connection/middleware";
 import { ModelsError } from "../model-poller";
 import { createSourceMiddleware } from "../source-middleware";
 
@@ -16,11 +16,11 @@ export default createSourceMiddleware<
   ({ wsControllerURL: _, meta }) => {
     return createPollingSource(
       async () => {
-        if (!hasConnection(meta)) {
+        if (!hasConnections(meta, ["wsControllerURL"] as const)) {
           throw new Error("connection not provided");
         }
 
-        const { connection } = meta;
+        const connection = meta.connections.wsControllerURL;
 
         if (!connection?.info.user?.identity) {
           throw new Error("not authenticated with controller");

--- a/src/store/middleware/source/model-list.ts
+++ b/src/store/middleware/source/model-list.ts
@@ -16,7 +16,7 @@ export default createSourceMiddleware<
   ({ wsControllerURL: _, meta }) => {
     return createPollingSource(
       async () => {
-        if (!hasConnections(meta, ["wsControllerURL"] as const)) {
+        if (!hasConnections(meta, ["wsControllerURL"])) {
           throw new Error("connection not provided");
         }
 

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -38,7 +38,7 @@ const store = configureStore({
     // https://redux-toolkit.js.org/usage/usage-with-typescript#correct-typings-for-the-dispatch-type
     const middleware = getDefaultMiddleware({
       serializableCheck: {
-        ignoredActionPaths: ["meta.connection"],
+        ignoredActionPaths: ["meta.connections"],
       },
     });
     // The checkAuth middleware must be first.

--- a/src/store/util.ts
+++ b/src/store/util.ts
@@ -1,20 +1,33 @@
 import type { PayloadAction, PayloadActionCreator } from "@reduxjs/toolkit";
 
 import type { ConnectionWithFacades } from "juju/types";
+import { isMetaAction } from "types";
+
+import { hasConnections } from "./middleware/connection/middleware";
 
 /**
- * Guard to ensure that the given action has `meta.connection` populated. This field is provided by
- * `connectionMiddleware`.
+ * Guard to ensure that the given action has `meta.connections` populated with expected connection
+ * keys. This field is provided by `connectionMiddleware`.
  */
-export function actionWithConnection<P, T extends string>(
+export function actionWithConnections<
+  P,
+  T extends string,
+  K extends readonly string[],
+>(
   expectedAction: PayloadActionCreator<P, T>,
   action: unknown,
-): action is PayloadAction<P, T, { connection: ConnectionWithFacades }> {
+  connectionKeys: K,
+): action is PayloadAction<
+  P,
+  T,
+  { connections: Record<K[number], ConnectionWithFacades> } & Record<
+    string,
+    unknown
+  >
+> {
   return (
     expectedAction.match(action) &&
-    "meta" in action &&
-    typeof action.meta === "object" &&
-    action.meta !== null &&
-    "connection" in action.meta
+    isMetaAction(action) &&
+    hasConnections(action.meta, connectionKeys)
   );
 }

--- a/src/store/util.ts
+++ b/src/store/util.ts
@@ -9,21 +9,14 @@ import { hasConnections } from "./middleware/connection/middleware";
  * Guard to ensure that the given action has `meta.connections` populated with expected connection
  * keys. This field is provided by `connectionMiddleware`.
  */
-export function actionWithConnections<
-  P,
-  T extends string,
-  K extends readonly string[],
->(
+export function actionWithConnections<P, T extends string, K extends string>(
   expectedAction: PayloadActionCreator<P, T>,
   action: unknown,
-  connectionKeys: K,
+  connectionKeys: K[],
 ): action is PayloadAction<
   P,
   T,
-  { connections: Record<K[number], ConnectionWithFacades> } & Record<
-    string,
-    unknown
-  >
+  { connections: Record<K, ConnectionWithFacades> } & Record<string, unknown>
 > {
   return (
     expectedAction.match(action) &&

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,17 @@ export const isPayloadAction = (
   !!action.payload &&
   typeof action.payload === "object";
 
+/**
+ * Guard to ensure action has `meta` key.
+ */
+export const isMetaAction = <P, T extends string>(
+  action: PayloadAction<P, T>,
+): action is PayloadAction<P, T, Record<string, unknown>> => {
+  return (
+    "meta" in action && typeof action.meta === "object" && action.meta !== null
+  );
+};
+
 export const isSpecificAction = <A extends Action>(
   action: UnknownAction,
   actionType: string,


### PR DESCRIPTION
Previously, `meta.connection` would be set to the connection associated
with `payload.wsControllerURL` if `meta.withConnection` was `true`. This
limited all actions to at most a single connection.

Now, `meta.connectionList` can be provided, containing a list of keys
present within `payload`. Connections will be added to `meta.connections`,
an object keyed by each key in `meta.connectionList`. If not provided,
it will default to `["wsControllerURL"]`.

Related utils, such as `hasConnection` have been updated to accept
a similar list of connection keys, in order to verify that they have
been added.

Before:

```
{
    type: "some/action",
    payload: {
        controller1: "wss://controller1.example.com/"
        controller2: "wss://controller2.example.com/"
    },
    metadata: {
        withConnection: true,
        connectionList: ["controller1", "controller2"],
    }
}
```

After:

```
{
    type: "some/action",
    payload: {
        controller1: "wss://controller1.example.com/"
        controller2: "wss://controller2.example.com/"
    },
    metadata: {
        withConnection: true,
        connectionList: ["controller1", "controller2"],
        connections: {
            controller1: Connection,
            controller2: Connection,
        }
    }
}
```