### PR TITLE
chore(ci): fix Juju workflows

### DIFF
--- a/.github/actions/setup-candid/action.yaml
+++ b/.github/actions/setup-candid/action.yaml
@@ -25,6 +25,13 @@ runs:
       uses: ./.github/actions/wait-for-snap
       with:
         snap: candid
+    - name: Wait for Candid config
+      shell: bash
+      run: |
+        until [ -f /var/snap/candid/current/config.yaml ]
+        do
+            sleep 1
+        done
     - name: Configure candid
       shell: bash
       run: |

--- a/.github/workflows/e2e-juju-k8s-charm-local-auth.yml
+++ b/.github/workflows/e2e-juju-k8s-charm-local-auth.yml
@@ -37,7 +37,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: "microk8s"
-          channel: 1.35-strict/stable
+          channel: 1.36-strict/stable
           juju-channel: ${{ inputs.juju-channel || steps.config.outputs.juju-channel }}
           microk8s-group: snap_microk8s
       - name: Save microk8s controller name

--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -46,6 +46,11 @@ on:
 
 permissions: read-all
 
+# Ensure only one e2e job runs at a time.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   juju-machine-local:
     name: Test Juju, machine-charm and local-auth
@@ -92,7 +97,7 @@ jobs:
     uses: ./.github/workflows/e2e-juju-machine-charm-local-auth.yml
     secrets: inherit
     with:
