### PR TITLE
feat(process): create process middleware

### DIFF
--- a/src/store/middleware/process/createProcess.test.ts
+++ b/src/store/middleware/process/createProcess.test.ts
@@ -1,0 +1,147 @@
+import type { Store } from "store/store";
+
+import { createProcess } from "./createProcess";
+import type { ProcessActions } from "./types";
+
+describe("start", () => {
+  let processActions: ProcessActions<{ value: number }, boolean, string>;
+  let dispatch: Store["dispatch"];
+
+  async function* runProcess(_payload: {
+    value: number;
+    meta: Record<string, unknown>;
+  }): AsyncIterator<boolean> {
+    yield false;
+    yield true;
+    return "result";
+  }
+  beforeEach(() => {
+    vi.useFakeTimers();
+    processActions = {
+      setStatus: vi.fn(),
+      setRunning: vi.fn(),
+      setOutcome: vi.fn(),
+    };
+    dispatch = vi.fn();
+  });
+
+  it("runs process function with payload", async ({ expect }) => {
+    const runner = vi.fn(runProcess);
+    const process = createProcess("myProcess", runner, processActions);
+    await process.start({ value: 123, meta: {} }, dispatch);
+    expect(runner).toHaveBeenCalledExactlyOnceWith({ value: 123, meta: {} });
+  });
+
+  it("calls setStatus", async ({ expect }) => {
+    const process = createProcess("myProcess", runProcess, processActions);
+    await process.start({ value: 123, meta: {} }, dispatch);
+    expect(processActions.setStatus).toHaveBeenCalledTimes(2);
+    expect(processActions.setStatus).toHaveBeenNthCalledWith(
+      1,
+      { value: 123, meta: {} },
+      false,
+    );
+    expect(processActions.setStatus).toHaveBeenNthCalledWith(
+      2,
+      { value: 123, meta: {} },
+      true,
+    );
+  });
+
+  it("calls setRunning", async ({ expect }) => {
+    const promise = Promise.withResolvers<void>();
+    const process = createProcess(
+      "myProcess",
+      // eslint-disable-next-line require-yield
+      async function* () {
+        await promise.promise;
+        return "result";
+      },
+      processActions,
+    );
+    const run = process.start({ value: 123, meta: {} }, dispatch);
+
+    await vi.runOnlyPendingTimersAsync();
+    expect(processActions.setRunning).toHaveBeenCalledTimes(1);
+    expect(processActions.setRunning).toHaveBeenNthCalledWith(
+      1,
+      { value: 123, meta: {} },
+      true,
+    );
+
+    promise.resolve();
+    await vi.runOnlyPendingTimersAsync();
+    expect(processActions.setRunning).toHaveBeenCalledTimes(2);
+    expect(processActions.setRunning).toHaveBeenNthCalledWith(
+      2,
+      { value: 123, meta: {} },
+      false,
+    );
+
+    await run;
+  });
+
+  it("calls setOutcome", async ({ expect }) => {
+    const process = createProcess("myProcess", runProcess, processActions);
+    await process.start({ value: 123, meta: {} }, dispatch);
+    expect(processActions.setOutcome).toHaveBeenCalledTimes(1);
+    expect(processActions.setOutcome).toHaveBeenNthCalledWith(
+      1,
+      { value: 123, meta: {} },
+      {
+        result: "result",
+      },
+    );
+  });
+
+  it("only resolves when process complete", async ({ expect }) => {
+    const promise = Promise.withResolvers<void>();
+    const process = createProcess(
+      "myProcess",
+      // eslint-disable-next-line require-yield
+      async function* () {
+        await promise.promise;
+        return "result";
+      },
+      processActions,
+    );
+    let resolved = false;
+    const run = process.start({ value: 123, meta: {} }, dispatch).then(() => {
+      resolved = true;
+      return;
+    });
+
+    await vi.runOnlyPendingTimersAsync();
+    expect(resolved).toBe(false);
+
+    promise.resolve();
+    await vi.runOnlyPendingTimersAsync();
+    expect(resolved).toBe(true);
+
+    await run;
+  });
+
+  it("handles error within process", async ({ expect }) => {
+    const someError = new Error("something");
+    const process = createProcess(
+      "myProcess",
+      // eslint-disable-next-line require-yield
+      async function* () {
+        throw someError;
+      },
+      processActions,
+    );
+    await process.start({ value: 123, meta: {} }, dispatch);
+    expect(processActions.setOutcome).toHaveBeenCalledTimes(1);
+    expect(processActions.setOutcome).toHaveBeenNthCalledWith(
+      1,
+      { value: 123, meta: {} },
+      {
+        error: {
+          message: "something",
+          source: someError,
+        },
+      },
+    );
+  });
+});

