### PR TITLE
feat: move target controller to the version table

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -38,7 +38,7 @@ contribute and what kinds of contributions are welcome.
       - [Vanilla Framework](#vanilla-framework)
       - [Vanilla React Components](#vanilla-react-components)
   - [Deployed JIMM controller](#deployed-jimm-controller)
-    - [Adding users](#adding-users)
+      - [Adding users](#adding-users)
     - [Self signed certificates](#self-signed-certificates)
     - [Juju on M1 Macs](#juju-on-m1-macs)
   - [Building the Docker image](#building-the-docker-image)
@@ -46,6 +46,7 @@ contribute and what kinds of contributions are welcome.
     - [Deploying a local app](#deploying-a-local-app)
     - [Setting up cross model integrations](#setting-up-cross-model-integrations)
     - [Getting models into a broken state](#getting-models-into-a-broken-state)
+    - [Setting up model migrations](#setting-up-model-migrations)
 
 ## Setting up the dashboard for development
 
@@ -567,3 +568,27 @@ To get the model out of the broken state run:
 ```shell
 juju exec --app nginx "status-set --application=True active"
 ```
+
+### Setting up model migrations
+
+There are two scenarios when testing model upgrades:
+1. Upgrade a model to a patch version that is equal to or lower than the current controller's patch version (this does not require a migration to a new controller).
+2. Upgrade to a patch version that is higher than the current controller's patch version or upgrade the model's major and/or minor version (this will require a migration to a controller with the new version).
+
+- Currently Multipass does not support environment variables in cloud init scripts so on your host open `scripts/cloud-init-jimm-lxd-oidc.yaml` and change the line `su -c '/home/ubuntu/juju-dashboard/scripts/cloud-init-jimm-lxd-oidc.sh' - ubuntu` to `su -c 'export AGENT_VERSION=3.6.19 && /home/ubuntu/juju-dashboard/scripts/cloud-init-jimm-lxd-oidc.sh' - ubuntu`
+- From the root of the dashboard run `multipass launch --cpus 2 --disk 25G --memory 12G --name jimm-oidc --timeout 5000 --cloud-init ./scripts/cloud-init-jimm-lxd-oidc.yaml` and wait for the JIMM container to be ready.
+- At this point we will have a model `test` on Juju 3.6.19, now we need to upgrade the controller so its version is higher than the model's version (note: it might take a while for the controller to upgrade):
+```
+multipass shell jimm-oidc
+juju switch qa-lxd
+juju upgrade-controller --agent-version 3.6.20
+```
+- We also need a controller that has a higher version that the model's current controller version, so add a second controller, this time running 3.6.21:
+```
+cd ~/jimm
+export AGENT_VERSION=3.6.21
+export CONTROLLER_NAME=jimm2
+./local/jimm/setup-controller.sh
+./local/jimm/add-controller.sh
+```
+- Lastly, if you want to use a local dashboard with this JIMM env then [update the config](#configure-jimm-for-localhost) and [configure your local dashboard](#controller-configuration) to point to the new controller, just as you would normally.

--- a/HACKING.md
+++ b/HACKING.md
@@ -47,6 +47,7 @@ contribute and what kinds of contributions are welcome.
     - [Setting up cross model integrations](#setting-up-cross-model-integrations)
     - [Getting models into a broken state](#getting-models-into-a-broken-state)
     - [Setting up model migrations](#setting-up-model-migrations)
+    - [Add a model to a specific JAAS controller](#add-a-model-to-a-specific-jaas-controller)
 
 ## Setting up the dashboard for development
 
@@ -592,3 +593,14 @@ export CONTROLLER_NAME=jimm2
 ./local/jimm/add-controller.sh
 ```
 - Lastly, if you want to use a local dashboard with this JIMM env then [update the config](#configure-jimm-for-localhost) and [configure your local dashboard](#controller-configuration) to point to the new controller, just as you would normally.
+
+### Add a model to a specific JAAS controller
+
+If you're using JAAS you might want to add a model to a specific controller.
+
+Assuming you have a local jimm repo and running jimm (if you haven't already built the jaas command it can be done with `./local/jimm/detect-jaas.sh`)
+
+```bash
+cd ~/jimm
+./jaas add-model --target-controller controller-name test-model
+```

--- a/HACKING.md
+++ b/HACKING.md
@@ -38,7 +38,7 @@ contribute and what kinds of contributions are welcome.
       - [Vanilla Framework](#vanilla-framework)
       - [Vanilla React Components](#vanilla-react-components)
   - [Deployed JIMM controller](#deployed-jimm-controller)
-      - [Adding users](#adding-users)
+    - [Adding users](#adding-users)
     - [Self signed certificates](#self-signed-certificates)
     - [Juju on M1 Macs](#juju-on-m1-macs)
   - [Building the Docker image](#building-the-docker-image)
@@ -352,7 +352,7 @@ Now you can connect to the VPN and then you should be able to access the dashboa
 
 https://jimm-dashboard.k8s.dev.canonical.com
 
-#### Adding users
+### Adding users
 
 The QA deployment uses Keycloak to manage users. The deployment includes a web
 UI which can be found at http://keycloak.localhost:8082/.

--- a/src/components/Aside/Aside.tsx
+++ b/src/components/Aside/Aside.tsx
@@ -12,7 +12,7 @@ import { useEffect, type PropsWithChildren } from "react";
 export type Props = PropsWithSpread<
   {
     className?: string;
-    width?: "narrow" | "unset" | "wide" | null;
+    width?: "medium" | "narrow" | "unset" | "wide" | null;
     pinned?: boolean;
     loading?: boolean;
     panelProps?: PanelProps;
@@ -61,6 +61,7 @@ export default function Aside({
     <AppAside
       className={classnames(className, {
         "is-narrow": width === "narrow",
+        "is-medium": width === "medium",
         "is-wide": width === "wide",
         "is-split": isSplit,
         "l-aside--initially-offscreen": animateMount,

--- a/src/components/Aside/_aside.scss
+++ b/src/components/Aside/_aside.scss
@@ -43,6 +43,10 @@
         }
       }
     }
+
+    &.is-medium {
+      width: 20rem;
+    }
   }
 
   .p-panel {

--- a/src/components/ModelTableList/ModelTable/ModelTable.tsx
+++ b/src/components/ModelTableList/ModelTable/ModelTable.tsx
@@ -133,13 +133,13 @@ function generateModelTableList(
                 <ModelVersion
                   modelName={model.model.name}
                   qualifier={qualifier}
-                  version={upgrade.currentVersion}
+                  versionOverride={upgrade.currentVersion}
                 />
                 <span className="u-sh1 u-sh1--right">&rarr;</span>
                 <ModelVersion
                   modelName={model.model.name}
                   qualifier={qualifier}
-                  version={upgrade.upgradeVersion}
+                  versionOverride={upgrade.upgradeVersion}
                 />
               </>
             ) : null}

--- a/src/components/ModelVersion/ModelVersion.test.tsx
+++ b/src/components/ModelVersion/ModelVersion.test.tsx
@@ -87,7 +87,7 @@ describe("ModelVersion", () => {
       <ModelVersion
         modelName="test-model"
         qualifier="eggman@external"
-        version="99.99.99"
+        versionOverride="99.99.99"
       />,
       { state },
     );

--- a/src/components/ModelVersion/ModelVersion.tsx
+++ b/src/components/ModelVersion/ModelVersion.tsx
@@ -18,7 +18,7 @@ export type Props = PropsWithSpread<
     modelName?: null | string;
     qualifier?: null | string;
     // A version that will be displayed instead of the model's current version.
-    version?: null | string;
+    versionOverride?: null | string;
   },
   Partial<ChipProps>
 >;
@@ -26,7 +26,7 @@ export type Props = PropsWithSpread<
 const ModelVersion: FC<Props> = ({
   modelName,
   qualifier,
-  version,
+  versionOverride,
   ...props
 }: Props) => {
   const modelUUID = useAppSelector((state) =>
@@ -36,7 +36,7 @@ const ModelVersion: FC<Props> = ({
   const controller = useAppSelector((state) =>
     getControllerByUUID(state, model?.info?.["controller-uuid"]),
   );
-  const currentVersion = version ?? model?.model.version;
+  const currentVersion = versionOverride ?? model?.model.version;
   const higherControllerVersion =
     currentVersion &&
     controller &&

--- a/src/components/Panel/_panel.scss
+++ b/src/components/Panel/_panel.scss
@@ -12,6 +12,11 @@
     flex-direction: column;
     padding-left: $sph--large;
     padding-right: $sph--large;
+
+    &.no-indent {
+      padding-left: 0;
+      padding-right: 0;
+    }
   }
 
   .side-panel__content-scrolling {

--- a/src/panels/UpgradeModelPanel/UpgradeModelController/Fields/Fields.test.tsx
+++ b/src/panels/UpgradeModelPanel/UpgradeModelController/Fields/Fields.test.tsx
@@ -1,5 +1,5 @@
 import { NotificationSeverity } from "@canonical/react-components";
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 
@@ -22,6 +22,7 @@ import {
   controllerFactory,
   modelMigrationTargetsStateFactory,
 } from "testing/factories/juju/juju";
+import { customWithin } from "testing/queries/within";
 import { renderComponent } from "testing/utils";
 
 import { FieldName } from "../types";
@@ -111,7 +112,7 @@ it("displays correctly when a migration is required", async () => {
     { state },
   );
   expect(
-    screen.getByRole("combobox", { name: Label.TARGET_CONTROLLER }),
+    screen.getByRole("button", { name: Label.TARGET_CONTROLLER }),
   ).toBeInTheDocument();
   expect(
     queryNotificationByText(Label.REVIEW_RISKS, { severity: "caution" }),
@@ -119,6 +120,20 @@ it("displays correctly when a migration is required", async () => {
   expect(
     screen.queryByRole("checkbox", { name: Label.CONFIRM }),
   ).not.toBeInTheDocument();
+  const rows = screen.getAllByRole("row");
+  // There should be a header, a model row and then a controller row.
+  expect(rows).toHaveLength(3);
+  const table = await screen.findByRole("table");
+  const controllerCol = customWithin(table).getCellByHeader(
+    Label.HEADER_UPGRADE_VERSION,
+  );
+  expect(controllerCol).toHaveTextContent(/controller1/);
+  expect(controllerCol).toHaveTextContent(/4.6.14/);
+  expect(
+    queryNotificationByText(Label.REQUIRES_MIGRATION, {
+      severity: NotificationSeverity.INFORMATION,
+    }),
+  ).toBeInTheDocument();
 });
 
 it("displays confirmation when a migration is required", async () => {
@@ -141,10 +156,10 @@ it("displays confirmation when a migration is required", async () => {
     </Formik>,
     { state },
   );
-  await userEvent.selectOptions(
-    screen.getByRole("combobox", { name: Label.TARGET_CONTROLLER }),
-    "controller1",
+  await userEvent.click(
+    screen.getByRole("button", { name: Label.TARGET_CONTROLLER }),
   );
+  await userEvent.click(screen.getByRole("option", { name: /controller1/ }));
   expect(
     queryNotificationByText(Label.REVIEW_RISKS, {
       severity: NotificationSeverity.CAUTION,
@@ -176,7 +191,7 @@ it("displays correctly when a migration is not required", async () => {
     { state },
   );
   expect(
-    screen.queryByRole("combobox", { name: Label.TARGET_CONTROLLER }),
+    screen.queryByRole("button", { name: Label.TARGET_CONTROLLER }),
   ).not.toBeInTheDocument();
   expect(
     queryNotificationByText(Label.REVIEW_RISKS, { severity: "caution" }),
@@ -184,4 +199,13 @@ it("displays correctly when a migration is not required", async () => {
   expect(
     screen.getByRole("checkbox", { name: Label.CONFIRM }),
   ).toBeInTheDocument();
+  // There should be a header and a model row.
+  expect(screen.getAllByRole("row")).toHaveLength(2);
+  await waitFor(() => {
+    expect(
+      queryNotificationByText(Label.REQUIRES_MIGRATION, {
+        severity: NotificationSeverity.INFORMATION,
+      }),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/src/panels/UpgradeModelPanel/UpgradeModelController/Fields/Fields.tsx
+++ b/src/panels/UpgradeModelPanel/UpgradeModelController/Fields/Fields.tsx
@@ -1,17 +1,22 @@
 import {
+  Chip,
+  CustomSelect,
   FormikField,
   NotificationSeverity,
-  Select,
   Notification as VanillaNotification,
 } from "@canonical/react-components";
 import { useFormikContext } from "formik";
 import type { FC } from "react";
 
+import ModelVersion from "components/ModelVersion";
 import type { VersionElem } from "juju/jimm/JIMMV4";
 import {
+  getControllerByUUID,
+  getModelDataByUUID,
   getModelMigrationControllersByVersion,
   getModelUUIDFromList,
 } from "store/juju/selectors";
+import { getControllerVersion } from "store/juju/utils/controllers";
 import { useAppSelector } from "store/store";
 
 import type { FormFields } from "../types";
@@ -35,10 +40,18 @@ const Fields: FC<Props> = ({
   const modelUUID = useAppSelector((state) =>
     getModelUUIDFromList(state, modelName, qualifier),
   );
+  const model = useAppSelector((state) => getModelDataByUUID(state, modelUUID));
+  const currentVersion = model?.model.version;
+  const modelController = useAppSelector((state) =>
+    getControllerByUUID(state, model?.info?.["controller-uuid"]),
+  );
+  const controllerVersion = modelController
+    ? getControllerVersion(modelController)
+    : null;
   const targetControllers = useAppSelector((state) =>
     getModelMigrationControllersByVersion(state, modelUUID, version.version),
   );
-  const { values } = useFormikContext<FormFields>();
+  const { setFieldValue, values } = useFormikContext<FormFields>();
   const showConfirm = needsMigration
     ? !!values[FieldName.TARGET_CONTROLLER]
     : true;
@@ -46,22 +59,109 @@ const Fields: FC<Props> = ({
   return (
     <>
       {needsMigration ? (
-        <FormikField
-          component={Select}
-          label={Label.TARGET_CONTROLLER}
-          name={FieldName.TARGET_CONTROLLER}
-          options={[
-            {
-              label: "",
-              value: "",
-            },
-            ...(targetControllers?.map((controller) => ({
-              label: controller.name,
-              value: controller.uuid,
-            })) ?? []),
-          ]}
-        />
+        <VanillaNotification severity={NotificationSeverity.INFORMATION}>
+          {Label.REQUIRES_MIGRATION}
+        </VanillaNotification>
       ) : null}
+      <h5>Changes</h5>
+      <table className="u-no-margin--bottom">
+        <thead>
+          <tr>
+            <th>{Label.HEADER_MODEL_NAME}</th>
+            <th>{Label.HEADER_CURRENT_VERSION}</th>
+            <th>{Label.HEADER_UPGRADE_VERSION}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th>{modelName}</th>
+            <td className="u-flex">
+              <div className="u-flex-grow">
+                {currentVersion ? (
+                  <ModelVersion
+                    modelName={model.model.name}
+                    qualifier={qualifier}
+                  />
+                ) : null}
+              </div>
+              <span>&rarr;</span>
+            </td>
+            <td>
+              <ModelVersion
+                modelName={model?.model.name}
+                qualifier={qualifier}
+                versionOverride={version.version}
+              />
+            </td>
+          </tr>
+          {needsMigration ? (
+            <tr>
+              <th></th>
+              <td className="u-flex">
+                <div className="u-flex-grow">
+                  <span className="u-sh1--right">{modelController?.name}</span>
+                  {controllerVersion ? (
+                    <Chip
+                      isReadOnly
+                      isDense
+                      isInline
+                      value={controllerVersion}
+                    />
+                  ) : null}
+                </div>
+                <span className="u-flex-content-center">&rarr;</span>
+              </td>
+              <td className="controller-select__cell">
+                {needsMigration ? (
+                  <>
+                    <FormikField
+                      name={FieldName.TARGET_CONTROLLER}
+                      type="hidden"
+                    />
+                    <CustomSelect
+                      defaultToggleLabel={Label.TARGET_CONTROLLER}
+                      toggleClassName="controller-select__toggle"
+                      dropdownClassName="controller-select__dropdown prevent-panel-close"
+                      value={values[FieldName.TARGET_CONTROLLER]}
+                      onChange={(value) => {
+                        void setFieldValue(FieldName.TARGET_CONTROLLER, value);
+                      }}
+                      options={[
+                        ...(targetControllers?.map((controller) => {
+                          const optionVersion =
+                            getControllerVersion(controller);
+                          return {
+                            label: (
+                              <span className="u-flex">
+                                <span className="u-flex-grow">
+                                  {controller.name}
+                                </span>
+                                <span>
+                                  {optionVersion ? (
+                                    <Chip
+                                      isReadOnly
+                                      isDense
+                                      isInline
+                                      value={optionVersion}
+                                    />
+                                  ) : null}
+                                </span>
+                              </span>
+                            ),
+                            text: controller.name,
+                            value: controller.uuid,
+                          };
+                        }) ?? []),
+                      ]}
+                    />
+                  </>
+                ) : null}
+              </td>
+            </tr>
+          ) : null}
+        </tbody>
+      </table>
+      <hr />
       {showConfirm ? (
         <div className="u-flex-grow u-flex-content-end u-sv3">
           <div className="u-sv1">

--- a/src/panels/UpgradeModelPanel/UpgradeModelController/Fields/types.ts
+++ b/src/panels/UpgradeModelPanel/UpgradeModelController/Fields/types.ts
@@ -1,5 +1,9 @@
 export enum Label {
   CONFIRM = "I understand the risk",
-  TARGET_CONTROLLER = "Target controller",
+  HEADER_CURRENT_VERSION = "Current version",
+  HEADER_MODEL_NAME = "Model name",
+  HEADER_UPGRADE_VERSION = "Upgrade version",
+  REQUIRES_MIGRATION = "This upgrade requires a controller migration.",
   REVIEW_RISKS = "Before upgrading, review the risks",
+  TARGET_CONTROLLER = "Select target controller",
 }

--- a/src/panels/UpgradeModelPanel/UpgradeModelController/UpgradeModelController.test.tsx
+++ b/src/panels/UpgradeModelPanel/UpgradeModelController/UpgradeModelController.test.tsx
@@ -1,5 +1,4 @@
-import { NotificationSeverity } from "@canonical/react-components";
-import { act, fireEvent, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import type { RootState } from "store/store";
@@ -25,7 +24,6 @@ import {
   modelMigrationTargetsStateFactory,
   supportedJujuVersionsStateFactory,
 } from "testing/factories/juju/juju";
-import { customWithin } from "testing/queries/within";
 import { renderComponent } from "testing/utils";
 import urls from "urls";
 
@@ -127,33 +125,23 @@ describe("UpgradeModelController", () => {
     expect(onRemovePanelQueryParams).toHaveBeenCalled();
   });
 
-  it("displays correctly when a migration is required", async () => {
-    const {
-      result: { queryNotificationByText },
-    } = renderComponent(
+  it("does not close the panel when clicking inside the target dropdown", async () => {
+    const onRemovePanelQueryParams = vi.fn();
+    renderComponent(
       <UpgradeModelController
         back={vi.fn}
-        onRemovePanelQueryParams={vi.fn()}
+        onRemovePanelQueryParams={onRemovePanelQueryParams}
         version={versionElemFactory.build({ version: "4.6.14" })}
         modelName="test1"
         qualifier="eggman@external"
       />,
       { state, url, path },
     );
-    const rows = screen.getAllByRole("row");
-    // There should be a header, a model row and then a controller row.
-    expect(rows).toHaveLength(3);
-    const table = await screen.findByRole("table");
-    const controllerCol = customWithin(table).getCellByHeader(
-      Label.HEADER_UPGRADE_VERSION,
+    await userEvent.click(
+      screen.getByRole("button", { name: FieldsLabel.TARGET_CONTROLLER }),
     );
-    expect(controllerCol).toHaveTextContent(/controller1/);
-    expect(controllerCol).toHaveTextContent(/1.2.3/);
-    expect(
-      queryNotificationByText(Label.REQUIRES_MIGRATION, {
-        severity: NotificationSeverity.INFORMATION,
-      }),
-    ).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("option", { name: /controller2/ }));
+    expect(onRemovePanelQueryParams).not.toHaveBeenCalled();
   });
 
   it("requires the controller and confirmation when a migration is required", async () => {
@@ -169,40 +157,16 @@ describe("UpgradeModelController", () => {
     );
     const submit = screen.queryByRole("button", { name: Label.SUBMIT });
     expect(submit).toHaveAttribute("aria-disabled");
-    await userEvent.selectOptions(
-      screen.getByRole("combobox", { name: FieldsLabel.TARGET_CONTROLLER }),
-      "controller2",
+    await userEvent.click(
+      screen.getByRole("button", { name: FieldsLabel.TARGET_CONTROLLER }),
     );
+    await userEvent.click(screen.getByRole("option", { name: /controller2/ }));
     expect(submit).toHaveAttribute("aria-disabled");
     const confirm = screen.getByRole("checkbox", { name: FieldsLabel.CONFIRM });
     await userEvent.click(confirm);
     // Vanilla doesn't display validation until the field loses focus.
     await act(() => fireEvent.blur(confirm));
     expect(submit).not.toHaveAttribute("aria-disabled");
-  });
-
-  it("displays correctly when a migration is not required", async () => {
-    const {
-      result: { queryNotificationByText },
-    } = renderComponent(
-      <UpgradeModelController
-        back={vi.fn}
-        onRemovePanelQueryParams={vi.fn()}
-        version={versionElemFactory.build({ version: "1.2.2" })}
-        modelName="test1"
-        qualifier="eggman@external"
-      />,
-      { state, url, path },
-    );
-    // There should be a header and a model row.
-    expect(screen.getAllByRole("row")).toHaveLength(2);
-    await waitFor(() => {
-      expect(
-        queryNotificationByText(Label.REQUIRES_MIGRATION, {
-          severity: NotificationSeverity.INFORMATION,
-        }),
-      ).not.toBeInTheDocument();
-    });
   });
 
   it("requires the confirmation when a migration is not required", async () => {

--- a/src/panels/UpgradeModelPanel/UpgradeModelController/UpgradeModelController.tsx
+++ b/src/panels/UpgradeModelPanel/UpgradeModelController/UpgradeModelController.tsx
@@ -1,11 +1,4 @@
-import {
-  Button,
-  Chip,
-  Icon,
-  ICONS,
-  NotificationSeverity,
-  Notification as VanillaNotification,
-} from "@canonical/react-components";
+import { Button } from "@canonical/react-components";
 import { Formik } from "formik";
 import { useId, useState, type FC } from "react";
 import * as Yup from "yup";
@@ -58,7 +51,6 @@ const UpgradeModelController: FC<Props> = ({
   const controllerVersion = modelController
     ? getControllerVersion(modelController)
     : null;
-  const currentVersion = model?.model.version;
   const needsMigration =
     (controllerVersion &&
       requiresMigration(controllerVersion, version.version)) ||
@@ -78,6 +70,13 @@ const UpgradeModelController: FC<Props> = ({
   return (
     <Panel
       animateMount={false}
+      checkCanClose={(event) => {
+        const target = event.target as HTMLElement;
+        // Prevent clicks in the custom select dropdown from closing the panel (the
+        // dropdown is rendered inside a portal so is outside the panel's children.)
+        return !target.closest(".prevent-panel-close");
+      }}
+      contentClassName="no-indent"
       drawer={
         <>
           <Button
@@ -109,66 +108,10 @@ const UpgradeModelController: FC<Props> = ({
       onRemovePanelQueryParams={onRemovePanelQueryParams}
       scrollingContentClassName="u-flex"
       titleId={titleId}
-      width="unset"
+      width="medium"
       {...testId(CharmsAndActionsPanelTestId.PANEL)}
     >
       <div className="u-flex u-flex-column">
-        <h5>Changes</h5>
-        <table>
-          <thead>
-            <tr>
-              <th>{Label.HEADER_MODEL_NAME}</th>
-              <th>{Label.HEADER_CURRENT_VERSION}</th>
-              <th>{Label.HEADER_UPGRADE_VERSION}</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <th>{modelName}</th>
-              <td className="u-flex">
-                <div className="u-flex-grow">
-                  {currentVersion ? (
-                    <Chip
-                      isReadOnly
-                      isDense
-                      isInline
-                      appearance="caution"
-                      value={currentVersion}
-                    />
-                  ) : null}
-                </div>
-                <span>&rarr;</span>
-              </td>
-              <td>
-                <Chip isReadOnly isDense isInline value={version.version} />
-              </td>
-            </tr>
-            {needsMigration ? (
-              <tr>
-                <th></th>
-                <td className="u-flex">
-                  <div className="u-flex-grow">
-                    <p className="u-no-padding--top u-no-margin--bottom">
-                      {modelController?.name}
-                    </p>
-                    {controllerVersion ? (
-                      <Chip
-                        isReadOnly
-                        isDense
-                        isInline
-                        value={controllerVersion}
-                      />
-                    ) : null}
-                  </div>
-                  <span className="u-flex-content-center">&rarr;</span>
-                </td>
-                <td className="u-vertical-align--middle">
-                  <Icon name={ICONS.help} />
-                </td>
-              </tr>
-            ) : null}
-          </tbody>
-        </table>
         <Formik<FormFields>
           initialValues={{
             [FieldName.TARGET_CONTROLLER]: "",
@@ -186,11 +129,6 @@ const UpgradeModelController: FC<Props> = ({
             onValidate={setIsValid}
             id={formId}
           >
-            {needsMigration ? (
-              <VanillaNotification severity={NotificationSeverity.INFORMATION}>
-                {Label.REQUIRES_MIGRATION}
-              </VanillaNotification>
-            ) : null}
             <Fields
               modelName={modelName}
               needsMigration={needsMigration}

--- a/src/panels/UpgradeModelPanel/UpgradeModelController/_upgrade-model-controller.scss
+++ b/src/panels/UpgradeModelPanel/UpgradeModelController/_upgrade-model-controller.scss
@@ -5,9 +5,9 @@
 }
 
 .p-custom-select .p-custom-select__toggle.controller-select__toggle {
-  margin-bottom: 0;
   background-color: $color-x-light;
   border-bottom: 0;
+  margin-bottom: 0;
 }
 
 .controller-select__dropdown

--- a/src/panels/UpgradeModelPanel/UpgradeModelController/_upgrade-model-controller.scss
+++ b/src/panels/UpgradeModelPanel/UpgradeModelController/_upgrade-model-controller.scss
@@ -1,0 +1,24 @@
+.controller-select__cell {
+  border-left: 1px solid $colors--theme--border-low-contrast;
+  border-right: 1px solid $colors--theme--border-low-contrast;
+  padding: $spv--x-small 0 0 0;
+}
+
+.p-custom-select .p-custom-select__toggle.controller-select__toggle {
+  margin-bottom: 0;
+  background-color: $color-x-light;
+  border-bottom: 0;
+}
+
+.controller-select__dropdown
+  .p-custom-select__dropdown
+  .p-custom-select__option.highlight {
+  &,
+  .p-chip {
+    background-color: $colors--theme--background-active;
+  }
+
+  * {
+    color: $colors--theme--text-default;
+  }
+}

--- a/src/panels/UpgradeModelPanel/UpgradeModelController/types.ts
+++ b/src/panels/UpgradeModelPanel/UpgradeModelController/types.ts
@@ -1,10 +1,6 @@
 export enum Label {
   CANCEL = "Cancel",
-  REQUIRES_MIGRATION = "This upgrade requires a controller migration.",
   SUBMIT = "Upgrade model",
-  HEADER_MODEL_NAME = "Model name",
-  HEADER_CURRENT_VERSION = "Current version",
-  HEADER_UPGRADE_VERSION = "Upgrade version",
 }
 
 export enum FieldName {

--- a/src/panels/UpgradeModelPanel/UpgradeModelVersion/RecommendedVersion/_recommended-version.scss
+++ b/src/panels/UpgradeModelPanel/UpgradeModelVersion/RecommendedVersion/_recommended-version.scss
@@ -13,6 +13,8 @@
   }
 
   &-details {
+    flex-grow: 1;
+
     @include mobile {
       display: block;
     }
@@ -33,6 +35,7 @@
   }
 
   &-changelog {
+    flex-grow: 1;
     text-align: right;
 
     @include mobile {

--- a/src/panels/UpgradeModelPanel/UpgradeModelVersion/UpgradeModelVersion.tsx
+++ b/src/panels/UpgradeModelPanel/UpgradeModelVersion/UpgradeModelVersion.tsx
@@ -158,6 +158,7 @@ const UpgradeModelVersion: FC<Props> = ({
   return (
     <Panel
       animateMount={firstRender}
+      contentClassName="no-indent"
       loading={
         !modelsLoaded ||
         // This checks the existence of the data instead of using the loading state otherwise,
@@ -189,7 +190,7 @@ const UpgradeModelVersion: FC<Props> = ({
       header={<UpgradeModelPanelHeader titleId={titleId} />}
       onRemovePanelQueryParams={onRemovePanelQueryParams}
       titleId={titleId}
-      width="unset"
+      width="medium"
       {...testId(UpgradeModelPanelTestId.PANEL)}
     >
       {content}

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -102,4 +102,5 @@ $color-navigation-background: $color-brand;
 @import "../pages/ModelsIndex/models";
 @import "../panels/ConfigPanel/config-panel";
 @import "../panels/ShareModelPanel/share-model";
+@import "../panels/UpgradeModelPanel/UpgradeModelController/upgrade-model-controller";
 @import "../panels/UpgradeModelPanel/UpgradeModelVersion/RecommendedVersion/recommended-version";

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,3 +52,8 @@ export enum FeatureFlags {
 export type Nullable<T> = {
   [P in keyof T]: null | T[P];
 };
+
+export const isKeyOf = <O extends object>(
+  key: PropertyKey,
+  data: O,
+): key is keyof O => !!key && typeof key === "string" && key in data;


### PR DESCRIPTION
## Done

- Add instructions for creating model migration controllers.
- Make the upgrade model panels wider.
- Update the target controller select to use a CustomSelect.
- Move the target controller select into the table of versions.

## QA

- If you don't already have controllers with different versions then follow the new instructions in the HACKING doc to set them up.
- Open the model upgrade panel and choose a version that is higher than the model's current controller (if using the hacking doc instructions this will be 3.6.21).
- On the second screen you should see the target controller select in the table of versions.

## Details

https://warthogs.atlassian.net/browse/JUJU-9697
https://warthogs.atlassian.net/browse/JUJU-9347

## Screenshots

<img width="746" height="583" alt="Screenshot 2026-04-22 at 12 44 00 pm" src="https://github.com/user-attachments/assets/c423f856-736f-4553-9fa0-d4a952ccf479" />