-      juju-channel: "4.0/stable"
+      juju-channel: "4.0/candidate"
       send-notification: false
     if: |
       github.event_name != 'pull_request' || (
@@ -103,7 +108,7 @@ jobs:
     uses: ./.github/workflows/e2e-juju-k8s-charm-local-auth.yml
     secrets: inherit
     with:
-      juju-channel: "4.0/stable"
+      juju-channel: "4.0/candidate"
       send-notification: false
     if: |
       github.event_name != 'pull_request' || (
@@ -114,7 +119,7 @@ jobs:
     uses: ./.github/workflows/e2e-jimm-k8s-charm-oidc-auth.yml
     secrets: inherit
     with:
-      juju-channel: "4.0/stable"
+      juju-channel: "4.0/candidate"
       send-notification: false
     if: |
       github.event_name != 'pull_request' || (

--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -97,7 +97,7 @@ jobs:
     uses: ./.github/workflows/e2e-juju-machine-charm-local-auth.yml
     secrets: inherit
     with:
-      juju-channel: "4.0/candidate"
+      juju-channel: "4.0/candidate" # Use the candidate channel while Juju 4.0 is in development.
       send-notification: false
     if: |
       github.event_name != 'pull_request' || (
@@ -108,7 +108,7 @@ jobs:
     uses: ./.github/workflows/e2e-juju-k8s-charm-local-auth.yml
     secrets: inherit
     with:
-      juju-channel: "4.0/candidate"
+      juju-channel: "4.0/candidate" # Use the candidate channel while Juju 4.0 is in development.
       send-notification: false
     if: |
       github.event_name != 'pull_request' || (
@@ -119,7 +119,7 @@ jobs:
     uses: ./.github/workflows/e2e-jimm-k8s-charm-oidc-auth.yml
     secrets: inherit
     with:
-      juju-channel: "4.0/candidate"
+      juju-channel: "4.0/candidate" # Use the candidate channel while Juju 4.0 is in development.
       send-notification: false
     if: |
       github.event_name != 'pull_request' || (

--- a/e2e/base/actions.spec.ts
+++ b/e2e/base/actions.spec.ts
@@ -86,9 +86,13 @@ test.describe("Actions", () => {
     // Go to the action logs and verify that the action was executed
     await page.getByRole("link", { name: AppLabel.VIEW_LOGS }).click();
     await expect(
-      page
-        .locator("tr", { hasText: application.name })
-        .and(page.locator("tr", { hasText: `1/${application.action}` })),
+      page.locator("tr", { hasText: application.name }).and(
+        page.locator("tr", {
+          // Juju 4 actions are zero indexed, while Juju 3 starts at 1. We don't really need to
+          // check the number, just the action so this uses a regex to match any number.
+          hasText: new RegExp(`\\d\\/${application.action}`),
+        }),
+      ),
     ).toBeInViewport();
   });
 

--- a/e2e/base/destroy-model.spec.ts
+++ b/e2e/base/destroy-model.spec.ts
@@ -39,7 +39,7 @@ test.describe("Destroy Model", () => {
       .getByRole("button", { name: ModelActionsLabel.TOGGLE })
       .click();
     await expect(
-      page.getByRole("button", {
+      page.getByRole("menuitem", {
         name: ModelActionsLabel.DESTROY,
       }),
     ).toHaveAttribute("aria-disabled", "true");
@@ -56,7 +56,7 @@ test.describe("Destroy Model", () => {
       .getByRole("button", { name: ModelActionsLabel.TOGGLE })
       .click();
     await page
-      .getByRole("button", {
+      .getByRole("menuitem", {
         name: ModelActionsLabel.DESTROY,
       })
       .click();

--- a/e2e/base/models.spec.ts
+++ b/e2e/base/models.spec.ts
@@ -5,7 +5,7 @@ import { Label as ModelLabel } from "pages/EntityDetails/Model/types";
 import { Label as EntityDetailsLabel } from "pages/EntityDetails/types";
 import urls from "urls";
 
-import { JujuEnv, test } from "../fixtures/setup";
+import { test } from "../fixtures/setup";
 import { ActionStack } from "../helpers/action";
 import { AddModel, GiveModelAccess } from "../helpers/actions";
 import type { User } from "../helpers/auth";
@@ -59,10 +59,7 @@ test.describe("Models", () => {
     await expect(page.getByText(EntityDetailsLabel.NOT_FOUND)).toBeVisible();
   });
 
-  test("model list disables access button to non-admins", async ({
-    page,
-    testOptions,
-  }) => {
+  test("model list disables access button to non-admins", async ({ page }) => {
     await user2.dashboardLogin(page, urls.models.index);
     await page
       .locator("tr", { hasText: sharedModel.name })
@@ -70,7 +67,7 @@ test.describe("Models", () => {
       .click();
     await expect(
       // In JIMM, this element is rendered as a link.
-      page.getByRole(testOptions.jujuEnv === JujuEnv.JIMM ? "link" : "button", {
+      page.getByRole("menuitem", {
         name: ModelActionsLabel.ACCESS,
       }),
     ).toHaveAttribute("aria-disabled", "true");

--- a/e2e/base/models.spec.ts
+++ b/e2e/base/models.spec.ts
@@ -5,7 +5,7 @@ import { Label as ModelLabel } from "pages/EntityDetails/Model/types";
 import { Label as EntityDetailsLabel } from "pages/EntityDetails/types";
 import urls from "urls";
 
-import { JujuEnv, test } from "../fixtures/setup";
+import { test } from "../fixtures/setup";
 import { ActionStack } from "../helpers/action";
 import { AddModel, GiveModelAccess } from "../helpers/actions";
 import type { User } from "../helpers/auth";
@@ -59,18 +59,16 @@ test.describe("Models", () => {
     await expect(page.getByText(EntityDetailsLabel.NOT_FOUND)).toBeVisible();
   });
 
-  test("model list disables access button to non-admins", async ({
-    page,
-    testOptions,
-  }) => {
+  test("model list disables access button to non-admins", async ({ page }) => {
     await user2.dashboardLogin(page, urls.models.index);
+    // Wait for the models to have loaded to prevent content shifts from causing the click to happen on the wrong item.
+    await expect(page.locator("tr")).toHaveCount(3);
     await page
       .locator("tr", { hasText: sharedModel.name })
       .getByRole("button", { name: ModelActionsLabel.TOGGLE })
       .click();
     await expect(
-      // In JIMM, this element is rendered as a link.
-      page.getByRole(testOptions.jujuEnv === JujuEnv.JIMM ? "link" : "button", {
+      page.getByRole("menuitem", {
         name: ModelActionsLabel.ACCESS,
       }),
     ).toHaveAttribute("aria-disabled", "true");

--- a/e2e/base/secrets.spec.ts
+++ b/e2e/base/secrets.spec.ts
@@ -72,12 +72,13 @@ test.describe("secrets", () => {
       .getByRole("button", { name: SecretFormPanelLabel.SUBMIT_ADD })
       .click();
 
-    // Verify the secret was added and copy the URI
-    await expect(
-      page.getByRole("dialog", {
+    // Wait for the panel close animation to finish so that it doesn't block clicking on the application tab.
+    await page
+      .getByRole("dialog", {
         name: SecretFormPanelLabel.TITLE_ADD,
-      }),
-    ).not.toBeInViewport();
+      })
+      .waitFor({ state: "detached" });
+    // Verify the secret was added and copy the URI
     await expect(page.locator("tr", { hasText: secret })).toBeInViewport();
     const secretID = await page
       .locator("tr", { hasText: secret })

--- a/e2e/fixtures/setup.ts
+++ b/e2e/fixtures/setup.ts
@@ -1,7 +1,7 @@
 import { test as base } from "@playwright/test";
 
 import { JujuCLI } from "../helpers/juju-cli";
-import { getEnv } from "../utils";
+import { exec, getEnv } from "../utils";
 
 export enum JujuEnv {
   JIMM = "jimm",
@@ -70,11 +70,13 @@ export const test = base.extend<Fixtures>({
     { option: true },
   ],
   jujuCLI: async ({ testOptions, browser }, use) => {
+    const versionOutput = await exec("juju --version");
     await use(
       new JujuCLI(
         testOptions.jujuEnv,
         testOptions.controllerName,
         testOptions.provider,
+        versionOutput.stdout.trim().split("-")?.[0],
         browser,
       ),
     );

--- a/e2e/helpers/actions/deployApplication.ts
+++ b/e2e/helpers/actions/deployApplication.ts
@@ -3,7 +3,7 @@ import { exec, generateRandomName } from "../../utils";
 import type { Action } from "../action";
 import type { JujuCLI } from "../juju-cli";
 import { Application, type Model } from "../objects";
-import { CharmName } from "../objects/application";
+import { CHARM_DEPLOY_ARGS, CharmName } from "../objects/application";
 
 /**
  * Deploy a new application.
@@ -12,7 +12,7 @@ export class DeployApplication implements Action<Application> {
   public application: Application;
   constructor(
     private model: Model,
-    provider: Provider,
+    private provider: Provider,
   ) {
     const charm = CharmName[provider];
     const name = generateRandomName(charm);
@@ -27,7 +27,7 @@ export class DeployApplication implements Action<Application> {
     }
     await exec(`juju switch '${this.model.name}'`);
     await exec(
-      `juju deploy '${this.application.charm}' '${this.application.name}'`,
+      `juju deploy '${this.application.charm}' '${this.application.name}' ${CHARM_DEPLOY_ARGS[this.provider]}`,
     );
     await exec(
       `TYPE=application NAME='${this.application.name}' TIMEOUT_MINUTES=10 EXPECTED_STATUS=active,blocked,error ./scripts/wait-for`,

--- a/e2e/helpers/juju-cli.ts
+++ b/e2e/helpers/juju-cli.ts
@@ -1,5 +1,7 @@
 import type { Browser } from "@playwright/test";
 
+import getMajorMinorVersion from "utils/getMajorMinorVersion";
+
 import { JujuEnv } from "../fixtures/setup";
 import { CloudAccessType } from "../fixtures/setup";
 import { getEnv, exec } from "../utils";
@@ -76,12 +78,20 @@ class BootstrapAction implements Action<User> {
   async rollback(jujuCLI: JujuCLI): Promise<void> {
     if (this.giveCredentials) {
       const user = this.result();
+      let credentialName = user.cliUsername;
+      const majorMinor = getMajorMinorVersion(jujuCLI.jujuVersion);
+      // Juju 4 requires the credential to be removed by the user and the credential is named after the provider.
+      if (jujuCLI.jujuEnv === JujuEnv.JUJU && majorMinor && majorMinor >= 4) {
+        await user.cliLogin(jujuCLI.browser);
+        credentialName = jujuCLI.provider;
+      }
       // Remove the user's credential
       await exec(
-        `juju remove-credential --force -c '${jujuCLI.controller}' '${jujuCLI.provider}' '${user.cliUsername}'`,
+        `juju remove-credential -c '${jujuCLI.controller}' '${jujuCLI.provider}' '${credentialName}'`,
       );
 
       if (jujuCLI.jujuEnv !== JujuEnv.JIMM) {
+        await jujuCLI.loginIdentityCLIAdmin();
         // Remove the user's access to the cloud
         await exec(
           `juju revoke-cloud -c '${jujuCLI.controller}' ${user.cliUsername} ${CloudAccessType.ADD_MODEL} ${jujuCLI.provider}`,
@@ -117,6 +127,7 @@ export class JujuCLI {
     public jujuEnv: JujuEnv,
     public controller: string,
     public provider: string,
+    public jujuVersion: string,
     public browser: Browser,
   ) {
     this.users = new Users(browser);

--- a/e2e/helpers/objects/application.ts
+++ b/e2e/helpers/objects/application.ts
@@ -9,25 +9,29 @@ import type { Model } from "../objects";
  */
 export enum CharmName {
   // spell
-  localhost = "anbox-cloud-dashboard",
-  microk8s = "pgbouncer-k8s",
+  localhost = "any-charm",
+  microk8s = "any-charm",
 }
 
 /**
  * Action to run.
  */
 export enum ActionName {
-  "anbox-cloud-dashboard" = "backup",
-  "pgbouncer-k8s" = "pre-upgrade-check",
+  "any-charm" = "get-relation-data",
 }
 
 /**
  * Config property to change.
  */
 export enum ConfigName {
-  "anbox-cloud-dashboard" = "location",
-  "pgbouncer-k8s" = "pool_mode",
+  "any-charm" = "python-packages",
 }
+
+export const CHARM_DEPLOY_ARGS = {
+  localhost: "--channel beta",
+  // --trust is required for the k8s charm to access secrets.
+  microk8s: "--channel beta --trust",
+};
 
 export class Application {
   public action: string;

--- a/e2e/juju/model-access-control.spec.ts
+++ b/e2e/juju/model-access-control.spec.ts
@@ -36,7 +36,9 @@ test.describe("Model Access Control", () => {
     await user2.dashboardLogin(page, urls.models.index);
 
     await page.getByRole("button", { name: ModelActionsLabel.TOGGLE }).click();
-    await page.getByRole("button", { name: ModelActionsLabel.ACCESS }).click();
+    await page
+      .getByRole("menuitem", { name: ModelActionsLabel.ACCESS })
+      .click();
 
     await expect(
       page.getByRole("dialog", {

--- a/src/auth/OIDCAuth.test.ts
+++ b/src/auth/OIDCAuth.test.ts
@@ -2,10 +2,10 @@ import type { Mock } from "vitest";
 
 import * as jimmListeners from "juju/jimm/listeners";
 import * as jimmThunks from "juju/jimm/thunks";
-import { actions as generalActions } from "store/general";
 
 import { Auth } from "./Auth";
 import { OIDCAuth } from "./OIDCAuth";
+import { OIDCAuthLabel } from "./types";
 
 describe("OIDCAuth", () => {
   let dispatch: Mock;
@@ -44,7 +44,6 @@ describe("OIDCAuth", () => {
     it("with user", async () => {
       const whoamiThunkMock = vi.spyOn(jimmThunks, "whoami");
       const pollWhoamiStartMock = vi.spyOn(jimmListeners, "pollWhoamiStart");
-      const storeLoginErrorMock = vi.spyOn(generalActions, "storeLoginError");
       dispatch
         // whoami
         .mockResolvedValueOnce({ payload: {} });
@@ -55,13 +54,11 @@ describe("OIDCAuth", () => {
       expect(whoamiThunkMock).toHaveBeenCalledOnce();
       expect(pollWhoamiStartMock).toHaveBeenCalledOnce();
       expect(connectionContinue).to.equal(true);
-      expect(storeLoginErrorMock).not.toHaveBeenCalledOnce();
     });
 
     it("without user", async () => {
       const whoamiThunkMock = vi.spyOn(jimmThunks, "whoami");
       const pollWhoamiStartMock = vi.spyOn(jimmListeners, "pollWhoamiStart");
-      const storeLoginErrorMock = vi.spyOn(generalActions, "storeLoginError");
       dispatch
         // whoami
         .mockResolvedValueOnce({ payload: null });
@@ -72,27 +69,20 @@ describe("OIDCAuth", () => {
       expect(whoamiThunkMock).toHaveBeenCalledOnce();
       expect(pollWhoamiStartMock).not.toHaveBeenCalled();
       expect(connectionContinue).to.equal(false);
-      expect(storeLoginErrorMock).not.toHaveBeenCalledOnce();
     });
 
     it("with user error", async () => {
-      const whoamiThunkMock = vi.spyOn(jimmThunks, "whoami");
-      const pollWhoamiStartMock = vi.spyOn(jimmListeners, "pollWhoamiStart");
-      const storeLoginErrorMock = vi.spyOn(generalActions, "storeLoginError");
       dispatch
         // whoami
         .mockResolvedValueOnce({
           payload: undefined,
           error: new Error("some error"),
         });
-      const connectionContinue = await Auth.instance.beforeControllerConnect({
-        wsControllerURL: "wss://1.2.3.4/api",
-      });
-      expect(dispatch).toBeCalledTimes(2);
-      expect(whoamiThunkMock).toHaveBeenCalledOnce();
-      expect(pollWhoamiStartMock).not.toHaveBeenCalled();
-      expect(connectionContinue).to.equal(false);
-      expect(storeLoginErrorMock).toHaveBeenCalledOnce();
+      await expect(
+        Auth.instance.beforeControllerConnect({
+          wsControllerURL: "wss://1.2.3.4/api",
+        }),
+      ).rejects.toThrowError(OIDCAuthLabel.WHOAMI);
     });
   });
 

--- a/src/auth/OIDCAuth.ts
+++ b/src/auth/OIDCAuth.ts
@@ -3,7 +3,6 @@ import { unwrapResult } from "@reduxjs/toolkit";
 
 import * as jimmListeners from "juju/jimm/listeners";
 import * as jimmThunks from "juju/jimm/thunks";
-import { actions as generalActions } from "store/general";
 import { listenerMiddleware } from "store/listenerMiddleware";
 import type { AppDispatch } from "store/store";
 
@@ -29,7 +28,7 @@ export class OIDCAuth extends pollingMixin(Auth) {
   }
 
   override async beforeControllerConnect({
-    wsControllerURL,
+    wsControllerURL: _,
   }: ControllerData): Promise<boolean> {
     try {
       const whoamiResponse = await this.dispatch(jimmThunks.whoami());
@@ -44,14 +43,7 @@ export class OIDCAuth extends pollingMixin(Auth) {
         return false;
       }
     } catch (error) {
-      this.dispatch(
-        generalActions.storeLoginError({
-          wsControllerURL,
-          error: OIDCAuthLabel.WHOAMI,
-        }),
-      );
-      // Halt the connection attempt.
-      return false;
+      throw new Error(OIDCAuthLabel.WHOAMI);
     }
 
     return true;

--- a/src/auth/OIDCAuth.ts
+++ b/src/auth/OIDCAuth.ts
@@ -3,7 +3,6 @@ import { unwrapResult } from "@reduxjs/toolkit";
 
 import * as jimmListeners from "juju/jimm/listeners";
 import * as jimmThunks from "juju/jimm/thunks";
-import { actions as generalActions } from "store/general";
 import { listenerMiddleware } from "store/listenerMiddleware";
 import type { AppDispatch } from "store/store";
 
@@ -28,9 +27,7 @@ export class OIDCAuth extends pollingMixin(Auth) {
     await this.dispatch(jimmThunks.logout());
   }
 
-  override async beforeControllerConnect({
-    wsControllerURL,
-  }: ControllerData): Promise<boolean> {
+  override async beforeControllerConnect(_: ControllerData): Promise<boolean> {
     try {
       const whoamiResponse = await this.dispatch(jimmThunks.whoami());
       const user = unwrapResult(whoamiResponse);
@@ -44,14 +41,7 @@ export class OIDCAuth extends pollingMixin(Auth) {
         return false;
       }
     } catch (error) {
-      this.dispatch(
-        generalActions.storeLoginError({
-          wsControllerURL,
-          error: OIDCAuthLabel.WHOAMI,
-        }),
-      );
-      // Halt the connection attempt.
-      return false;
+      throw new Error(OIDCAuthLabel.WHOAMI);
     }
 
     return true;

--- a/src/store/middleware/model-poller.ts
+++ b/src/store/middleware/model-poller.ts
@@ -41,7 +41,6 @@ import { ModelsError } from "./types";
 export enum LoginError {
   LOG = "Unable to log into controller.",
   NO_INFO = "Unable to retrieve controller details.",
-  WHOAMI = "Unable to check authentication status. You can attempt to log in anyway.",
 }
 
 function runModelPoller(


### PR DESCRIPTION
## Done

Last run before label change: https://github.com/canonical/juju-dashboard/actions/runs/26380890550?pr=2296.

- Fixed the contextual menu item roles to match the changes in react-components.
- Fixed Candid snap issue.
- Made it so that it cancels in-progress jobs when pushing changes.
- Fixed issues in e2e related to shifting content.
- Swapped to a faster charm.
- Fixed an issue where if there was an error when checking the login status it would display the "could not continue" error instead of the specific whoami error.

NOTE:
- the JIMM workflows are being addressed in this PR: https://github.com/canonical/juju-dashboard/pull/2236.
- Juju 4.0 with microk8s is currently failing due to a secrets issue that I will address separately if it's not a bug in the latest release.
