### PR TITLE
fix(cloud-init): configure docker firewall rules before initialisation

### DIFF
--- a/scripts/cloud-init-jimm-lxd-oidc.yaml
+++ b/scripts/cloud-init-jimm-lxd-oidc.yaml
@@ -54,6 +54,13 @@ runcmd:
     # Finish Docker setup.
     sudo addgroup --system docker
     sudo adduser ubuntu docker
+
+    # Don't allow Docker to set global drop rule.
+    # See: https://docs.docker.com/engine/network/packet-filtering-firewalls/#docker-on-a-router
+    DAEMON_CONF=/var/snap/docker/current/config/daemon.json
+    sudo cat ${DAEMON_CONF} | jq '."ip-forward-no-drop" = true' | sudo tee "${DAEMON_CONF}.tmp"
+    sudo mv "${DAEMON_CONF}.tmp" ${DAEMON_CONF}
+
     sudo snap disable docker
     sudo snap enable docker
 


### PR DESCRIPTION
Docker adds a firewall rule to drop all non-accepted forwarded connections. Use the `ip-forward-no-drop` daemon configuration option to disable this during cloud init setup.


See:
- https://docs.docker.com/engine/network/packet-filtering-firewalls/#docker-on-a-router
- https://github.com/docker/for-linux/issues/103

# QA

- Launch a multipass instance with the cloud init: `multipass launch --cpus 2 --disk 25G --memory 12G --name jimm-with-internet --timeout 5000 --cloud-init ./scripts/cloud-init-jimm-lxd-oidc.yaml`
- Launch an LXD container: `lxc launch ubuntu:24.04`
- Connect to container: `lxc ssh {container name}`
- Ensure network connectivity: `ping 1.1.1.1`