--- a/src/store/middleware/process/createProcess.ts
+++ b/src/store/middleware/process/createProcess.ts
@@ -1,0 +1,91 @@
+import type { PayloadActionCreator } from "@reduxjs/toolkit";
+import { createAction } from "@reduxjs/toolkit";
+
+import type { Store } from "store/store";
+import { toErrorString } from "utils";
+
+import type { Hooks, Process, ProcessActions } from "./types";
+
+export function createProcess<Payload, Status, Result>(
+  identifier: string,
+  runProcess: (
+    payload: { meta: Record<string, unknown> } & Payload,
+  ) => AsyncIterator<Status, Result, void>,
+  processActions: ProcessActions<Payload, Status, Result>,
+  hooks?: Hooks<Payload>,
+): Process<Payload> {
+  const actions = {
+    run: createAction(
+      `process/${identifier}/run`,
+      (
+        payload: Payload,
+      ): { payload: Payload; meta?: Record<string, unknown> } =>
+        Object.assign(
+          {
+            payload,
+          },
+          hooks?.addActionMeta
+            ? { meta: hooks.addActionMeta(payload) }
+            : undefined,
+        ),
+    ) as unknown as PayloadActionCreator<Payload>,
+  };
+
+  const start = async (
+    payload: { meta: Record<string, unknown> } & Payload,
+    dispatch: Store["dispatch"],
+  ): Promise<void> => {
+    // Mark as running.
+    dispatch(processActions.setRunning(payload, true));
+
+    // Begin running.
+    const process = runProcess(payload);
+
+    /**
+     * For the given iterator result, dispatch into the store as a status update or result, using
+     * the provided action.
+     *
+     * @returns `true` if this is the last result from the iterator.
+     */
+    function processIteratorResult(
+      result: IteratorResult<Status, Result>,
+    ): boolean {
+      if (result.done) {
+        // Final item from this iterator, set the outcome.
+        dispatch(processActions.setOutcome(payload, { result: result.value }));
+        return true;
+      } else {
+        // Status update.
+        dispatch(processActions.setStatus(payload, result.value));
+        return false;
+      }
+    }
+
+    // Continually poll from process iterator.
+    while (true) {
+      try {
+        const result = await process.next();
+        if (processIteratorResult(result)) {
+          // Process completed.
+          break;
+        }
+      } catch (error) {
+        // Process has thrown an error, so store it.
+        dispatch(
+          processActions.setOutcome(payload, {
+            error: {
+              message: toErrorString(error),
+              source: error,
+            },
+          }),
+        );
+        break;
+      }
+    }
+
+    // Mark process as not running.
+    dispatch(processActions.setRunning(payload, false));
+  };
+
+  return { actions, start };
+}

--- a/src/store/middleware/process/createProcess.ts
+++ b/src/store/middleware/process/createProcess.ts
@@ -1,4 +1,3 @@
-import type { PayloadActionCreator } from "@reduxjs/toolkit";
 import { createAction } from "@reduxjs/toolkit";
 
 import type { Store } from "store/store";
