### PR TITLE
feat: yaml to list view data porting and confirmation dialog

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "slice-ansi": "7.1.2",
     "strip-ansi": "7.2.0",
     "vanilla-framework": "4.51.0",
+    "yaml": "2.9.0",
     "yup": "1.7.1"
   },
   "devDependencies": {

--- a/src/pages/AddModel/ConfigsConstraints/CategoriesListing/CategoriesListing.test.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/CategoriesListing/CategoriesListing.test.tsx
@@ -28,6 +28,8 @@ describe("CategoriesListing", () => {
       searchPlaceholder: "Search configurations",
       yamlPlaceholder: Label.MODEL_CONFIG_PLACEHOLDER,
       searchName: "configSearch",
+      setYAMLErrors: vi.fn(),
+      yamlErrorLabel: Label.INCORRECT_YAML_CONFIGURATION_ERROR,
     };
   });
 
@@ -178,6 +180,28 @@ describe("CategoriesListing", () => {
     expect(textarea.value).toContain("default-space: my-space");
     expect(textarea.value).toContain("# Proxy & Mirror");
     expect(textarea.value).toContain("apt-http-proxy: http://proxy.example");
+  });
+
+  it("calls setYAMLErrors and stays in YAML mode when YAML has invalid keys", async () => {
+    render(
+      <Formik
+        initialValues={{ [FieldName.CONFIG_INPUT_MODE]: InputMode.YAML }}
+        onSubmit={vi.fn()}
+      >
+        <CategoriesListing {...defaultProps} />
+      </Formik>,
+    );
+
+    const textarea = screen.getByPlaceholderText(
+      Label.MODEL_CONFIG_PLACEHOLDER,
+    ) as HTMLTextAreaElement;
+    await userEvent.clear(textarea);
+    await userEvent.type(textarea, "unknown-field: value");
+
+    await userEvent.click(screen.getByRole("radio", { name: InputMode.LIST }));
+
+    expect(defaultProps.setYAMLErrors).toHaveBeenCalledOnce();
+    expect(screen.getByRole("radio", { name: InputMode.YAML })).toBeChecked();
   });
 
   it("filters categories by field name", () => {

--- a/src/pages/AddModel/ConfigsConstraints/CategoriesListing/CategoriesListing.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/CategoriesListing/CategoriesListing.tsx
@@ -16,6 +16,7 @@ import useDebounce from "hooks/useDebounce";
 
 import { InputMode } from "../../types";
 import StackList from "../StackList";
+import { YAMLErrorType } from "../YAMLErrorsModal/types";
 import type { ConfigFieldValue, FormFields } from "../types";
 import {
   buildYAML,
@@ -62,9 +63,9 @@ const CategoriesListing = ({
       }
 
       if (
-        errors.invalidKeys.length > 0 ||
-        errors.invalidValues.length > 0 ||
-        errors.otherErrors.length > 0
+        errors[YAMLErrorType.UNKNOWN_KEYS].length > 0 ||
+        errors[YAMLErrorType.INVALID_VALUES].length > 0 ||
+        errors[YAMLErrorType.OTHERS].length > 0
       ) {
         void setFieldTouched(yamlKey, true, false);
         // setFieldError must be called after setFieldTouched to prevent

--- a/src/pages/AddModel/ConfigsConstraints/CategoriesListing/CategoriesListing.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/CategoriesListing/CategoriesListing.tsx
@@ -21,6 +21,7 @@ import {
   buildYAML,
   filterCategoriesBySearch,
   getCategoriesWithVisibleFields,
+  validateAndParseYAML,
 } from "../utils";
 
 import type { Props } from "./types";
@@ -37,6 +38,8 @@ const CategoriesListing = ({
   searchPlaceholder,
   yamlPlaceholder,
   searchName,
+  setYAMLErrors,
+  yamlErrorLabel,
 }: Props): JSX.Element => {
   const id = useId();
   const { values, setFieldValue } = useFormikContext<
@@ -49,6 +52,32 @@ const CategoriesListing = ({
   const handleModeChange = (isListModeSelected: boolean): void => {
     if (!isListModeSelected) {
       void setFieldValue(yamlKey, buildYAML(categoriesList, values));
+    } else {
+      const { validValues, errors } = validateAndParseYAML(
+        values[yamlKey] ?? "",
+        categoriesList,
+        values,
+      );
+      Object.entries(validValues).forEach(([label, value]) => {
+        void setFieldValue(label, value);
+      });
+
+      if (
+        errors.invalidKeys.length > 0 ||
+        errors.invalidValues.length > 0 ||
+        errors.otherErrors.length > 0
+      ) {
+        void setFieldTouched(yamlKey, true, false);
+        // setFieldError must be called after setFieldTouched to prevent
+        // Formik's internal validation run from wiping the error message.
+        setTimeout(() => {
+          setFieldError(yamlKey, yamlErrorLabel);
+        }, 0);
+        setYAMLErrors({ errors, inputMode, yamlKey });
+        return;
+      }
+
+      setFieldError(yamlKey, undefined);
     }
 
     void setFieldValue(

--- a/src/pages/AddModel/ConfigsConstraints/CategoriesListing/CategoriesListing.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/CategoriesListing/CategoriesListing.tsx
@@ -42,9 +42,8 @@ const CategoriesListing = ({
   yamlErrorLabel,
 }: Props): JSX.Element => {
   const id = useId();
-  const { values, setFieldValue } = useFormikContext<
-    FormFields & Record<string, ConfigFieldValue>
-  >();
+  const { values, setFieldError, setFieldTouched, setFieldValue } =
+    useFormikContext<FormFields & Record<string, ConfigFieldValue>>();
   const [searchQuery, setSearchQuery] = useDebounce("", 250);
   const [changedOnly, setChangedOnly] = useState(false);
 
@@ -58,9 +57,9 @@ const CategoriesListing = ({
         categoriesList,
         values,
       );
-      Object.entries(validValues).forEach(([label, value]) => {
+      for (const [label, value] of Object.entries(validValues)) {
         void setFieldValue(label, value);
-      });
+      }
 
       if (
         errors.invalidKeys.length > 0 ||
@@ -122,7 +121,9 @@ const CategoriesListing = ({
         {title}
       </h5>
       <p className="u-no-margin--bottom p-text--small">
-        <a href={docsLink}>{docsLabel}</a>
+        <a href={docsLink} target="_blank">
+          {docsLabel}
+        </a>
       </p>
       <div className="u-flex u-flex--gap">
         <div>

--- a/src/pages/AddModel/ConfigsConstraints/CategoriesListing/CategoriesListing.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/CategoriesListing/CategoriesListing.tsx
@@ -53,8 +53,13 @@ const CategoriesListing = ({
     if (!isListModeSelected) {
       void setFieldValue(yamlKey, buildYAML(categoriesList, values));
     } else {
+      const yamlString = values[yamlKey];
+      if (!yamlString) {
+        void setFieldValue(inputMode, InputMode.LIST);
+        return;
+      }
       const { validValues, errors } = validateAndParseYAML(
-        values[yamlKey] ?? "",
+        yamlString,
         categoriesList,
         values,
       );

--- a/src/pages/AddModel/ConfigsConstraints/CategoriesListing/types.ts
+++ b/src/pages/AddModel/ConfigsConstraints/CategoriesListing/types.ts
@@ -1,3 +1,4 @@
+import type { YAMLErrorsModalState } from "../YAMLErrorsModal/types";
 import type { CategoryDefinition, FieldName } from "../types";
 
 export type Props = {
@@ -12,4 +13,6 @@ export type Props = {
   searchPlaceholder: string;
   yamlPlaceholder: string;
   searchName: string;
+  setYAMLErrors: (state: YAMLErrorsModalState) => void;
+  yamlErrorLabel: string;
 };

--- a/src/pages/AddModel/ConfigsConstraints/ConfigsConstraints.test.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/ConfigsConstraints.test.tsx
@@ -169,4 +169,73 @@ describe("ConfigsConstraints", () => {
       screen.getByRole("radio", { name: Label.DISABLE_ALL_COMMANDS }),
     ).toBeChecked();
   });
+
+  it("shows the error modal when switching to list mode with invalid YAML", async () => {
+    renderComponent(
+      <Formik
+        initialValues={{
+          [FieldName.CONFIG_INPUT_MODE]: InputMode.YAML,
+          [FieldName.CONSTRAINT_INPUT_MODE]: InputMode.LIST,
+          [FieldName.CONFIG_YAML]: "unknown-field: value",
+        }}
+        onSubmit={vi.fn()}
+      >
+        <ConfigsConstraints />
+      </Formik>,
+    );
+
+    const configsSection = screen.getByRole("region", {
+      name: Label.CONFIGS_TITLE,
+    });
+    await userEvent.click(
+      within(configsSection).getByRole("radio", { name: InputMode.LIST }),
+    );
+
+    const dialog = screen.getByRole("dialog", {
+      name: "Invalid values will be lost",
+    });
+    expect(dialog).toBeInTheDocument();
+    expect(
+      within(dialog).getByText(/invalid configuration values/i),
+    ).toBeInTheDocument();
+  });
+
+  it("wipes invalid YAML entries when switching to list mode forcefully", async () => {
+    renderComponent(
+      <Formik
+        initialValues={{
+          [FieldName.CONFIG_INPUT_MODE]: InputMode.YAML,
+          [FieldName.CONSTRAINT_INPUT_MODE]: InputMode.LIST,
+          [FieldName.CONFIG_YAML]:
+            "default-space: my-space\nunknown-field: value",
+        }}
+        onSubmit={vi.fn()}
+      >
+        <ConfigsConstraints />
+      </Formik>,
+    );
+
+    const configsSection = screen.getByRole("region", {
+      name: Label.CONFIGS_TITLE,
+    });
+    await userEvent.click(
+      within(configsSection).getByRole("radio", { name: InputMode.LIST }),
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Switch to list view" }),
+    );
+
+    expect(
+      screen.queryByRole("dialog", { name: "Invalid values will be lost" }),
+    ).not.toBeInTheDocument();
+    expect(
+      within(configsSection).getByRole("radio", { name: InputMode.LIST }),
+    ).toBeChecked();
+
+    // The valid field value was ported over
+    const defaultSpaceInput = within(configsSection).getByLabelText(
+      "default-space",
+    ) as HTMLInputElement;
+    expect(defaultSpaceInput.value).toBe("my-space");
+  });
 });

--- a/src/pages/AddModel/ConfigsConstraints/ConfigsConstraints.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/ConfigsConstraints.tsx
@@ -1,19 +1,45 @@
 import { FormikField, List } from "@canonical/react-components";
-import type { JSX } from "react";
+import { useFormikContext } from "formik";
+import { useState, type JSX } from "react";
 
 import { testId } from "testing/utils";
 import { externalURLs } from "urls";
 
+import { InputMode } from "../types";
+
 import CategoriesListing from "./CategoriesListing";
 import TruncatedCommands from "./TruncatedCommands";
+import YAMLErrorsModal from "./YAMLErrorsModal";
+import type { YAMLErrorsModalState } from "./YAMLErrorsModal/types";
 import { CONFIG_CATEGORIES } from "./configCatalog";
 import { CONSTRAINT_CATEGORIES } from "./constraintsCatalog";
 import { DISABLED_COMMAND_OPTIONS } from "./disabledCommandOptions";
-import { FieldName, Label, TestId } from "./types";
+import { FieldName, type FormFields, Label, TestId } from "./types";
 
 const ConfigsConstraints = (): JSX.Element => {
+  const { setFieldValue } = useFormikContext<
+    FormFields & Record<string, string>
+  >();
+  const [yamlErrorsModalState, setYAMLErrors] =
+    useState<null | YAMLErrorsModalState>(null);
+
   return (
     <div {...testId(TestId.CONFIGS_CONSTRAINTS_FORM)}>
+      {yamlErrorsModalState ? (
+        <YAMLErrorsModal
+          errors={yamlErrorsModalState.errors}
+          yamlKey={yamlErrorsModalState.yamlKey}
+          onConfirm={() => {
+            const { inputMode, yamlKey } = yamlErrorsModalState;
+            void setFieldValue(yamlKey, "");
+            void setFieldValue(inputMode, InputMode.LIST);
+            setYAMLErrors(null);
+          }}
+          onClose={() => {
+            setYAMLErrors(null);
+          }}
+        />
+      ) : null}
       <CategoriesListing
         title={Label.CONFIGS_TITLE}
         categoriesList={CONFIG_CATEGORIES}
@@ -26,6 +52,8 @@ const ConfigsConstraints = (): JSX.Element => {
         searchPlaceholder="Search configurations"
         yamlPlaceholder={Label.MODEL_CONFIG_PLACEHOLDER}
         searchName="configSearch"
+        setYAMLErrors={setYAMLErrors}
+        yamlErrorLabel={Label.INCORRECT_YAML_CONFIGURATION_ERROR}
       />
       <CategoriesListing
         title={Label.CONSTRAINTS_TITLE}
@@ -39,6 +67,8 @@ const ConfigsConstraints = (): JSX.Element => {
         searchPlaceholder="Search constraints"
         yamlPlaceholder={Label.MODEL_CONSTRAINT_PLACEHOLDER}
         searchName="constraintSearch"
+        setYAMLErrors={setYAMLErrors}
+        yamlErrorLabel={Label.INCORRECT_YAML_CONSTRAINT_ERROR}
       />
       <h5 className="u-no-padding--top u-no-margin--bottom">
         {Label.DISABLED_COMMANDS}

--- a/src/pages/AddModel/ConfigsConstraints/YAMLErrorsModal/YAMLErrorsModal.test.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/YAMLErrorsModal/YAMLErrorsModal.test.tsx
@@ -1,0 +1,86 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+
+import { renderComponent } from "testing/utils";
+
+import { FieldName } from "../types";
+
+import YAMLErrorsModal from "./YAMLErrorsModal";
+import type { YAMLErrors } from "./types";
+
+describe("YAMLErrorsModal", () => {
+  let initialValues: YAMLErrors;
+
+  beforeEach(() => {
+    initialValues = { invalidKeys: [], invalidValues: [], otherErrors: [] };
+  });
+
+  it("renders the modal with correct labels", () => {
+    renderComponent(
+      <YAMLErrorsModal
+        errors={initialValues}
+        yamlKey={FieldName.CONSTRAINT_YAML}
+        onConfirm={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/invalid constraint values/i)).toBeInTheDocument();
+  });
+
+  it("renders errors properly", () => {
+    renderComponent(
+      <YAMLErrorsModal
+        errors={{
+          invalidKeys: [{ line: 2, message: "Unknown key: bad-key" }],
+          invalidValues: [{ line: 3, message: "Expected a number" }],
+          otherErrors: [
+            { line: 1, message: "Invalid format. Expected <key>: <value>" },
+          ],
+        }}
+        yamlKey={FieldName.CONFIG_YAML}
+        onConfirm={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText(/Line 2: Unknown key: bad-key/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Line 3: Expected a number/)).toBeInTheDocument();
+    expect(screen.getByText(/Invalid format/)).toBeInTheDocument();
+  });
+
+  it("calls onConfirm when confirm button is clicked", async () => {
+    const onConfirm = vi.fn();
+    renderComponent(
+      <YAMLErrorsModal
+        errors={initialValues}
+        yamlKey={FieldName.CONFIG_YAML}
+        onConfirm={onConfirm}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Switch to list view" }),
+    );
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it("calls onClose when cancel button is clicked", async () => {
+    const onClose = vi.fn();
+    renderComponent(
+      <YAMLErrorsModal
+        errors={initialValues}
+        yamlKey={FieldName.CONFIG_YAML}
+        onConfirm={vi.fn()}
+        onClose={onClose}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+});

--- a/src/pages/AddModel/ConfigsConstraints/YAMLErrorsModal/YAMLErrorsModal.test.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/YAMLErrorsModal/YAMLErrorsModal.test.tsx
@@ -25,7 +25,6 @@ describe("YAMLErrorsModal", () => {
         onClose={vi.fn()}
       />,
     );
-
     expect(screen.getByText(/invalid constraint values/i)).toBeInTheDocument();
   });
 
@@ -46,10 +45,12 @@ describe("YAMLErrorsModal", () => {
     );
 
     expect(
+      screen.getByText(/Line 1: Invalid format. Expected <key>: <value>/),
+    ).toBeInTheDocument();
+    expect(
       screen.getByText(/Line 2: Unknown key: bad-key/),
     ).toBeInTheDocument();
     expect(screen.getByText(/Line 3: Expected a number/)).toBeInTheDocument();
-    expect(screen.getByText(/Invalid format/)).toBeInTheDocument();
   });
 
   it("calls onConfirm when confirm button is clicked", async () => {

--- a/src/pages/AddModel/ConfigsConstraints/YAMLErrorsModal/YAMLErrorsModal.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/YAMLErrorsModal/YAMLErrorsModal.tsx
@@ -11,8 +11,12 @@ const ErrorList = ({
 }: {
   label: string;
   errors: YAMLValidationError[];
-}): JSX.Element | null =>
-  errors.length > 0 ? (
+}): JSX.Element | null => {
+  if (errors.length === 0) {
+    return null;
+  }
+
+  return (
     <ul className="u-no-padding--left u-no-margin--left">
       {label}:
       {errors.map(({ line, message }, index) => {
@@ -23,7 +27,8 @@ const ErrorList = ({
         );
       })}
     </ul>
-  ) : null;
+  );
+};
 
 const YAMLErrorsModal = ({
   errors,

--- a/src/pages/AddModel/ConfigsConstraints/YAMLErrorsModal/YAMLErrorsModal.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/YAMLErrorsModal/YAMLErrorsModal.tsx
@@ -3,23 +3,25 @@ import type { JSX } from "react";
 
 import { FieldName } from "../types";
 
-import type { YAMLErrors, YAMLErrorsModalProps } from "./types";
+import type { YAMLErrorsModalProps, YAMLValidationError } from "./types";
 
 const ErrorList = ({
   label,
   errors,
 }: {
   label: string;
-  errors: YAMLErrors["invalidKeys" | "invalidValues" | "otherErrors"];
+  errors: YAMLValidationError[];
 }): JSX.Element | null =>
   errors.length > 0 ? (
     <ul className="u-no-padding--left u-no-margin--left">
       {label}:
-      {errors.map((error, index) => (
-        <li className="u-sh3" key={`${label}-${index}`}>
-          Line {error.line}: {error.message}
-        </li>
-      ))}
+      {errors.map(({ line, message }, index) => {
+        return (
+          <li className="u-sh3" key={`${label}-${index}`}>
+            {line ? `Line ${line}: ${message}` : message}
+          </li>
+        );
+      })}
     </ul>
   ) : null;
 

--- a/src/pages/AddModel/ConfigsConstraints/YAMLErrorsModal/YAMLErrorsModal.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/YAMLErrorsModal/YAMLErrorsModal.tsx
@@ -3,6 +3,7 @@ import type { JSX } from "react";
 
 import {
   ENTITY_LABELS,
+  YAMLErrorType,
   type YAMLErrorsModalProps,
   type YAMLValidationError,
 } from "./types";
@@ -55,9 +56,15 @@ const YAMLErrorsModal = ({
           You have one or more invalid {ENTITY_LABELS[yamlKey]} values.{" "}
           <b>If you switch to list view, those values will be lost.</b>
         </p>
-        <ErrorList label="Invalid keys" errors={errors.invalidKeys} />
-        <ErrorList label="Invalid values" errors={errors.invalidValues} />
-        <ErrorList label="Other errors" errors={errors.otherErrors} />
+        <ErrorList
+          label="Invalid keys"
+          errors={errors[YAMLErrorType.UNKNOWN_KEYS]}
+        />
+        <ErrorList
+          label="Invalid values"
+          errors={errors[YAMLErrorType.INVALID_VALUES]}
+        />
+        <ErrorList label="Other errors" errors={errors[YAMLErrorType.OTHERS]} />
       </ConfirmationModal>
     </Portal>
   );

--- a/src/pages/AddModel/ConfigsConstraints/YAMLErrorsModal/YAMLErrorsModal.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/YAMLErrorsModal/YAMLErrorsModal.tsx
@@ -1,0 +1,58 @@
+import { ConfirmationModal, usePortal } from "@canonical/react-components";
+import type { JSX } from "react";
+
+import { FieldName } from "../types";
+
+import type { YAMLErrors, YAMLErrorsModalProps } from "./types";
+
+const ErrorList = ({
+  label,
+  errors,
+}: {
+  label: string;
+  errors: YAMLErrors["invalidKeys" | "invalidValues" | "otherErrors"];
+}): JSX.Element | null =>
+  errors.length > 0 ? (
+    <ul className="u-no-padding--left u-no-margin--left">
+      {label}:
+      {errors.map((error, index) => (
+        <li className="u-sh3" key={`${label}-${index}`}>
+          Line {error.line}: {error.message}
+        </li>
+      ))}
+    </ul>
+  ) : null;
+
+const YAMLErrorsModal = ({
+  errors,
+  yamlKey,
+  onConfirm,
+  onClose,
+}: YAMLErrorsModalProps): JSX.Element => {
+  const { Portal } = usePortal();
+
+  return (
+    <Portal>
+      <ConfirmationModal
+        title="Invalid values will be lost"
+        className="configs__error-modal"
+        cancelButtonLabel="Cancel"
+        confirmButtonLabel="Switch to list view"
+        confirmButtonAppearance="primary"
+        onConfirm={onConfirm}
+        close={onClose}
+      >
+        <p>
+          You have one or more invalid{" "}
+          {yamlKey === FieldName.CONFIG_YAML ? "configuration" : "constraint"}{" "}
+          values. <b>If you switch to list view, those values will be lost.</b>
+        </p>
+        <ErrorList label="Invalid keys" errors={errors.invalidKeys} />
+        <ErrorList label="Invalid values" errors={errors.invalidValues} />
+        <ErrorList label="Other errors" errors={errors.otherErrors} />
+      </ConfirmationModal>
+    </Portal>
+  );
+};
+
+export default YAMLErrorsModal;

--- a/src/pages/AddModel/ConfigsConstraints/YAMLErrorsModal/YAMLErrorsModal.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/YAMLErrorsModal/YAMLErrorsModal.tsx
@@ -1,9 +1,11 @@
 import { ConfirmationModal, usePortal } from "@canonical/react-components";
 import type { JSX } from "react";
 
-import { FieldName } from "../types";
-
-import type { YAMLErrorsModalProps, YAMLValidationError } from "./types";
+import {
+  ENTITY_LABELS,
+  type YAMLErrorsModalProps,
+  type YAMLValidationError,
+} from "./types";
 
 const ErrorList = ({
   label,
@@ -50,9 +52,8 @@ const YAMLErrorsModal = ({
         close={onClose}
       >
         <p>
-          You have one or more invalid{" "}
-          {yamlKey === FieldName.CONFIG_YAML ? "configuration" : "constraint"}{" "}
-          values. <b>If you switch to list view, those values will be lost.</b>
+          You have one or more invalid {ENTITY_LABELS[yamlKey]} values.{" "}
+          <b>If you switch to list view, those values will be lost.</b>
         </p>
         <ErrorList label="Invalid keys" errors={errors.invalidKeys} />
         <ErrorList label="Invalid values" errors={errors.invalidValues} />

--- a/src/pages/AddModel/ConfigsConstraints/YAMLErrorsModal/index.ts
+++ b/src/pages/AddModel/ConfigsConstraints/YAMLErrorsModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./YAMLErrorsModal";

--- a/src/pages/AddModel/ConfigsConstraints/YAMLErrorsModal/types.ts
+++ b/src/pages/AddModel/ConfigsConstraints/YAMLErrorsModal/types.ts
@@ -5,10 +5,16 @@ export type YAMLValidationError = {
   line?: number;
 };
 
+export enum YAMLErrorType {
+  UNKNOWN_KEYS = "invalidKeys",
+  INVALID_VALUES = "invalidValues",
+  OTHERS = "otherErrors",
+}
+
 export type YAMLErrors = {
-  invalidKeys: YAMLValidationError[];
-  invalidValues: YAMLValidationError[];
-  otherErrors: YAMLValidationError[];
+  [YAMLErrorType.UNKNOWN_KEYS]: YAMLValidationError[];
+  [YAMLErrorType.INVALID_VALUES]: YAMLValidationError[];
+  [YAMLErrorType.OTHERS]: YAMLValidationError[];
 };
 
 export type YAMLErrorsModalState = {

--- a/src/pages/AddModel/ConfigsConstraints/YAMLErrorsModal/types.ts
+++ b/src/pages/AddModel/ConfigsConstraints/YAMLErrorsModal/types.ts
@@ -1,8 +1,8 @@
 import type { FieldName } from "../types";
 
 export type YAMLValidationError = {
-  line: number;
   message: string;
+  line?: number;
 };
 
 export type YAMLErrors = {

--- a/src/pages/AddModel/ConfigsConstraints/YAMLErrorsModal/types.ts
+++ b/src/pages/AddModel/ConfigsConstraints/YAMLErrorsModal/types.ts
@@ -1,0 +1,25 @@
+import type { FieldName } from "../types";
+
+export type YAMLValidationError = {
+  line: number;
+  message: string;
+};
+
+export type YAMLErrors = {
+  invalidKeys: YAMLValidationError[];
+  invalidValues: YAMLValidationError[];
+  otherErrors: YAMLValidationError[];
+};
+
+export type YAMLErrorsModalState = {
+  errors: YAMLErrors;
+  inputMode: FieldName.CONFIG_INPUT_MODE | FieldName.CONSTRAINT_INPUT_MODE;
+  yamlKey: FieldName.CONFIG_YAML | FieldName.CONSTRAINT_YAML;
+};
+
+export type YAMLErrorsModalProps = {
+  errors: YAMLErrors;
+  yamlKey: FieldName.CONFIG_YAML | FieldName.CONSTRAINT_YAML;
+  onConfirm: () => void;
+  onClose: () => void;
+};

--- a/src/pages/AddModel/ConfigsConstraints/YAMLErrorsModal/types.ts
+++ b/src/pages/AddModel/ConfigsConstraints/YAMLErrorsModal/types.ts
@@ -1,4 +1,4 @@
-import type { FieldName } from "../types";
+import { FieldName } from "../types";
 
 export type YAMLValidationError = {
   message: string;
@@ -22,4 +22,12 @@ export type YAMLErrorsModalProps = {
   yamlKey: FieldName.CONFIG_YAML | FieldName.CONSTRAINT_YAML;
   onConfirm: () => void;
   onClose: () => void;
+};
+
+export const ENTITY_LABELS: Record<
+  FieldName.CONFIG_YAML | FieldName.CONSTRAINT_YAML,
+  string
+> = {
+  [FieldName.CONFIG_YAML]: "configuration",
+  [FieldName.CONSTRAINT_YAML]: "constraint",
 };

--- a/src/pages/AddModel/ConfigsConstraints/constraintsCatalog.ts
+++ b/src/pages/AddModel/ConfigsConstraints/constraintsCatalog.ts
@@ -4,7 +4,7 @@ import { BOOLEAN_OPTIONS } from "consts";
 
 import type { CategoryDefinition } from "./types";
 
-const EMPTY_OPTION = { label: "Choose an option", value: "" };
+const EMPTY_OPTION = { label: "Unset", value: "" };
 
 export const CONSTRAINT_CATEGORIES: CategoryDefinition[] = [
   {

--- a/src/pages/AddModel/ConfigsConstraints/types.ts
+++ b/src/pages/AddModel/ConfigsConstraints/types.ts
@@ -23,6 +23,8 @@ export enum Label {
   DISABLE_REMOVE_OBJECT_DESC = "Prevents destruction of the model and removal of applications, machines, units, relations, and storage.",
   DISABLE_ALL_COMMANDS = "Disable all commands",
   DISABLE_ALL_COMMANDS_DESC = "Disables every command that can modify a Juju controller, model, or workload.",
+  INCORRECT_YAML_CONFIGURATION_ERROR = "One or more invalid configuration values",
+  INCORRECT_YAML_CONSTRAINT_ERROR = "One or more invalid constraint values",
   NO_CHANGED_CONFIGS = "No configs were changed from default",
   NO_CHANGED_CONSTRAINTS = "No constraints were changed from default",
 }

--- a/src/pages/AddModel/ConfigsConstraints/utils.test.ts
+++ b/src/pages/AddModel/ConfigsConstraints/utils.test.ts
@@ -408,13 +408,14 @@ describe("utils", () => {
       expect(errors.invalidKeys[0].line).toBe(1);
     });
 
-    it("reports other error for lines missing a colon", () => {
-      const { errors } = validateAndParseYAML("no-colon-here", categories);
-
-      expect(errors.otherErrors).toHaveLength(1);
-      expect(errors.otherErrors[0].message).toContain(
-        "Invalid format. Expected <key>: <value>",
+    it("reports other error for malformed YAML syntax", () => {
+      const { errors } = validateAndParseYAML(
+        "key: value\n  bad-indent: oops",
+        categories,
       );
+
+      expect(errors.otherErrors.length).toBeGreaterThanOrEqual(1);
+      expect(errors.otherErrors[0].line).toBeGreaterThan(0);
     });
 
     it("reports an invalid value for select fields with disallowed values", () => {

--- a/src/pages/AddModel/ConfigsConstraints/utils.test.ts
+++ b/src/pages/AddModel/ConfigsConstraints/utils.test.ts
@@ -36,7 +36,7 @@ describe("utils", () => {
           {
             label: "cores",
             description: "Number of cores",
-            isNumeric: true,
+            valueType: "number",
           },
         ],
       },
@@ -382,20 +382,11 @@ describe("utils", () => {
       expect(validValues).toEqual({
         "default-space": "custom",
         "logging-config": "debug",
-        cores: "4",
+        cores: 4,
       });
       expect(errors.invalidKeys).toHaveLength(0);
       expect(errors.invalidValues).toHaveLength(0);
       expect(errors.otherErrors).toHaveLength(0);
-    });
-
-    it("normalizes double-quoted empty string to actual empty string", () => {
-      const { validValues } = validateAndParseYAML(
-        'default-space: ""',
-        categories,
-      );
-
-      expect(validValues["default-space"]).toBe("");
     });
 
     it("reports an invalid key for unknown fields", () => {
@@ -457,6 +448,93 @@ describe("utils", () => {
 
       expect(errors.invalidValues).toHaveLength(1);
       expect(errors.invalidValues[0].message).toContain("Expected a number");
+    });
+
+    it("parses boolean YAML scalars as 'true'/'false' strings", () => {
+      const boolCategories: CategoryDefinition[] = [
+        {
+          category: "Test",
+          fields: [
+            {
+              label: "my-bool",
+              description: "A boolean field",
+              defaultValue: "false",
+              valueType: "boolean",
+              input: {
+                type: "select",
+                options: [
+                  { label: "True", value: "true" },
+                  { label: "False", value: "false" },
+                ],
+              },
+            },
+          ],
+        },
+      ];
+
+      const { validValues, errors } = validateAndParseYAML(
+        "my-bool: true",
+        boolCategories,
+      );
+
+      expect(validValues["my-bool"]).toBe(true);
+      expect(errors.invalidValues).toHaveLength(0);
+    });
+
+    it("reports an invalid value for boolean fields with non-boolean input", () => {
+      const boolCategories: CategoryDefinition[] = [
+        {
+          category: "Test",
+          fields: [
+            {
+              label: "my-bool",
+              description: "A boolean field",
+              defaultValue: "false",
+              valueType: "boolean",
+              input: {
+                type: "select",
+                options: [
+                  { label: "True", value: "true" },
+                  { label: "False", value: "false" },
+                ],
+              },
+            },
+          ],
+        },
+      ];
+      const { errors } = validateAndParseYAML(
+        'my-bool: "not-a-bool"',
+        boolCategories,
+      );
+
+      expect(errors.invalidValues).toHaveLength(1);
+      expect(errors.invalidValues[0].message).toContain(
+        "Expected one of: true, false",
+      );
+    });
+
+    it("reports an invalid value when a field has a sequence or mapping value", () => {
+      const { errors } = validateAndParseYAML(
+        "default-space:\n  - item1\n  - item2",
+        categories,
+      );
+
+      expect(errors.invalidValues).toHaveLength(1);
+      expect(errors.invalidValues[0].message).toContain(
+        "Invalid value for default-space",
+      );
+      expect(errors.invalidValues[0].line).toBe(1);
+    });
+
+    it("reports an other error when the top-level YAML is not a key-value map", () => {
+      const { errors } = validateAndParseYAML("- item1\n- item2", categories);
+
+      expect(errors.otherErrors.length).toBeGreaterThanOrEqual(1);
+      expect(
+        errors.otherErrors.some((error) =>
+          error.message.includes("Expected a top-level key-value map"),
+        ),
+      ).toBe(true);
     });
 
     it("includes catalog default for previously changed fields absent from YAML", () => {

--- a/src/pages/AddModel/ConfigsConstraints/utils.test.ts
+++ b/src/pages/AddModel/ConfigsConstraints/utils.test.ts
@@ -7,6 +7,7 @@ import {
   getCategoriesWithVisibleFields,
   getConfigInitialValues,
   isConfigChanged,
+  validateAndParseYAML,
 } from "./utils";
 
 describe("utils", () => {
@@ -26,6 +27,16 @@ describe("utils", () => {
             label: "container-networking-method",
             defaultValue: "provider",
             description: "Networking method",
+          },
+        ],
+      },
+      {
+        category: "Compute",
+        fields: [
+          {
+            label: "cores",
+            description: "Number of cores",
+            isNumeric: true,
           },
         ],
       },
@@ -260,6 +271,7 @@ describe("utils", () => {
       expect(result).toEqual({
         "default-space": "alpha",
         "container-networking-method": "provider",
+        cores: "",
         "logging-config": "",
       });
     });
@@ -357,6 +369,106 @@ describe("utils", () => {
         );
         expect(hasMatch).toBe(true);
       });
+    });
+  });
+
+  describe("validateAndParseYAML", () => {
+    it("parses the YAML into valid key-value pairs", () => {
+      const { validValues, errors } = validateAndParseYAML(
+        "# a comment\n\ndefault-space: custom\nlogging-config: debug\ncores: 4",
+        categories,
+      );
+
+      expect(validValues).toEqual({
+        "default-space": "custom",
+        "logging-config": "debug",
+        cores: "4",
+      });
+      expect(errors.invalidKeys).toHaveLength(0);
+      expect(errors.invalidValues).toHaveLength(0);
+      expect(errors.otherErrors).toHaveLength(0);
+    });
+
+    it("normalizes double-quoted empty string to actual empty string", () => {
+      const { validValues } = validateAndParseYAML(
+        'default-space: ""',
+        categories,
+      );
+
+      expect(validValues["default-space"]).toBe("");
+    });
+
+    it("reports an invalid key for unknown fields", () => {
+      const { errors } = validateAndParseYAML("unknown-key: value", categories);
+
+      expect(errors.invalidKeys).toHaveLength(1);
+      expect(errors.invalidKeys[0].message).toContain(
+        "Unknown key: unknown-key",
+      );
+      expect(errors.invalidKeys[0].line).toBe(1);
+    });
+
+    it("reports other error for lines missing a colon", () => {
+      const { errors } = validateAndParseYAML("no-colon-here", categories);
+
+      expect(errors.otherErrors).toHaveLength(1);
+      expect(errors.otherErrors[0].message).toContain(
+        "Invalid format. Expected <key>: <value>",
+      );
+    });
+
+    it("reports an invalid value for select fields with disallowed values", () => {
+      const selectCategories: CategoryDefinition[] = [
+        {
+          category: "Test",
+          fields: [
+            {
+              label: "my-select",
+              description: "A select field",
+              input: {
+                type: "select",
+                options: [
+                  { label: "A", value: "a" },
+                  { label: "B", value: "b" },
+                ],
+              },
+            },
+          ],
+        },
+      ];
+
+      const { errors } = validateAndParseYAML(
+        "my-select: invalid",
+        selectCategories,
+      );
+
+      expect(errors.invalidValues).toHaveLength(1);
+      expect(errors.invalidValues[0].message).toContain(
+        "Expected one of: a, b",
+      );
+    });
+
+    it("reports an invalid value for numeric fields with non-numeric input", () => {
+      const { errors } = validateAndParseYAML(
+        "cores: not-a-number",
+        categories,
+      );
+
+      expect(errors.invalidValues).toHaveLength(1);
+      expect(errors.invalidValues[0].message).toContain("Expected a number");
+    });
+
+    it("includes catalog default for previously changed fields absent from YAML", () => {
+      const { validValues } = validateAndParseYAML(
+        "logging-config: debug",
+        categories,
+        { "default-space": "my-space" },
+      );
+
+      // logging-config is in the YAML
+      expect(validValues["logging-config"]).toBe("debug");
+      // default-space was changed but absent from YAML — should reset to default
+      expect(validValues["default-space"]).toBe("alpha");
     });
   });
 });

--- a/src/pages/AddModel/ConfigsConstraints/utils.test.ts
+++ b/src/pages/AddModel/ConfigsConstraints/utils.test.ts
@@ -52,6 +52,17 @@ describe("utils", () => {
           },
         ],
       },
+      {
+        category: "Cloud-specific configurations",
+        fields: [
+          {
+            label: "vpc-id-force",
+            description: "VPC ID",
+            defaultValue: false,
+            valueType: "boolean",
+          },
+        ],
+      },
     ];
   });
 
@@ -274,6 +285,7 @@ describe("utils", () => {
         "container-networking-method": "provider",
         cores: "",
         "logging-config": "",
+        "vpc-id-force": false,
       });
     });
 
@@ -376,18 +388,38 @@ describe("utils", () => {
   describe("validateAndParseYAML", () => {
     it("parses the YAML into valid key-value pairs", () => {
       const { validValues, errors } = validateAndParseYAML(
-        "# a comment\n\ndefault-space: custom\nlogging-config: debug\ncores: 4",
+        "# a comment\n\ndefault-space: custom\nvpc-id-force: true\ncores: 4",
         categories,
       );
 
       expect(validValues).toEqual({
         "default-space": "custom",
-        "logging-config": "debug",
+        "vpc-id-force": true,
         cores: 4,
       });
       expect(errors.invalidKeys).toHaveLength(0);
       expect(errors.invalidValues).toHaveLength(0);
       expect(errors.otherErrors).toHaveLength(0);
+    });
+
+    it("rejects YAML 1.1 equivalents", () => {
+      // YAML 1.2: true/false are booleans, plain integers are numbers
+      // YAML 1.1 equivalents: 'off' and '1_234' are strings in YAML 1.2
+      const { errors: invalidErrors } = validateAndParseYAML(
+        "vpc-id-force: off\ncores: 1_234",
+        categories,
+      );
+      expect(invalidErrors[YAMLErrorType.INVALID_VALUES]).toHaveLength(2);
+    });
+
+    it("accepts scientific notation for numeric fields", () => {
+      const { validValues, errors } = validateAndParseYAML(
+        "cores: 1.23456e13",
+        categories,
+      );
+
+      expect(errors[YAMLErrorType.INVALID_VALUES]).toHaveLength(0);
+      expect(validValues["cores"]).toBe(1.23456e13);
     });
 
     it("reports an invalid key for unknown fields", () => {

--- a/src/pages/AddModel/ConfigsConstraints/utils.test.ts
+++ b/src/pages/AddModel/ConfigsConstraints/utils.test.ts
@@ -1,3 +1,4 @@
+import { YAMLErrorType } from "./YAMLErrorsModal/types";
 import type { CategoryDefinition } from "./types";
 import {
   buildConfigsConstraintsPayload,
@@ -6,6 +7,7 @@ import {
   getChangedFields,
   getCategoriesWithVisibleFields,
   getConfigInitialValues,
+  getYAMLErrorMessage,
   isConfigChanged,
   validateAndParseYAML,
 } from "./utils";
@@ -224,7 +226,6 @@ describe("utils", () => {
         "logging-config": "<root>=DEBUG",
         arch: "amd64",
       });
-
       expect(result).toEqual({
         "default-space": "custom-space",
         "logging-config": "<root>=DEBUG",
@@ -433,7 +434,6 @@ describe("utils", () => {
         "my-select: invalid",
         selectCategories,
       );
-
       expect(errors.invalidValues).toHaveLength(1);
       expect(errors.invalidValues[0].message).toContain(
         "Expected one of: a, b",
@@ -476,7 +476,6 @@ describe("utils", () => {
         "my-bool: true",
         boolCategories,
       );
-
       expect(validValues["my-bool"]).toBe(true);
       expect(errors.invalidValues).toHaveLength(0);
     });
@@ -502,11 +501,11 @@ describe("utils", () => {
           ],
         },
       ];
+
       const { errors } = validateAndParseYAML(
         'my-bool: "not-a-bool"',
         boolCategories,
       );
-
       expect(errors.invalidValues).toHaveLength(1);
       expect(errors.invalidValues[0].message).toContain(
         "Expected one of: true, false",
@@ -548,6 +547,35 @@ describe("utils", () => {
       expect(validValues["logging-config"]).toBe("debug");
       // default-space was changed but absent from YAML — should reset to default
       expect(validValues["default-space"]).toBe("alpha");
+    });
+  });
+
+  describe("getYAMLErrorMessage", () => {
+    it("returns an invalid format message with the given context", () => {
+      expect(
+        getYAMLErrorMessage(YAMLErrorType.OTHERS, { context: "Error context" }),
+      ).toBe("Invalid format. Error context");
+    });
+
+    it("returns an unknown key message with the given key", () => {
+      expect(
+        getYAMLErrorMessage(YAMLErrorType.UNKNOWN_KEYS, { key: "bad-key" }),
+      ).toBe("Unknown key: bad-key");
+    });
+
+    it("returns an invalid value message", () => {
+      expect(
+        getYAMLErrorMessage(YAMLErrorType.INVALID_VALUES, { key: "my-field" }),
+      ).toBe("Invalid value for my-field");
+    });
+
+    it("returns an invalid value message with expected value", () => {
+      expect(
+        getYAMLErrorMessage(YAMLErrorType.INVALID_VALUES, {
+          key: "my-field",
+          expectedValue: "a number",
+        }),
+      ).toBe("Invalid value for my-field. Expected a number");
     });
   });
 });

--- a/src/pages/AddModel/ConfigsConstraints/utils.ts
+++ b/src/pages/AddModel/ConfigsConstraints/utils.ts
@@ -1,4 +1,6 @@
-import type { YAMLErrors } from "./YAMLErrorsModal/types";
+import { parseDocument, isMap, isPair, isScalar } from "yaml";
+
+import type { YAMLErrors, YAMLValidationError } from "./YAMLErrorsModal/types";
 import { CONFIG_CATEGORIES } from "./configCatalog";
 import { CONSTRAINT_CATEGORIES } from "./constraintsCatalog";
 import type { CategoryDefinition, ConfigFieldValue } from "./types";
@@ -114,107 +116,101 @@ export const filterCategoriesBySearch = (
 };
 
 export function validateAndParseYAML(
-  yaml: string,
+  yamlString: string,
   categories: CategoryDefinition[],
   currentValues: Record<string, string> = {},
 ): {
   validValues: Record<string, string>;
   errors: YAMLErrors;
 } {
-  const fieldsByLabel = new Map(
-    categories.flatMap((category) =>
-      category.fields.map((field) => [field.label, field] as const),
-    ),
+  const fieldsByLabel = categories.reduce(
+    (acc, { fields }) => {
+      fields.forEach((field) => {
+        acc[field.label] = field;
+      });
+      return acc;
+    },
+    {} as Record<string, CategoryDefinition["fields"][number]>,
   );
 
   const validValues: Record<string, string> = {};
-  const errors: YAMLErrors = {
-    invalidKeys: [],
-    invalidValues: [],
-    otherErrors: [],
-  };
+  const invalidKeys: YAMLValidationError[] = [];
+  const invalidValues: YAMLValidationError[] = [];
 
-  yaml.split("\n").forEach((line, index) => {
-    const lineNumber = index + 1;
-    const trimmedLine = line.trim();
+  const { errors: docErrors, contents } = parseDocument(yamlString);
 
-    // Ignore empty lines and comments
-    if (!trimmedLine || trimmedLine.startsWith("#")) {
-      return;
-    }
-
-    const separatorIndex = trimmedLine.indexOf(":");
-    if (separatorIndex === -1) {
-      errors.otherErrors.push({
-        line: lineNumber,
-        message: "Invalid format. Expected <key>: <value>",
-      });
-      return;
-    }
-
-    const key = trimmedLine.slice(0, separatorIndex).trim();
-    const yamlValue = trimmedLine.slice(separatorIndex + 1).trim();
-    // Handle quoted empty string values correctly. This is done for double quotes only as buildYAML always emits "".
-    const normalizedValue = yamlValue === '""' ? "" : yamlValue;
-
-    if (!key) {
-      errors.invalidKeys.push({
-        line: lineNumber,
-        message: "Invalid key. Key cannot be empty",
-      });
-      return;
-    }
-
-    // Validate the value against the field definitions
-    const field = fieldsByLabel.get(key);
-    if (!field) {
-      errors.invalidKeys.push({
-        line: lineNumber,
-        message: `Unknown key: ${key}`,
-      });
-      return;
-    }
-
-    // If the field has a predefined set of allowed values, check if the value is valid
-    if (field.input?.type === "select") {
-      const allowedValues = (field.input.options ?? []).map(
-        ({ value }) => value,
-      );
-      if (!allowedValues.includes(normalizedValue)) {
-        errors.invalidValues.push({
-          line: lineNumber,
-          message: `Invalid value for ${key}. Expected one of: ${allowedValues.join(", ")}`,
-        });
-        return;
+  // Walk the top-level key-value pairs and validate each against the catalog.
+  if (isMap(contents)) {
+    for (const pair of contents.items) {
+      if (!isPair(pair) || !isScalar(pair.key)) {
+        continue;
       }
-    }
 
-    // If the field is numeric, validate the value
-    if (
-      field.isNumeric &&
-      normalizedValue &&
-      !/^-?\d+(\.\d+)?$/.test(normalizedValue)
-    ) {
-      errors.invalidValues.push({
-        line: lineNumber,
-        message: `Invalid type for ${key}. Expected a number`,
-      });
-      return;
-    }
+      const key = String(pair.key.value);
+      const line = pair.key.range
+        ? yamlString.slice(0, pair.key.range[0]).split("\n").length
+        : 0;
 
-    validValues[key] = normalizedValue;
-  });
+      const field = fieldsByLabel[key];
+      if (!field) {
+        invalidKeys.push({ line, message: `Unknown key: ${key}` });
+        continue;
+      }
+
+      // Coerce parsed value to string as the library already handled booleans,
+      // nulls, numbers, quoted strings etc. correctly.
+      const rawValue = isScalar(pair.value) ? pair.value.value : null;
+      const value =
+        rawValue === null || rawValue === undefined ? "" : rawValue.toString();
+
+      // If the field has a predefined set of allowed values, check if valid.
+      if (field.input?.type === "select") {
+        const allowedValues = (field.input.options ?? []).map(
+          ({ value: optionValue }) => optionValue,
+        );
+        if (!allowedValues.includes(value)) {
+          invalidValues.push({
+            line,
+            message: `Invalid value for ${key}. Expected one of: ${allowedValues.join(", ")}`,
+          });
+          continue;
+        }
+      }
+
+      // If the field is numeric, validate the value.
+      if (field.isNumeric && value && isNaN(Number(value))) {
+        invalidValues.push({
+          line,
+          message: `Invalid type for ${key}. Expected a number`,
+        });
+        continue;
+      }
+
+      validValues[key] = value;
+    }
+  }
 
   // For fields that were previously changed but absent from YAML, include
   // their catalog default so callers can reset them in a single pass.
-  fieldsByLabel.forEach((field) => {
+  for (const label in fieldsByLabel) {
+    const { defaultValue } = fieldsByLabel[label];
     if (
-      !(field.label in validValues) &&
-      isConfigChanged(field.label, currentValues, field.defaultValue)
+      !(label in validValues) &&
+      isConfigChanged(label, currentValues, defaultValue)
     ) {
-      validValues[field.label] = field.defaultValue?.toString() ?? "";
+      validValues[label] = defaultValue?.toString() ?? "";
     }
-  });
+  }
 
-  return { validValues, errors };
+  return {
+    validValues,
+    errors: {
+      invalidKeys,
+      invalidValues,
+      otherErrors: docErrors.map((error) => ({
+        line: error.linePos?.[0]?.line,
+        message: error.message,
+      })),
+    },
+  };
 }

--- a/src/pages/AddModel/ConfigsConstraints/utils.ts
+++ b/src/pages/AddModel/ConfigsConstraints/utils.ts
@@ -1,4 +1,4 @@
-import { parseDocument, isMap, isPair, isScalar } from "yaml";
+import { stringify, parseDocument, isMap, isPair, isScalar } from "yaml";
 
 import type { YAMLErrors, YAMLValidationError } from "./YAMLErrorsModal/types";
 import { CONFIG_CATEGORIES } from "./configCatalog";
@@ -49,24 +49,30 @@ export const buildYAML = (
   categories: CategoryDefinition[],
   values: Record<string, ConfigFieldValue>,
 ): string => {
-  const yamlSections = categories
-    .map((category) => {
-      const changedFields = getChangedFields(category, values).map((field) => {
-        const value = values[field.label];
-        // Quote empty string values to ensure they are represented correctly in YAML
-        const quotedValue = value === "" ? '""' : value;
-        return `${field.label}: ${quotedValue}`;
-      });
+  const sections: string[] = [];
 
-      if (changedFields.length === 0) {
-        return null;
-      }
+  for (const category of categories) {
+    const changedFields = getChangedFields(category, values);
+    if (changedFields.length === 0) {
+      continue;
+    }
 
-      return [`# ${category.category}`, ...changedFields].join("\n");
-    })
-    .filter(Boolean);
+    const fieldObject: Record<string, ConfigFieldValue> = {};
+    for (const field of changedFields) {
+      const value = values[field.label];
+      // Coerce boolean string values to actual booleans so stringify
+      // outputs them as unquoted true/false rather than quoted strings.
+      fieldObject[field.label] =
+        field.valueType === "boolean"
+          ? value === "true" || value === true
+          : value;
+    }
 
-  return yamlSections.join("\n\n");
+    // Prepend the category name as a YAML comment, then the stringified fields.
+    sections.push(`# ${category.category}\n${stringify(fieldObject)}`);
+  }
+
+  return sections.join("\n");
 };
 
 export const buildConfigsConstraintsPayload = (
@@ -118,35 +124,59 @@ export const filterCategoriesBySearch = (
 export function validateAndParseYAML(
   yamlString: string,
   categories: CategoryDefinition[],
-  currentValues: Record<string, string> = {},
+  currentValues: Record<string, ConfigFieldValue> = {},
 ): {
-  validValues: Record<string, string>;
+  validValues: Record<string, ConfigFieldValue>;
   errors: YAMLErrors;
 } {
   const fieldsByLabel = categories.reduce(
     (acc, { fields }) => {
-      fields.forEach((field) => {
+      for (const field of fields) {
         acc[field.label] = field;
-      });
+      }
       return acc;
     },
     {} as Record<string, CategoryDefinition["fields"][number]>,
   );
 
-  const validValues: Record<string, string> = {};
+  const validValues: Record<string, ConfigFieldValue> = {};
   const invalidKeys: YAMLValidationError[] = [];
   const invalidValues: YAMLValidationError[] = [];
+  const otherErrors: YAMLValidationError[] = [];
 
   const { errors: docErrors, contents } = parseDocument(yamlString);
 
-  // Walk the top-level key-value pairs and validate each against the catalog.
-  if (isMap(contents)) {
+  otherErrors.push(
+    ...docErrors.map((error) => ({
+      line: error.linePos?.[0]?.line,
+      message: error.message,
+    })),
+  );
+
+  if (!isMap(contents)) {
+    // An empty document is fine; anything else that isn't a map is malformed.
+    if (contents !== null) {
+      otherErrors.push({
+        line: 1,
+        message: "Invalid format. Expected a top-level key-value map",
+      });
+    }
+  } else {
     for (const pair of contents.items) {
-      if (!isPair(pair) || !isScalar(pair.key)) {
+      if (!isPair(pair)) {
+        otherErrors.push({
+          message: "Invalid format. Unexpected non-key-value item in map",
+        });
+        continue;
+      }
+      if (!isScalar(pair.key)) {
+        otherErrors.push({
+          message: "Invalid format. Unexpected non-scalar key",
+        });
         continue;
       }
 
-      const key = String(pair.key.value);
+      const key = pair.key.toString();
       const line = pair.key.range
         ? yamlString.slice(0, pair.key.range[0]).split("\n").length
         : 0;
@@ -157,60 +187,62 @@ export function validateAndParseYAML(
         continue;
       }
 
-      // Coerce parsed value to string as the library already handled booleans,
-      // nulls, numbers, quoted strings etc. correctly.
-      const rawValue = isScalar(pair.value) ? pair.value.value : null;
-      const value =
-        rawValue === null || rawValue === undefined ? "" : rawValue.toString();
-
-      // If the field has a predefined set of allowed values, check if valid.
-      if (field.input?.type === "select") {
-        const allowedValues = (field.input.options ?? []).map(
-          ({ value: optionValue }) => optionValue,
-        );
-        if (!allowedValues.includes(value)) {
-          invalidValues.push({
-            line,
-            message: `Invalid value for ${key}. Expected one of: ${allowedValues.join(", ")}`,
-          });
-          continue;
-        }
-      }
-
-      // If the field is numeric, validate the value.
-      if (field.isNumeric && value && isNaN(Number(value))) {
-        invalidValues.push({
-          line,
-          message: `Invalid type for ${key}. Expected a number`,
-        });
+      if (!isScalar(pair.value)) {
+        invalidValues.push({ line, message: `Invalid value for ${key}` });
         continue;
       }
 
-      validValues[key] = value;
+      const { value } = pair.value;
+
+      if (field.valueType === "number") {
+        if (typeof value !== "number") {
+          invalidValues.push({
+            line,
+            message: `Invalid type for ${key}. Expected a number`,
+          });
+          continue;
+        }
+        validValues[key] = value;
+      } else if (field.valueType === "boolean") {
+        if (typeof value !== "boolean") {
+          invalidValues.push({
+            line,
+            message: `Invalid type for ${key}. Expected one of: true, false`,
+          });
+          continue;
+        }
+        validValues[key] = value;
+      } else {
+        // Plain string field. For select fields, validate against allowed values.
+        const stringValue = value?.toString();
+        if (field.input?.type === "select") {
+          const allowedValues = (field.input.options ?? []).map(
+            ({ value: optionValue }) => optionValue,
+          );
+          if (!allowedValues.includes(stringValue)) {
+            invalidValues.push({
+              line,
+              message: `Invalid value for ${key}. Expected one of: ${allowedValues.join(", ")}`,
+            });
+            continue;
+          }
+        }
+        validValues[key] = stringValue;
+      }
     }
   }
 
-  // For fields that were previously changed but absent from YAML, include
-  // their catalog default so callers can reset them in a single pass.
+  // For fields that were previously changed but absent from the YAML, reset
+  // them to their catalog default so the caller can apply in a single pass.
   for (const label in fieldsByLabel) {
     const { defaultValue } = fieldsByLabel[label];
     if (
       !(label in validValues) &&
       isConfigChanged(label, currentValues, defaultValue)
     ) {
-      validValues[label] = defaultValue?.toString() ?? "";
+      validValues[label] = defaultValue;
     }
   }
 
-  return {
-    validValues,
-    errors: {
-      invalidKeys,
-      invalidValues,
-      otherErrors: docErrors.map((error) => ({
-        line: error.linePos?.[0]?.line,
-        message: error.message,
-      })),
-    },
-  };
+  return { validValues, errors: { invalidKeys, invalidValues, otherErrors } };
 }

--- a/src/pages/AddModel/ConfigsConstraints/utils.ts
+++ b/src/pages/AddModel/ConfigsConstraints/utils.ts
@@ -1,6 +1,10 @@
 import { stringify, parseDocument, isMap, isPair, isScalar } from "yaml";
 
-import type { YAMLErrors, YAMLValidationError } from "./YAMLErrorsModal/types";
+import {
+  type YAMLErrors,
+  YAMLErrorType,
+  type YAMLValidationError,
+} from "./YAMLErrorsModal/types";
 import { CONFIG_CATEGORIES } from "./configCatalog";
 import { CONSTRAINT_CATEGORIES } from "./constraintsCatalog";
 import type { CategoryDefinition, ConfigFieldValue } from "./types";
@@ -121,6 +125,26 @@ export const filterCategoriesBySearch = (
     .filter((category) => category.fields.length > 0);
 };
 
+export const getYAMLErrorMessage = (
+  type: YAMLErrorType,
+  options?: {
+    key?: string;
+    expectedValue?: string;
+    context?: string;
+  },
+): string => {
+  switch (type) {
+    case YAMLErrorType.OTHERS:
+      return `Invalid format. ${options?.context ?? ""}`;
+    case YAMLErrorType.UNKNOWN_KEYS:
+      return `Unknown key: ${options?.key}`;
+    case YAMLErrorType.INVALID_VALUES:
+      return options?.expectedValue
+        ? `Invalid value for ${options?.key}. Expected ${options?.expectedValue}`
+        : `Invalid value for ${options?.key}`;
+  }
+};
+
 export function validateAndParseYAML(
   yamlString: string,
   categories: CategoryDefinition[],
@@ -158,20 +182,26 @@ export function validateAndParseYAML(
     if (contents !== null) {
       otherErrors.push({
         line: 1,
-        message: "Invalid format. Expected a top-level key-value map",
+        message: getYAMLErrorMessage(YAMLErrorType.OTHERS, {
+          context: "Expected a top-level key-value map",
+        }),
       });
     }
   } else {
     for (const pair of contents.items) {
       if (!isPair(pair)) {
         otherErrors.push({
-          message: "Invalid format. Unexpected non-key-value item in map",
+          message: getYAMLErrorMessage(YAMLErrorType.OTHERS, {
+            context: "Unexpected non-key-value item in map",
+          }),
         });
         continue;
       }
       if (!isScalar(pair.key)) {
         otherErrors.push({
-          message: "Invalid format. Unexpected non-scalar key",
+          message: getYAMLErrorMessage(YAMLErrorType.OTHERS, {
+            context: "Unexpected non-scalar key",
+          }),
         });
         continue;
       }
@@ -183,12 +213,22 @@ export function validateAndParseYAML(
 
       const field = fieldsByLabel[key];
       if (!field) {
-        invalidKeys.push({ line, message: `Unknown key: ${key}` });
+        invalidKeys.push({
+          line,
+          message: getYAMLErrorMessage(YAMLErrorType.UNKNOWN_KEYS, {
+            key,
+          }),
+        });
         continue;
       }
 
       if (!isScalar(pair.value)) {
-        invalidValues.push({ line, message: `Invalid value for ${key}` });
+        invalidValues.push({
+          line,
+          message: getYAMLErrorMessage(YAMLErrorType.INVALID_VALUES, {
+            key,
+          }),
+        });
         continue;
       }
 
@@ -198,7 +238,10 @@ export function validateAndParseYAML(
         if (typeof value !== "number") {
           invalidValues.push({
             line,
-            message: `Invalid type for ${key}. Expected a number`,
+            message: getYAMLErrorMessage(YAMLErrorType.INVALID_VALUES, {
+              key,
+              expectedValue: "a number",
+            }),
           });
           continue;
         }
@@ -207,7 +250,10 @@ export function validateAndParseYAML(
         if (typeof value !== "boolean") {
           invalidValues.push({
             line,
-            message: `Invalid type for ${key}. Expected one of: true, false`,
+            message: getYAMLErrorMessage(YAMLErrorType.INVALID_VALUES, {
+              key,
+              expectedValue: "one of: true, false",
+            }),
           });
           continue;
         }
@@ -222,7 +268,10 @@ export function validateAndParseYAML(
           if (!allowedValues.includes(stringValue)) {
             invalidValues.push({
               line,
-              message: `Invalid value for ${key}. Expected one of: ${allowedValues.join(", ")}`,
+              message: getYAMLErrorMessage(YAMLErrorType.INVALID_VALUES, {
+                key,
+                expectedValue: `one of: ${allowedValues.join(", ")}`,
+              }),
             });
             continue;
           }

--- a/src/pages/AddModel/ConfigsConstraints/utils.ts
+++ b/src/pages/AddModel/ConfigsConstraints/utils.ts
@@ -1,3 +1,4 @@
+import type { YAMLErrors } from "./YAMLErrorsModal/types";
 import { CONFIG_CATEGORIES } from "./configCatalog";
 import { CONSTRAINT_CATEGORIES } from "./constraintsCatalog";
 import type { CategoryDefinition, ConfigFieldValue } from "./types";
@@ -50,6 +51,7 @@ export const buildYAML = (
     .map((category) => {
       const changedFields = getChangedFields(category, values).map((field) => {
         const value = values[field.label];
+        // Quote empty string values to ensure they are represented correctly in YAML
         const quotedValue = value === "" ? '""' : value;
         return `${field.label}: ${quotedValue}`;
       });
@@ -110,3 +112,109 @@ export const filterCategoriesBySearch = (
     }))
     .filter((category) => category.fields.length > 0);
 };
+
+export function validateAndParseYAML(
+  yaml: string,
+  categories: CategoryDefinition[],
+  currentValues: Record<string, string> = {},
+): {
+  validValues: Record<string, string>;
+  errors: YAMLErrors;
+} {
+  const fieldsByLabel = new Map(
+    categories.flatMap((category) =>
+      category.fields.map((field) => [field.label, field] as const),
+    ),
+  );
+
+  const validValues: Record<string, string> = {};
+  const errors: YAMLErrors = {
+    invalidKeys: [],
+    invalidValues: [],
+    otherErrors: [],
+  };
+
+  yaml.split("\n").forEach((line, index) => {
+    const lineNumber = index + 1;
+    const trimmedLine = line.trim();
+
+    // Ignore empty lines and comments
+    if (!trimmedLine || trimmedLine.startsWith("#")) {
+      return;
+    }
+
+    const separatorIndex = trimmedLine.indexOf(":");
+    if (separatorIndex === -1) {
+      errors.otherErrors.push({
+        line: lineNumber,
+        message: "Invalid format. Expected <key>: <value>",
+      });
+      return;
+    }
+
+    const key = trimmedLine.slice(0, separatorIndex).trim();
+    const yamlValue = trimmedLine.slice(separatorIndex + 1).trim();
+    // Handle quoted empty string values correctly. This is done for double quotes only as buildYAML always emits "".
+    const normalizedValue = yamlValue === '""' ? "" : yamlValue;
+
+    if (!key) {
+      errors.invalidKeys.push({
+        line: lineNumber,
+        message: "Invalid key. Key cannot be empty",
+      });
+      return;
+    }
+
+    // Validate the value against the field definitions
+    const field = fieldsByLabel.get(key);
+    if (!field) {
+      errors.invalidKeys.push({
+        line: lineNumber,
+        message: `Unknown key: ${key}`,
+      });
+      return;
+    }
+
+    // If the field has a predefined set of allowed values, check if the value is valid
+    if (field.input?.type === "select") {
+      const allowedValues = (field.input.options ?? []).map(
+        ({ value }) => value,
+      );
+      if (!allowedValues.includes(normalizedValue)) {
+        errors.invalidValues.push({
+          line: lineNumber,
+          message: `Invalid value for ${key}. Expected one of: ${allowedValues.join(", ")}`,
+        });
+        return;
+      }
+    }
+
+    // If the field is numeric, validate the value
+    if (
+      field.isNumeric &&
+      normalizedValue &&
+      !/^-?\d+(\.\d+)?$/.test(normalizedValue)
+    ) {
+      errors.invalidValues.push({
+        line: lineNumber,
+        message: `Invalid type for ${key}. Expected a number`,
+      });
+      return;
+    }
+
+    validValues[key] = normalizedValue;
+  });
+
+  // For fields that were previously changed but absent from YAML, include
+  // their catalog default so callers can reset them in a single pass.
+  fieldsByLabel.forEach((field) => {
+    if (
+      !(field.label in validValues) &&
+      isConfigChanged(field.label, currentValues, field.defaultValue)
+    ) {
+      validValues[field.label] = field.defaultValue?.toString() ?? "";
+    }
+  });
+
+  return { validValues, errors };
+}

--- a/src/pages/AddModel/ConfigsConstraints/utils.ts
+++ b/src/pages/AddModel/ConfigsConstraints/utils.ts
@@ -1,4 +1,11 @@
-import { stringify, parseDocument, isMap, isPair, isScalar } from "yaml";
+import {
+  Document as YAMLDocument,
+  YAMLMap,
+  parseDocument,
+  isMap,
+  isPair,
+  isScalar,
+} from "yaml";
 
 import {
   type YAMLErrors,
@@ -53,7 +60,8 @@ export const buildYAML = (
   categories: CategoryDefinition[],
   values: Record<string, ConfigFieldValue>,
 ): string => {
-  const sections: string[] = [];
+  const doc = new YAMLDocument(new YAMLMap());
+  const map = doc.contents as YAMLMap;
 
   for (const category of categories) {
     const changedFields = getChangedFields(category, values);
@@ -61,22 +69,30 @@ export const buildYAML = (
       continue;
     }
 
-    const fieldObject: Record<string, ConfigFieldValue> = {};
-    for (const field of changedFields) {
+    for (const [index, field] of changedFields.entries()) {
       const value = values[field.label];
       // Coerce boolean string values to actual booleans so stringify
       // outputs them as unquoted true/false rather than quoted strings.
-      fieldObject[field.label] =
+      const coerced =
         field.valueType === "boolean"
           ? value === "true" || value === true
           : value;
+      const pair = doc.createPair(field.label, coerced);
+      if (index === 0) {
+        // Attach the category name as a comment before the first key in each
+        // category. spaceBefore inserts a blank line between categories.
+        pair.key.commentBefore = ` ${category.category}`;
+        pair.key.spaceBefore = map.items.length > 0;
+      }
+      map.add(pair);
     }
-
-    // Prepend the category name as a YAML comment, then the stringified fields.
-    sections.push(`# ${category.category}\n${stringify(fieldObject)}`);
   }
 
-  return sections.join("\n");
+  if (map.items.length === 0) {
+    return "";
+  }
+
+  return doc.toString();
 };
 
 export const buildConfigsConstraintsPayload = (
@@ -139,9 +155,11 @@ export const getYAMLErrorMessage = (
     case YAMLErrorType.UNKNOWN_KEYS:
       return `Unknown key: ${options?.key}`;
     case YAMLErrorType.INVALID_VALUES:
-      return options?.expectedValue
-        ? `Invalid value for ${options?.key}. Expected ${options?.expectedValue}`
-        : `Invalid value for ${options?.key}`;
+      const message = `Invalid value for ${options?.key}`;
+      if (options?.expectedValue) {
+        return `${message}. Expected ${options?.expectedValue}`;
+      }
+      return message;
   }
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9160,6 +9160,7 @@ __metadata:
     vite-tsconfig-paths: "npm:6.1.1"
     vitest: "npm:4.1.9"
     vitest-fetch-mock: "npm:0.4.5"
+    yaml: "npm:2.9.0"
     yup: "npm:1.7.1"
   languageName: unknown
   linkType: soft
@@ -13827,6 +13828,15 @@ __metadata:
   version: 5.0.0
   resolution: "yallist@npm:5.0.0"
   checksum: 10c0/a499c81ce6d4a1d260d4ea0f6d49ab4da09681e32c3f0472dee16667ed69d01dae63a3b81745a24bd78476ec4fcf856114cb4896ace738e01da34b2c42235416
+  languageName: node
+  linkType: hard
+
+"yaml@npm:2.9.0":
+  version: 2.9.0
+  resolution: "yaml@npm:2.9.0"
+  bin:
+    yaml: bin.mjs
+  checksum: 10c0/f340718df45e97a9551b9bf9dac61c80050bc464513b710debfb5067c380c8472e3b67809cffacb4ab5ffb5e66ef9310816c88b05f371cec60abfedd8c88e0a2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Depends on https://github.com/canonical/juju-dashboard/pull/2384 https://github.com/canonical/juju-dashboard/pull/2385

## Done

- Added `YAMLErrorsModal` in `ConfigsConstraints` to show different types of errors that show up during YAML validation and parsing.
- Added a util to validate and parse YAML text input when the triggers a switch to list mode. The util uses `parseDocument` function from `yaml` library
- This util also makes note of various errors that show up during parsing and segregates them based on "Invalid key", "Invalid value" and "Other" errors.
- The modal uses these three error types and displays them accordingly, along with the line number
- The util is also equipped to drop any key-value pairs that were added in list mode but wiped in yaml mode. Those keys are reverted to default making them unchanged.
- Forcing a switch without fixing erroneous values drops them. Any values that were parsed without errors are set in the formik context.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Go to ConfigsConstraints tab on AddModel page and play a bit with the List<->YAML mode
  - Set a value in list mode, switch to YAML, reset it in YAML, switch to list.
  - Set incorrect values and value types
  - Use incorrect format for setting "key- value" instead of "key: value"
  - Try setting an unknown key-value pair
  - Set a field expecting numerical value to a string
- All the above cases should be handled gracefully. [Figma](https://www.figma.com/design/Rs1v3IS0oY2RK4CU4yo4Ly/25.10-JAAS-model-management---Juju?node-id=2068-148122&m=dev)

## Details

https://warthogs.atlassian.net/browse/JUJU-9833

## Screenshots
<img width="1352" height="658" alt="Screenshot 2026-06-23 at 7 34 55 PM" src="https://github.com/user-attachments/assets/daa73e3a-217f-4309-b0a4-29c630ec08e1" />

