### PR TITLE
feat: display upgrade status

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -10,6 +10,7 @@
           "extend",
           "mixin",
           "include",
+          "for",
           "function",
           "if",
           "warn",

--- a/src/components/ModelTableList/ModelTable/ModelTable.tsx
+++ b/src/components/ModelTableList/ModelTable/ModelTable.tsx
@@ -1,4 +1,4 @@
-import { Chip, MainTable } from "@canonical/react-components";
+import { Chip, MainTable, Spinner } from "@canonical/react-components";
 import type {
   MainTableCell,
   MainTableRow,
@@ -12,8 +12,17 @@ import ModelDetailsLink from "components/ModelDetailsLink";
 import ModelVersion from "components/ModelVersion";
 import Status from "components/Status";
 import TruncatedTooltip from "components/TruncatedTooltip";
-import { getControllerData, getDestructionState } from "store/juju/selectors";
-import type { Controllers, DestroyState, ModelData } from "store/juju/types";
+import {
+  getControllerData,
+  getDestructionState,
+  getModelUpgrades,
+} from "store/juju/selectors";
+import type {
+  Controllers,
+  DestroyState,
+  ModelData,
+  ModelUpgradeState,
+} from "store/juju/types";
 import { getControllerByUUID } from "store/juju/utils/controllers";
 import {
   extractOwnerName,
@@ -55,6 +64,7 @@ const getConditionalCell = (
 function generateModelTableList(
   models: ModelData[],
   controllers: Controllers | null,
+  modelUpgrades: ModelUpgradeState,
   groupBy: GroupBy,
   destructionState: DestroyState,
   groupLabel?: string,
@@ -78,6 +88,9 @@ function generateModelTableList(
         : controller?.path) || controllerUUID;
     const lastUpdated = getLastUpdated(model);
     const isDying = model.uuid in destructionState;
+    const upgrade =
+      model.uuid in modelUpgrades ? modelUpgrades[model.uuid] : null;
+    const isUpgrading = !!upgrade;
     const columns = [
       {
         ...testId(TestId.COLUMN_NAME),
@@ -86,7 +99,12 @@ function generateModelTableList(
             <div className="model-name-column">
               {isDying ? (
                 <span className="model-name-column__status u-truncate">
-                  Destroying&hellip;&nbsp;
+                  Destroying&hellip;
+                </span>
+              ) : null}
+              {isUpgrading ? (
+                <span className="model-name-column__status">
+                  <Spinner />
                 </span>
               ) : null}
               <div className="model-name-column__name">
@@ -100,14 +118,31 @@ function generateModelTableList(
                   >
                     {model.model.name}
                   </ModelDetailsLink>
-                  <ModelVersion
-                    className="models__version"
-                    modelName={model.model.name}
-                    qualifier={qualifier}
-                  />
+                  {isUpgrading ? null : (
+                    <ModelVersion
+                      className="models__version"
+                      modelName={model.model.name}
+                      qualifier={qualifier}
+                    />
+                  )}
                 </TruncatedTooltip>
               </div>
             </div>
+            {isUpgrading ? (
+              <>
+                <ModelVersion
+                  modelName={model.model.name}
+                  qualifier={qualifier}
+                  version={upgrade.currentVersion}
+                />
+                <span className="u-sh1 u-sh1--right">&rarr;</span>
+                <ModelVersion
+                  modelName={model.model.name}
+                  qualifier={qualifier}
+                  version={upgrade.upgradeVersion}
+                />
+              </>
+            ) : null}
             {groupBy === GroupBy.STATUS && groupLabel === "Blocked" ? (
               <WarningMessage model={model} />
             ) : null}
@@ -243,6 +278,7 @@ export default function ModelTable({
 }: Props): JSX.Element {
   const controllers = useAppSelector(getControllerData);
   const destructionState = useAppSelector(getDestructionState);
+  const modelUpgrades = useAppSelector(getModelUpgrades);
 
   const headerOptions = {
     showCloud: [GroupBy.STATUS, GroupBy.OWNER].includes(groupBy),
@@ -258,11 +294,12 @@ export default function ModelTable({
       generateModelTableList(
         models,
         controllers,
+        modelUpgrades,
         groupBy,
         destructionState,
         groupLabel,
       ),
-    [models, controllers, groupBy, destructionState, groupLabel],
+    [models, controllers, modelUpgrades, groupBy, destructionState, groupLabel],
   );
 
   return (

--- a/src/components/ModelTableList/ModelTableList.test.tsx
+++ b/src/components/ModelTableList/ModelTableList.test.tsx
@@ -7,8 +7,10 @@ import {
   controllerFactory,
   jujuStateFactory,
   modelDataFactory,
+  modelUpgradeFactory,
 } from "testing/factories/juju/juju";
 import { rootStateFactory } from "testing/factories/root";
+import { customWithin } from "testing/queries/within";
 import { renderComponent } from "testing/utils";
 
 import { CloudGroupTestId } from "./CloudGroup";
@@ -121,5 +123,24 @@ describe("ModelTableList", () => {
     expect(within(row).getByTestId(TestId.COLUMN_CONTROLLER)).toHaveTextContent(
       "admins/1-eu-west-1-aws-jaas",
     );
+  });
+
+  it("displays when a model is being upgraded", () => {
+    const testModelUUID = "abc123";
+    state.juju.modelUpgrade = {
+      [testModelUUID]: modelUpgradeFactory.build({
+        currentVersion: "1.2.3",
+        upgradeVersion: "2.3.4",
+      }),
+    };
+    renderComponent(<ModelTableList filters={{}} groupedBy="" />, {
+      state,
+    });
+    const row = screen.getByTestId(`model-uuid-${testModelUUID}`);
+    const [nameCell] = customWithin(row).getAllByRole("gridcell");
+    expect(
+      customWithin(nameCell).getSpinnerByLabel("Loading"),
+    ).toBeInTheDocument();
+    expect(nameCell).toHaveTextContent(/1.2.3→2.3.4/);
   });
 });

--- a/src/components/ModelTableList/_model-table-list.scss
+++ b/src/components/ModelTableList/_model-table-list.scss
@@ -5,6 +5,7 @@
 
     &__status {
       flex-shrink: 0;
+      margin-right: $sph--small;
     }
 
     &__name {

--- a/src/components/ModelTableList/_model-table-list.scss
+++ b/src/components/ModelTableList/_model-table-list.scss
@@ -50,6 +50,23 @@
   .status-group {
     td,
     th {
+      @include desktop {
+        // Summary icons
+        &:nth-child(2) {
+          width: 8rem;
+        }
+
+        // Last updated
+        &:nth-child(7) {
+          width: 7rem;
+        }
+
+        // Actions
+        &:nth-child(8) {
+          width: 5rem;
+        }
+      }
+
       @include mobile-and-medium {
         // Credential
         &:nth-child(5),
@@ -73,6 +90,23 @@
   .owners-group {
     td,
     th {
+      @include desktop {
+        // Summary icons
+        &:nth-child(2) {
+          width: 8rem;
+        }
+
+        // Last updated
+        &:nth-child(7) {
+          width: 7rem;
+        }
+
+        // Actions
+        &:nth-child(8) {
+          width: 5rem;
+        }
+      }
+
       @include mobile-and-medium {
         // Credential
         &:nth-child(5),
@@ -96,6 +130,33 @@
   .cloud-group {
     td,
     th {
+      @include desktop {
+        // Summary icons
+        &:nth-child(2) {
+          width: 8rem;
+        }
+
+        // Region
+        &:nth-child(5) {
+          width: 7rem;
+        }
+
+        // Credential
+        &:nth-child(6) {
+          width: 7rem;
+        }
+
+        // Last updated
+        &:nth-child(8) {
+          width: 7rem;
+        }
+
+        // Actions
+        &:nth-child(9) {
+          width: 5rem;
+        }
+      }
+
       @include mobile-and-medium {
         // Credential
         &:nth-child(6),

--- a/src/components/ModelVersion/ModelVersion.test.tsx
+++ b/src/components/ModelVersion/ModelVersion.test.tsx
@@ -81,4 +81,16 @@ describe("ModelVersion", () => {
     );
     expect(document.querySelector(".p-chip--caution")).toBeInTheDocument();
   });
+
+  it("can override the version", () => {
+    renderComponent(
+      <ModelVersion
+        modelName="test-model"
+        qualifier="eggman@external"
+        version="99.99.99"
+      />,
+      { state },
+    );
+    expect(document.querySelector(".p-chip")).toHaveTextContent("99.99.99");
+  });
 });

--- a/src/components/ModelVersion/ModelVersion.tsx
+++ b/src/components/ModelVersion/ModelVersion.tsx
@@ -17,11 +17,18 @@ export type Props = PropsWithSpread<
   {
     modelName?: null | string;
     qualifier?: null | string;
+    // A version that will be displayed instead of the model's current version.
+    version?: null | string;
   },
   Partial<ChipProps>
 >;
 
-const ModelVersion: FC<Props> = ({ modelName, qualifier, ...props }: Props) => {
+const ModelVersion: FC<Props> = ({
+  modelName,
+  qualifier,
+  version,
+  ...props
+}: Props) => {
   const modelUUID = useAppSelector((state) =>
     getModelUUIDFromList(state, modelName, qualifier),
   );
@@ -29,7 +36,7 @@ const ModelVersion: FC<Props> = ({ modelName, qualifier, ...props }: Props) => {
   const controller = useAppSelector((state) =>
     getControllerByUUID(state, model?.info?.["controller-uuid"]),
   );
-  const currentVersion = model?.model.version;
+  const currentVersion = version ?? model?.model.version;
   const higherControllerVersion =
     currentVersion &&
     controller &&

--- a/src/scss/custom/_utilities_horizontal-spacing.scss
+++ b/src/scss/custom/_utilities_horizontal-spacing.scss
@@ -1,0 +1,20 @@
+@mixin vf-u-horizontal-spacing($start: -3, $end: 3) {
+  @for $i from $start through $end {
+    @if $i != 0 {
+      // Mimic the sv spacing utils for horizontal spacing.
+      .u-sh#{$i} {
+        margin-left: calc($sp-unit * $i);
+      }
+
+      // Support spacing on the right side of elements.
+      .u-sh#{$i}--right {
+        margin-right: calc($sp-unit * $i);
+      }
+
+      // Support spacing on the above elements.
+      .u-sv#{$i}--top {
+        margin-top: calc($sp-unit * $i);
+      }
+    }
+  }
+}

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -26,6 +26,7 @@ $color-link-visited: $color-link;
 @import "custom/status_icons";
 @import "custom/tables";
 @import "custom/icons";
+@import "custom/utilities_horizontal-spacing";
 
 // Settings
 $grid-max-width: 100%;
@@ -33,6 +34,7 @@ $color-navigation-background: $color-brand;
 
 @include vanilla;
 @include vf-p-icon-settings;
+@include vf-u-horizontal-spacing;
 
 // Include additional icons
 @include vf-p-icon-applications;

--- a/src/store/juju/selectors.test.ts
+++ b/src/store/juju/selectors.test.ts
@@ -153,6 +153,7 @@ import {
   getModelMigrationControllersByVersion,
   getModelUpgradeVersions,
   getRecommendedVersions,
+  getModelUpgrades,
 } from "./selectors";
 
 describe("selectors", () => {
@@ -3327,6 +3328,19 @@ describe("getUserCredentialsState", () => {
       loaded: false,
       loading: false,
     });
+  });
+});
+
+describe("getModelUpgrades", () => {
+  it("gets model upgrade state", () => {
+    const state = rootStateFactory.build({
+      juju: jujuStateFactory.build({
+        modelUpgrade: {
+          abc123: modelUpgradeFactory.build(),
+        },
+      }),
+    });
+    expect(getModelUpgrades(state)).toStrictEqual(state.juju.modelUpgrade);
   });
 });
 

--- a/src/store/juju/selectors.ts
+++ b/src/store/juju/selectors.ts
@@ -1403,10 +1403,18 @@ export const getSupportedJujuVersions = createSelector(
 /**
   Get a model upgrade by UUID.
 */
+export const getModelUpgrades = createSelector(
+  [slice],
+  (state) => state.modelUpgrade,
+);
+
+/**
+  Get a model upgrade by UUID.
+*/
 export const getModelUpgrade = createSelector(
-  [slice, (_, uuid: null | string = null): null | string => uuid],
-  (state, uuid) =>
-    uuid && uuid in state.modelUpgrade ? state.modelUpgrade[uuid] : null,
+  [getModelUpgrades, (_, uuid: null | string = null): null | string => uuid],
+  (modelUpgrades, uuid) =>
+    uuid && uuid in modelUpgrades ? modelUpgrades[uuid] : null,
 );
 
 export const getModelMigrationTargets = createSelector(


### PR DESCRIPTION
## Done

- Display upgrade status in the model list.

## QA

- Go to the model list.
- Open the redux dev tools and get a model UUID.
- In the dispatch box enter the following, with the model UUID from above:
```
{
  type: "juju/addModelUpgrade",
  payload: {
    modelUUID: "<enter a real model uuid>",
    currentVersion: "3.6.19",
    upgradeVersion: "3.6.21",
    }
}
```
- The upgrade spinner and version change should appear in the table.

## Details

https://warthogs.atlassian.net/browse/JUJU-9508

## Screenshots

<img width="453" height="165" alt="Screenshot 2026-04-21 at 12 29 08 pm" src="https://github.com/user-attachments/assets/94dd2960-60f5-4559-806b-f77bec2d3d93" />