@@ -15,20 +14,10 @@ export function createProcess<Payload, Status, Result>(
   hooks?: Hooks<Payload>,
 ): Process<Payload> {
   const actions = {
-    run: createAction(
-      `process/${identifier}/run`,
-      (
-        payload: Payload,
-      ): { payload: Payload; meta?: Record<string, unknown> } =>
-        Object.assign(
-          {
-            payload,
-          },
-          hooks?.addActionMeta
-            ? { meta: hooks.addActionMeta(payload) }
-            : undefined,
-        ),
-    ) as unknown as PayloadActionCreator<Payload>,
+    run: createAction(`process/${identifier}/run`, (payload: Payload) => ({
+      payload,
+      meta: hooks?.addActionMeta?.(payload),
+    })),
   };
 
   const start = async (

--- a/src/store/middleware/process/index.ts
+++ b/src/store/middleware/process/index.ts
@@ -1,0 +1,6 @@
+import createMiddleware from "./middleware";
+
+export type { ProcessOutcome, ProcessActions, Process } from "./types";
+
+// Construct the middleware with process handlers.
+export default createMiddleware([]);

--- a/src/store/middleware/process/middleware.ts
+++ b/src/store/middleware/process/middleware.ts
@@ -1,7 +1,7 @@
-import type { PayloadAction } from "@reduxjs/toolkit";
 import { isAction, type Middleware } from "@reduxjs/toolkit";
 
 import type { RootState, Store } from "store/store";
+import { isMetaAction } from "types";
 
 import type { Process } from "./types";
 
@@ -23,15 +23,11 @@ export default function createMiddleware<P extends Process<Payload>, Payload>(
       }
 
       if (process.actions.run.match(action)) {
-        const actionPayload = action.payload as Payload;
-        const actionMeta = (
-          action as PayloadAction<Payload, string, Record<string, unknown>>
-        ).meta as Record<string, unknown> | undefined;
-        const payload = Object.assign(
-          {},
-          actionPayload,
-          actionMeta ? { meta: actionMeta } : undefined,
-        );
+        const actionPayload = action.payload;
+        const actionMeta = isMetaAction(action)
+          ? { meta: action.meta }
+          : undefined;
+        const payload = Object.assign({}, actionPayload, actionMeta);
         await process.start(payload, store.dispatch);
         return;
       } else {

--- a/src/store/middleware/process/middleware.ts
+++ b/src/store/middleware/process/middleware.ts
@@ -1,0 +1,43 @@
+import type { PayloadAction } from "@reduxjs/toolkit";
+import { isAction, type Middleware } from "@reduxjs/toolkit";
+
+import type { RootState, Store } from "store/store";
+
+import type { Process } from "./types";
+
+export default function createMiddleware<P extends Process<Payload>, Payload>(
+  processes: P[],
+): Middleware<void, RootState, Store["dispatch"]> {
+  return (store) => (next) => {
+    return async (action) => {
+      // Don't bother trying to process if not a normal action.
+      if (!isAction(action)) {
+        return next(action);
+      }
+
+      const process = processes.find(({ actions }) =>
+        actions.run.match(action),
+      );
+      if (!process) {
+        return next(action);
+      }
+
+      if (process.actions.run.match(action)) {
+        const actionPayload = action.payload as Payload;
+        const actionMeta = (
+          action as PayloadAction<Payload, string, Record<string, unknown>>
+        ).meta as Record<string, unknown> | undefined;
+        const payload = Object.assign(
+          {},
+          actionPayload,
+          actionMeta ? { meta: actionMeta } : undefined,
+        );
+        await process.start(payload, store.dispatch);
+        return;
+      } else {
+        // This shouldn't be possible to reach, but is necessary for when new actions are added.
+        return next(action);
+      }
+    };
+  };
+}

--- a/src/store/middleware/process/types.ts
+++ b/src/store/middleware/process/types.ts
@@ -1,0 +1,30 @@
+import type { PayloadAction, PayloadActionCreator } from "@reduxjs/toolkit";
+
+import type { Store } from "store/store";
+
+export type Hooks<P> = {
+  addActionMeta?: (payload: P) => Record<string, unknown>;
+};
+
+export type ProcessOutcome<Result> =
+  | { error: { message: string; source: unknown } }
+  | { result: Result };
+
+export type ProcessActions<Payload, Status, Result> = {
+  setStatus: (payload: Payload, status: Status) => PayloadAction<unknown>;
+  setRunning: (payload: Payload, running: boolean) => PayloadAction<unknown>;
+  setOutcome: (
+    payload: Payload,
+    outcome: ProcessOutcome<Result>,
+  ) => PayloadAction<unknown>;
+};
+
+export type Process<Payload> = {
+  actions: {
+    run: PayloadActionCreator<Payload>;
+  };
+  start: (
+    payload: { meta: Record<string, unknown> } & Payload,
+    dispatch: Store["dispatch"],
+  ) => Promise<void>;
+};

--- a/src/store/middleware/process/types.ts
+++ b/src/store/middleware/process/types.ts
@@ -1,4 +1,8 @@
-import type { PayloadAction, PayloadActionCreator } from "@reduxjs/toolkit";
+import type {
+  PayloadAction,
+  PayloadActionCreator,
+  PrepareAction,
+} from "@reduxjs/toolkit";
 
 import type { Store } from "store/store";
 
@@ -21,7 +25,7 @@ export type ProcessActions<Payload, Status, Result> = {
 
 export type Process<Payload> = {
   actions: {
-    run: PayloadActionCreator<Payload>;
+    run: PayloadActionCreator<Payload, string, PrepareAction<Payload>>;
   };
   start: (
     payload: { meta: Record<string, unknown> } & Payload,

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -11,6 +11,7 @@ import { modelPollerMiddleware } from "store/middleware/model-poller";
 import { logger } from "utils/logger";
 
 import { listenerMiddleware } from "./listenerMiddleware";
+import processMiddleware from "./middleware/process";
 import sourceMiddleware from "./middleware/source";
 
 type PreloadedState = Record<string, unknown>;
@@ -46,6 +47,7 @@ const store = configureStore({
     middleware.push(listenerMiddleware.middleware);
     middleware.push(modelPollerMiddleware);
     middleware.push(...sourceMiddleware);
+    middleware.push(processMiddleware);
     return middleware;
   },
   preloadedState,


### PR DESCRIPTION
Create process middleware to handle the lifecycle of one-shot functions. Includes a `createProcess` function to handle the plumbing.