### PR TITLE
feat(connection-manager): different connection logic

### DIFF
--- a/src/juju/api.ts
+++ b/src/juju/api.ts
@@ -83,13 +83,13 @@ export function generateConnectionOptions(
   };
 }
 
-function stopPingerLoop(intervalId: number): void {
+export function stopPingerLoop(intervalId: number): void {
   if (intervalId) {
     clearInterval(intervalId);
   }
 }
 
-function startPingerLoop(conn: ConnectionWithFacades): number {
+export function startPingerLoop(conn: ConnectionWithFacades): number {
   // Ping to keep the connection alive.
   const intervalId = window.setInterval(() => {
     conn.facades.pinger?.ping(null).catch((err) => {

--- a/src/store/middleware/connection/connection-manager.test.ts
+++ b/src/store/middleware/connection/connection-manager.test.ts
@@ -1,43 +1,36 @@
 import type { Client } from "@canonical/jujulib";
-import type { MockInstance } from "vitest";
+import * as jujuLib from "@canonical/jujulib";
+import type { Mock, MockInstance } from "vitest";
 
 import { Auth, LocalAuth } from "auth";
 import * as jujuModule from "juju/api";
 import type { ConnectionWithFacades } from "juju/types";
 
-import { ConnectionManager } from "./connection-manager";
+import {
+  ConnectionManager,
+  CONNECTION_HANDLERS_BY_PATH,
+  DefaultHandler,
+} from "./connection-manager";
 
 describe("ConnectionManager", () => {
   const connection = {} as ConnectionWithFacades;
-  const intervalId = 1234;
-  let bakeryResult: Awaited<ReturnType<(typeof jujuModule)["loginWithBakery"]>>;
-  let bakerySpy: MockInstance;
-  let juju: Client;
+  let connectionHandler: MockInstance;
+  let connectionOnClose: Mock;
 
   beforeEach(() => {
-    new LocalAuth(vi.fn());
-    juju = {
-      logout: vi.fn().mockImplementation((cb) => cb()),
-    } as unknown as Client;
-    bakeryResult = {
-      conn: connection,
-      juju,
-      intervalId,
-    };
-    bakerySpy = vi
-      .spyOn(jujuModule, "loginWithBakery")
-      .mockResolvedValue(bakeryResult);
-  });
-
-  afterEach(() => {
-    // @ts-expect-error - Resetting singleton for each test run.
-    delete Auth.instance;
+    connectionOnClose = vi.fn();
+    connectionHandler = CONNECTION_HANDLERS_BY_PATH[DefaultHandler] = vi
+      .fn()
+      .mockResolvedValue({
+        connection,
+        onClose: connectionOnClose,
+      });
   });
 
   it("creates new connection if not existing", async ({ expect }) => {
     const manager = new ConnectionManager({ getCredentials: vi.fn() });
     const result = await manager.get("wss://example.com/");
-    expect(jujuModule.loginWithBakery).toHaveBeenCalledTimes(1);
+    expect(connectionHandler).toHaveBeenCalledTimes(1);
     expect(result).toEqual(connection);
   });
 
@@ -45,16 +38,16 @@ describe("ConnectionManager", () => {
     const manager = new ConnectionManager({ getCredentials: vi.fn() });
     const result1 = await manager.get("wss://example.com/");
     const result2 = await manager.get("wss://example.com/");
-    expect(jujuModule.loginWithBakery).toHaveBeenCalledTimes(1);
+    expect(connectionHandler).toHaveBeenCalledTimes(1);
     expect(result1).toEqual(connection);
     expect(result2).toEqual(connection);
   });
 
   it("re-uses pending connection if present", async ({ expect }) => {
     vi.useFakeTimers();
-    // Ensure bakery is pending
-    const bakeryPromise = Promise.withResolvers();
-    bakerySpy.mockReturnValue(bakeryPromise.promise);
+    // Ensure connection is pending
+    const connectionPromise = Promise.withResolvers();
+    connectionHandler.mockReturnValue(connectionPromise.promise);
 
     const manager = new ConnectionManager({ getCredentials: vi.fn() });
     // Begin connections, won't immediately resolve.
@@ -70,11 +63,11 @@ describe("ConnectionManager", () => {
     });
     await vi.runOnlyPendingTimersAsync();
 
-    expect(bakerySpy).toHaveBeenCalledTimes(1);
+    expect(connectionHandler).toHaveBeenCalledTimes(1);
     expect(resolved1).toBe(false);
     expect(resolved2).toBe(false);
 
-    bakeryPromise.resolve(bakeryResult);
+    connectionPromise.resolve({ connection });
     await vi.runOnlyPendingTimersAsync();
 
     expect(resolved1).toBe(true);
@@ -101,21 +94,22 @@ describe("ConnectionManager", () => {
     it("correctly cleans up", async ({ expect }) => {
       const manager = new ConnectionManager({ getCredentials: vi.fn() });
       await manager.get("wss://example.com/");
+      expect(connectionOnClose).not.toHaveBeenCalled();
       await manager.logout("wss://example.com/");
-      expect(juju.logout).toHaveBeenCalledTimes(1);
+      expect(connectionOnClose).toHaveBeenCalledTimes(1);
     });
 
     it("immediately returns if not connected", async ({ expect }) => {
       const manager = new ConnectionManager({ getCredentials: vi.fn() });
       await manager.logout("wss://example.com/");
-      expect(jujuModule.loginWithBakery).not.toHaveBeenCalled();
+      expect(connectionHandler).not.toHaveBeenCalled();
     });
 
     it("waits for connection if in progress", async ({ expect }) => {
       vi.useFakeTimers();
-      // Ensure bakery is pending
-      const bakeryPromise = Promise.withResolvers();
-      bakerySpy.mockReturnValue(bakeryPromise.promise);
+      // Ensure connection is pending
+      const connectionPromise = Promise.withResolvers();
+      connectionHandler.mockReturnValue(connectionPromise.promise);
 
       const manager = new ConnectionManager({ getCredentials: vi.fn() });
       // Begin connection, won't immediately resolve.
@@ -131,9 +125,130 @@ describe("ConnectionManager", () => {
       await vi.runOnlyPendingTimersAsync();
       expect(logoutResolved).toBe(false);
 
-      bakeryPromise.resolve(bakeryResult);
+      connectionPromise.resolve({ connection });
       await vi.runOnlyPendingTimersAsync();
       expect(logoutResolved).toBe(true);
+    });
+  });
+});
+
+describe("connection handlers", () => {
+  describe("default", () => {
+    let logout: Mock;
+    let logoutCb: Mock;
+    const connection = {} as ConnectionWithFacades;
+    let connectAndLoginSpy: MockInstance;
+
+    const defaultHandler = CONNECTION_HANDLERS_BY_PATH[DefaultHandler];
+
+    beforeEach(() => {
+      new LocalAuth(vi.fn());
+      logoutCb = vi.fn();
+      logout = vi.fn((cb) => cb(0, logoutCb));
+      connectAndLoginSpy = vi
+        .spyOn(jujuLib, "connectAndLogin")
+        .mockResolvedValue({
+          conn: connection,
+          logout,
+        });
+    });
+
+    afterEach(() => {
+      // @ts-expect-error - Resetting singleton for each test run.
+      delete Auth.instance;
+    });
+
+    it("calls `connectAndLogin`", async ({ expect }) => {
+      const credential = { user: "admin", password: "example123" };
+      const result = await defaultHandler("wss://example.com", credential);
+      expect(connectAndLoginSpy).toHaveBeenCalledExactlyOnceWith(
+        "wss://example.com",
+        expect.anything(),
+        expect.anything(),
+        jujuModule.CLIENT_VERSION,
+      );
+      expect(result.connection).toEqual(connection);
+    });
+
+    it("calls connection logout on close", async ({ expect }) => {
+      const result = await defaultHandler("wss://example.com", undefined);
+      expect(result.onClose).not.toBeUndefined();
+      expect(logout).not.toHaveBeenCalled();
+      await result.onClose?.();
+
+      expect(logout).toHaveBeenCalledTimes(1);
+      expect(logoutCb).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("controller", () => {
+    const connection = {} as ConnectionWithFacades;
+    const intervalId = 1234;
+    let bakeryResult: Awaited<
+      ReturnType<(typeof jujuModule)["loginWithBakery"]>
+    >;
+    let bakerySpy: MockInstance;
+    let juju: Client;
+
+    const controllerHandler = CONNECTION_HANDLERS_BY_PATH["/api"];
+
+    beforeEach(() => {
+      new LocalAuth(vi.fn());
+      juju = {
+        logout: vi.fn().mockImplementation((cb) => cb()),
+      } as unknown as Client;
+      bakeryResult = {
+        conn: connection,
+        juju,
+        intervalId,
+      };
+      bakerySpy = vi
+        .spyOn(jujuModule, "loginWithBakery")
+        .mockResolvedValue(bakeryResult);
+    });
+
+    afterEach(() => {
+      // @ts-expect-error - Resetting singleton for each test run.
+      delete Auth.instance;
+    });
+
+    it("attempts to login with `loginWithBakery`", async ({ expect }) => {
+      const credential = { user: "admin", password: "example123" };
+      const result = await controllerHandler(
+        "wss://example.com/api",
+        credential,
+      );
+      expect(bakerySpy).toHaveBeenCalledExactlyOnceWith(
+        "wss://example.com/api",
+        credential,
+      );
+      expect(result.connection).toEqual(connection);
+    });
+
+    describe("on close", () => {
+      let onClose: Awaited<ReturnType<typeof controllerHandler>>["onClose"];
+
+      beforeEach(async () => {
+        const result = await controllerHandler(
+          "wss://example.com/api",
+          undefined,
+        );
+        ({ onClose } = result);
+      });
+
+      it("calls `juju.logout`", async ({ expect }) => {
+        expect(juju.logout).not.toHaveBeenCalled();
+        expect(onClose).not.toBeUndefined();
+        await onClose?.();
+        expect(juju.logout).toBeCalledTimes(1);
+      });
+
+      it("clears interval", async ({ expect }) => {
+        const clearIntervalSpy = vi.spyOn(window, "clearInterval");
+        expect(onClose).not.toBeUndefined();
+        await onClose?.();
+        expect(clearIntervalSpy).toHaveBeenCalledExactlyOnceWith(intervalId);
+      });
     });
   });
 });

--- a/src/store/middleware/connection/connection-manager.test.ts
+++ b/src/store/middleware/connection/connection-manager.test.ts
@@ -4,7 +4,7 @@ import type { Mock, MockInstance } from "vitest";
 
 import { Auth, LocalAuth } from "auth";
 import * as jujuModule from "juju/api";
-import type { ConnectionWithFacades } from "juju/types";
+import { Label, type ConnectionWithFacades } from "juju/types";
 
 import {
   ConnectionManager,
@@ -178,6 +178,16 @@ describe("connection handlers", () => {
 
       expect(logout).toHaveBeenCalledTimes(1);
       expect(logoutCb).toHaveBeenCalledTimes(1);
+    });
+
+    it("throws error on timeout", async ({ expect }) => {
+      vi.useFakeTimers();
+      connectAndLoginSpy.mockReturnValue(new Promise(() => {}));
+      const connectionPromise = defaultHandler("wss://example.com", undefined);
+      vi.advanceTimersByTime(jujuModule.LOGIN_TIMEOUT);
+      await expect(async () => await connectionPromise).rejects.toThrow(
+        Label.LOGIN_TIMEOUT_ERROR,
+      );
     });
   });
 

--- a/src/store/middleware/connection/connection-manager.test.ts
+++ b/src/store/middleware/connection/connection-manager.test.ts
@@ -138,6 +138,8 @@ describe("connection handlers", () => {
     let logoutCb: Mock;
     const connection = {} as ConnectionWithFacades;
     let connectAndLoginSpy: MockInstance;
+    let startPingerLoopSpy: MockInstance;
+    let stopPingerLoopSpy: MockInstance;
 
     const defaultHandler = CONNECTION_HANDLERS_BY_PATH[DefaultHandler];
 
@@ -151,6 +153,12 @@ describe("connection handlers", () => {
           conn: connection,
           logout,
         });
+      startPingerLoopSpy = vi
+        .spyOn(jujuModule, "startPingerLoop")
+        .mockReturnValue(1234);
+      stopPingerLoopSpy = vi
+        .spyOn(jujuModule, "stopPingerLoop")
+        .mockReturnValue();
     });
 
     afterEach(() => {
@@ -167,6 +175,7 @@ describe("connection handlers", () => {
         expect.anything(),
         jujuModule.CLIENT_VERSION,
       );
+      expect(startPingerLoopSpy).to.toHaveBeenCalledExactlyOnceWith(connection);
       expect(result.connection).toEqual(connection);
     });
 
@@ -178,6 +187,7 @@ describe("connection handlers", () => {
 
       expect(logout).toHaveBeenCalledTimes(1);
       expect(logoutCb).toHaveBeenCalledTimes(1);
+      expect(stopPingerLoopSpy).toHaveBeenCalledExactlyOnceWith(1234);
     });
 
     it("throws error on timeout", async ({ expect }) => {

--- a/src/store/middleware/connection/connection-manager.ts
+++ b/src/store/middleware/connection/connection-manager.ts
@@ -4,6 +4,7 @@ import { Auth } from "auth";
 import {
   CLIENT_VERSION,
   generateConnectionOptions,
+  LOGIN_TIMEOUT,
   loginWithBakery,
 } from "juju/api";
 import { Label, type ConnectionWithFacades } from "juju/types";
@@ -50,14 +51,18 @@ export const CONNECTION_HANDLERS_BY_PATH: Record<
    * Handler used by default
    */
   [DefaultHandler]: async (wsURL, credentials) => {
+    const timeout = new Promise<never>((_resolve, reject) => {
+      setTimeout(() => {
+        reject(Label.LOGIN_TIMEOUT_ERROR);
+      }, LOGIN_TIMEOUT);
+    });
+
     const options = generateConnectionOptions(true);
     const instanceCredentials = Auth.instance.determineCredentials(credentials);
-    const { conn, logout } = await connectAndLogin(
-      wsURL,
-      options,
-      instanceCredentials,
-      CLIENT_VERSION,
-    );
+    const { conn, logout } = await Promise.race([
+      connectAndLogin(wsURL, options, instanceCredentials, CLIENT_VERSION),
+      timeout,
+    ]);
     if (!conn) {
       throw new Error(`could not connect to ${wsURL}`);
     }

--- a/src/store/middleware/connection/connection-manager.ts
+++ b/src/store/middleware/connection/connection-manager.ts
@@ -1,7 +1,11 @@
-import type { Client } from "@canonical/jujulib";
+import { connectAndLogin } from "@canonical/jujulib";
 
 import { Auth } from "auth";
-import { loginWithBakery } from "juju/api";
+import {
+  CLIENT_VERSION,
+  generateConnectionOptions,
+  loginWithBakery,
+} from "juju/api";
 import { Label, type ConnectionWithFacades } from "juju/types";
 import type { AuthCredential } from "store/general/types";
 import { logger } from "utils/logger";
@@ -14,16 +18,114 @@ type Hooks = {
   ) => Promise<void> | void;
 };
 
-type SavedConnection = {
+/**
+ * The result of a connection handler.
+ */
+type ConnectionResult = {
   connection: ConnectionWithFacades;
-  intervalId?: number;
-  juju?: Client;
+  onClose?: () => PromiseLike<void>;
+};
+
+/**
+ * A function which resolves with a connection for a given URL and credentials.
+ */
+type ConnectionHandler = (
+  wsControllerURL: string,
+  credentials: AuthCredential | undefined,
+) => Promise<ConnectionResult>;
+
+/**
+ * Symbol representing the default handler.
+ */
+export const DefaultHandler = Symbol();
+
+/**
+ * Map of URL paths to a connection handler, with `DefaultHandler` suitable for any connection kind.
+ */
+export const CONNECTION_HANDLERS_BY_PATH: Record<
+  string | typeof DefaultHandler,
+  ConnectionHandler
+> = {
+  /**
+   * Handler used by default
+   */
+  [DefaultHandler]: async (wsControllerURL, credentials) => {
+    const options = generateConnectionOptions(true);
+    const instanceCredentials = Auth.instance.determineCredentials(credentials);
+    const { conn, logout } = await connectAndLogin(
+      wsControllerURL,
+      options,
+      instanceCredentials,
+      CLIENT_VERSION,
+    );
+    if (!conn) {
+      throw new Error(`could not connect to ${wsControllerURL}`);
+    }
+    return {
+      connection: conn,
+      onClose: async (): Promise<void> => {
+        await new Promise<void>((resolve) => {
+          logout((code, cb) => {
+            resolve();
+            cb(code);
+          });
+        });
+      },
+    };
+  },
+  /*
+   * If a URL path is `/api`, then it is a controller.
+   */
+  "/api": async (wsControllerURL, credentials) => {
+    const continueConnection = await Auth.instance.beforeControllerConnect({
+      wsControllerURL,
+      credentials,
+    });
+    if (!continueConnection) {
+      throw new Error("could not continue connection");
+    }
+
+    const {
+      conn: connection,
+      error,
+      juju,
+      intervalId,
+    } = await loginWithBakery(wsControllerURL, credentials).catch((cause) => {
+      const message =
+        "Unable to log into the controller, check that the controller address is correct and that it is online.";
+      logger.error(message, cause);
+      throw new Error(message, { cause });
+    });
+    if (error) {
+      throw new Error(Label.CONTROLLER_LOGIN_ERROR);
+    }
+    if (!connection) {
+      throw new Error("Could not connect to controller");
+    }
+
+    return {
+      connection,
+      onClose: async (): Promise<void> => {
+        if (intervalId !== undefined && intervalId !== null) {
+          clearInterval(intervalId);
+        }
+        if (juju) {
+          await new Promise<void>((resolve) => {
+            juju.logout((code, cb) => {
+              resolve();
+              cb(code);
+            });
+          });
+        }
+      },
+    };
+  },
 };
 
 export class ConnectionManager {
   private connections = new Map<
     string,
-    Promise<ConnectionWithFacades> | SavedConnection
+    ConnectionResult | Promise<ConnectionWithFacades>
   >();
   private hooks: Hooks;
 
@@ -53,8 +155,8 @@ export class ConnectionManager {
   async logout(wsControllerURL: string): Promise<void> {
     // Wait to get the connection;
     let connection:
+      | ConnectionResult
       | Promise<ConnectionWithFacades>
-      | SavedConnection
       | undefined = undefined;
     do {
       connection = this.connections.get(wsControllerURL);
@@ -69,17 +171,7 @@ export class ConnectionManager {
     // Remove it from the map.
     this.connections.delete(wsControllerURL);
 
-    if (connection.intervalId !== undefined) {
-      clearInterval(connection.intervalId);
-    }
-    if (connection.juju) {
-      await new Promise<void>((resolve) => {
-        connection.juju?.logout((code, cb) => {
-          resolve();
-          cb(code);
-        });
-      });
-    }
+    await connection.onClose?.();
   }
 
   /**
@@ -100,37 +192,31 @@ export class ConnectionManager {
 
     const credentials = this.hooks.getCredentials(wsControllerURL);
 
-    const continueConnection = await Auth.instance.beforeControllerConnect({
+    // Extract the path to determine the connection handler.
+    let path = "";
+    try {
+      const url = new URL(wsControllerURL);
+      path = url.pathname;
+    } catch (err) {
+      logger.warn(
+        `invalid URL for connection, falling back on default connection handler`,
+        wsControllerURL,
+        err,
+      );
+    }
+
+    // Select an appropriate connection handler.
+    const connectionHandler =
+      CONNECTION_HANDLERS_BY_PATH[path] ??
+      CONNECTION_HANDLERS_BY_PATH[DefaultHandler];
+
+    const connectionResult = await connectionHandler(
       wsControllerURL,
       credentials,
-    });
-    if (!continueConnection) {
-      throw new Error("could not continue connection");
-    }
+    );
+    const { connection } = connectionResult;
 
-    const {
-      conn: connection,
-      error,
-      juju,
-      intervalId,
-    } = await loginWithBakery(wsControllerURL, credentials).catch((cause) => {
-      const message =
-        "Unable to log into the controller, check that the controller address is correct and that it is online.";
-      logger.error(message, cause);
-      throw new Error(message, { cause });
-    });
-    if (error) {
-      throw new Error(Label.CONTROLLER_LOGIN_ERROR);
-    }
-    if (!connection) {
-      throw new Error("Could not connect to controller");
-    }
-
-    this.connections.set(wsControllerURL, {
-      connection,
-      intervalId: intervalId ?? undefined,
-      juju,
-    });
+    this.connections.set(wsControllerURL, connectionResult);
     connectionPromise.resolve(connection);
 
     await this.hooks.onConnection?.(wsControllerURL, connection);

--- a/src/store/middleware/connection/connection-manager.ts
+++ b/src/store/middleware/connection/connection-manager.ts
@@ -11,9 +11,9 @@ import type { AuthCredential } from "store/general/types";
 import { logger } from "utils/logger";
 
 type Hooks = {
-  getCredentials: (wsControllerURL: string) => AuthCredential | undefined;
+  getCredentials: (wsURL: string) => AuthCredential | undefined;
   onConnection?: (
-    wsControllerURL: string,
+    wsURL: string,
     connection: ConnectionWithFacades,
   ) => Promise<void> | void;
 };
@@ -30,7 +30,7 @@ type ConnectionResult = {
  * A function which resolves with a connection for a given URL and credentials.
  */
 type ConnectionHandler = (
-  wsControllerURL: string,
+  wsURL: string,
   credentials: AuthCredential | undefined,
 ) => Promise<ConnectionResult>;
 
@@ -49,17 +49,17 @@ export const CONNECTION_HANDLERS_BY_PATH: Record<
   /**
    * Handler used by default
    */
-  [DefaultHandler]: async (wsControllerURL, credentials) => {
+  [DefaultHandler]: async (wsURL, credentials) => {
     const options = generateConnectionOptions(true);
     const instanceCredentials = Auth.instance.determineCredentials(credentials);
     const { conn, logout } = await connectAndLogin(
-      wsControllerURL,
+      wsURL,
       options,
       instanceCredentials,
       CLIENT_VERSION,
     );
     if (!conn) {
-      throw new Error(`could not connect to ${wsControllerURL}`);
+      throw new Error(`could not connect to ${wsURL}`);
     }
     return {
       connection: conn,
@@ -134,11 +134,11 @@ export class ConnectionManager {
   }
 
   /**
-   * Fetch the connection for a given controller. If the connection doesn't exist, then create it
+   * Fetch the connection for a given URL. If the connection doesn't exist, then create it
    * before returning.
    */
-  async get(wsControllerURL: string): Promise<ConnectionWithFacades> {
-    const existing = this.connections.get(wsControllerURL);
+  async get(wsURL: string): Promise<ConnectionWithFacades> {
+    const existing = this.connections.get(wsURL);
     if (existing !== undefined) {
       if (existing instanceof Promise) {
         return await existing;
@@ -146,20 +146,20 @@ export class ConnectionManager {
         return existing.connection;
       }
     }
-    return await this.connect(wsControllerURL);
+    return await this.connect(wsURL);
   }
 
   /**
    * Logout from a connection.
    */
-  async logout(wsControllerURL: string): Promise<void> {
+  async logout(wsURL: string): Promise<void> {
     // Wait to get the connection;
     let connection:
       | ConnectionResult
       | Promise<ConnectionWithFacades>
       | undefined = undefined;
     do {
-      connection = this.connections.get(wsControllerURL);
+      connection = this.connections.get(wsURL);
       if (!connection) {
         return;
       } else if (connection instanceof Promise) {
@@ -169,7 +169,7 @@ export class ConnectionManager {
     } while (connection === undefined);
 
     // Remove it from the map.
-    this.connections.delete(wsControllerURL);
+    this.connections.delete(wsURL);
 
     await connection.onClose?.();
   }
@@ -184,23 +184,21 @@ export class ConnectionManager {
   /**
    * Connect to a controller, and save it.
    */
-  private async connect(
-    wsControllerURL: string,
-  ): Promise<ConnectionWithFacades> {
+  private async connect(wsURL: string): Promise<ConnectionWithFacades> {
     const connectionPromise = Promise.withResolvers<ConnectionWithFacades>();
-    this.connections.set(wsControllerURL, connectionPromise.promise);
+    this.connections.set(wsURL, connectionPromise.promise);
 
-    const credentials = this.hooks.getCredentials(wsControllerURL);
+    const credentials = this.hooks.getCredentials(wsURL);
 
     // Extract the path to determine the connection handler.
     let path = "";
     try {
-      const url = new URL(wsControllerURL);
+      const url = new URL(wsURL);
       path = url.pathname;
     } catch (err) {
       logger.warn(
         `invalid URL for connection, falling back on default connection handler`,
-        wsControllerURL,
+        wsURL,
         err,
       );
     }
@@ -210,16 +208,13 @@ export class ConnectionManager {
       CONNECTION_HANDLERS_BY_PATH[path] ??
       CONNECTION_HANDLERS_BY_PATH[DefaultHandler];
 
-    const connectionResult = await connectionHandler(
-      wsControllerURL,
-      credentials,
-    );
+    const connectionResult = await connectionHandler(wsURL, credentials);
     const { connection } = connectionResult;
 
-    this.connections.set(wsControllerURL, connectionResult);
+    this.connections.set(wsURL, connectionResult);
     connectionPromise.resolve(connection);
 
-    await this.hooks.onConnection?.(wsControllerURL, connection);
+    await this.hooks.onConnection?.(wsURL, connection);
 
     return connection;
   }

--- a/src/store/middleware/connection/connection-manager.ts
+++ b/src/store/middleware/connection/connection-manager.ts
@@ -6,6 +6,8 @@ import {
   generateConnectionOptions,
   LOGIN_TIMEOUT,
   loginWithBakery,
+  startPingerLoop,
+  stopPingerLoop,
 } from "juju/api";
 import { Label, type ConnectionWithFacades } from "juju/types";
 import type { AuthCredential } from "store/general/types";
@@ -66,10 +68,14 @@ export const CONNECTION_HANDLERS_BY_PATH: Record<
     if (!conn) {
       throw new Error(`could not connect to ${wsURL}`);
     }
+
+    const intervalId = startPingerLoop(conn);
+
     return {
       connection: conn,
       onClose: async (): Promise<void> => {
         await new Promise<void>((resolve) => {
+          stopPingerLoop(intervalId);
           logout((code, cb) => {
             resolve();
             cb(code);

--- a/src/store/middleware/model-poller.test.ts
+++ b/src/store/middleware/model-poller.test.ts
@@ -34,14 +34,18 @@ import cloudInfoSource from "./source/cloud-info";
 import modelListSource from "./source/model-list";
 import type { MockMiddlewareResult } from "./types";
 
-vi.mock("juju/api", () => ({
-  disableControllerUUIDMasking: vi.fn(),
-  fetchControllerList: vi.fn(),
-  loginWithBakery: vi.fn(),
-  fetchAndStoreModelStatus: vi.fn(),
-  fetchModelInfo: vi.fn(),
-  setModelSharingPermissions: vi.fn(),
-}));
+vi.mock("juju/api", async (importOriginal) => {
+  const original = (await importOriginal()) as typeof jujuModule;
+  return {
+    ...original,
+    disableControllerUUIDMasking: vi.fn(),
+    fetchControllerList: vi.fn(),
+    loginWithBakery: vi.fn(),
+    fetchAndStoreModelStatus: vi.fn(),
+    fetchModelInfo: vi.fn(),
+    setModelSharingPermissions: vi.fn(),
+  };
+});
 
 vi.mock("juju/jimm/api", () => ({
   checkRelation: vi.fn(),

--- a/src/store/middleware/model-poller.test.ts
+++ b/src/store/middleware/model-poller.test.ts
@@ -53,7 +53,7 @@ vi.mock("juju/jimm/api", () => ({
 describe("model poller", () => {
   let fakeStore: MiddlewareAPI<Dispatch<UnknownAction>, RootState>;
   let next: Mock;
-  const wsControllerURL = "wss://example.com";
+  const wsControllerURL = "wss://example.com/api";
   const controllers: ControllerArgs[] = [
     [wsControllerURL, { user: "eggman@external", password: "test" }],
   ];
@@ -183,7 +183,7 @@ describe("model poller", () => {
     expect(next).not.toHaveBeenCalled();
     expect(fakeStore.dispatch).toHaveBeenCalledWith(
       generalActions.storeLoginError({
-        wsControllerURL: "wss://example.com",
+        wsControllerURL: "wss://example.com/api",
         error: Label.CONTROLLER_LOGIN_ERROR,
       }),
     );
@@ -391,7 +391,7 @@ describe("model poller", () => {
     expect(next).not.toHaveBeenCalled();
     expect(fakeStore.dispatch).toHaveBeenCalledWith(
       generalActions.storeLoginError({
-        wsControllerURL: "wss://example.com",
+        wsControllerURL: "wss://example.com/api",
         error: LoginError.NO_INFO,
       }),
     );
@@ -748,7 +748,7 @@ describe("model poller", () => {
       permissionFrom: "read",
       permissionTo: "write",
       user: "admin",
-      wsControllerURL: "wss://example.com",
+      wsControllerURL: "wss://example.com/api",
     });
     const response = middleware(next)(action);
     await vi.runOnlyPendingTimersAsync();
@@ -770,7 +770,7 @@ describe("model poller", () => {
     const middleware = await runMiddleware();
     const action = jujuActions.fetchAuditEvents({
       "user-tag": "user-eggman@external",
-      wsControllerURL: "wss://example.com",
+      wsControllerURL: "wss://example.com/api",
     });
     await middleware(next)(action);
     expect(jimmModule.findAuditEvents).toHaveBeenCalledWith(
@@ -814,7 +814,7 @@ describe("model poller", () => {
     const middleware = await runMiddleware();
     const action = jujuActions.fetchAuditEvents({
       "user-tag": "user-eggman@external",
-      wsControllerURL: "wss://example.com",
+      wsControllerURL: "wss://example.com/api",
     });
     await middleware(next)(action);
     expect(fakeStore.dispatch).toHaveBeenCalledWith(
@@ -834,7 +834,7 @@ describe("model poller", () => {
     );
     const middleware = await runMiddleware();
     const action = jujuActions.fetchCrossModelQuery({
-      wsControllerURL: "wss://example.com",
+      wsControllerURL: "wss://example.com/api",
       query: ".",
     });
     await middleware(next)(action);
@@ -882,7 +882,7 @@ describe("model poller", () => {
     );
     const middleware = await runMiddleware();
     const action = jujuActions.fetchCrossModelQuery({
-      wsControllerURL: "wss://example.com",
+      wsControllerURL: "wss://example.com/api",
       query: ".",
     });
     await middleware(next)(action);
@@ -902,7 +902,7 @@ describe("model poller", () => {
     );
     const middleware = await runMiddleware();
     const action = jujuActions.fetchCrossModelQuery({
-      wsControllerURL: "wss://example.com",
+      wsControllerURL: "wss://example.com/api",
       query: ".",
     });
     await middleware(next)(action);
@@ -922,7 +922,7 @@ describe("model poller", () => {
     );
     const middleware = await runMiddleware();
     const action = jujuActions.fetchCrossModelQuery({
-      wsControllerURL: "wss://example.com",
+      wsControllerURL: "wss://example.com/api",
       query: ".",
     });
     await middleware(next)(action);
@@ -946,7 +946,7 @@ describe("model poller", () => {
     );
     const middleware = await runMiddleware();
     const action = jujuActions.checkRelation({
-      wsControllerURL: "wss://example.com",
+      wsControllerURL: "wss://example.com/api",
       tuple,
     });
     await middleware(next)(action);
@@ -995,7 +995,7 @@ describe("model poller", () => {
     );
     const middleware = await runMiddleware();
     const action = jujuActions.checkRelation({
-      wsControllerURL: "wss://example.com",
+      wsControllerURL: "wss://example.com/api",
       tuple,
     });
     await middleware(next)(action);
@@ -1019,7 +1019,7 @@ describe("model poller", () => {
     );
     const middleware = await runMiddleware();
     const action = jujuActions.checkRelation({
-      wsControllerURL: "wss://example.com",
+      wsControllerURL: "wss://example.com/api",
       tuple,
     });
     await middleware(next)(action);
@@ -1047,7 +1047,7 @@ describe("model poller", () => {
     );
     const middleware = await runMiddleware();
     const action = jujuActions.checkRelations({
-      wsControllerURL: "wss://example.com",
+      wsControllerURL: "wss://example.com/api",
       tuples,
       requestId,
     });
@@ -1104,7 +1104,7 @@ describe("model poller", () => {
     const middleware = await runMiddleware();
     const action = jujuActions.checkRelations({
       requestId,
-      wsControllerURL: "wss://example.com",
+      wsControllerURL: "wss://example.com/api",
       tuples,
     });
     await middleware(next)(action);
@@ -1133,7 +1133,7 @@ describe("model poller", () => {
     });
     const middleware = await runMiddleware();
     const action = jujuActions.destroyModels({
-      wsControllerURL: "wss://example.com",
+      wsControllerURL: "wss://example.com/api",
       models: [
         {
           "model-tag": "model-123abc",
@@ -1161,7 +1161,7 @@ describe("model poller", () => {
     expect(fakeStore.dispatch).toHaveBeenCalledWith(
       jujuActions.updateModelsDestroyed({
         modelUUIDs: ["123abc"],
-        wsControllerURL: "wss://example.com",
+        wsControllerURL: "wss://example.com/api",
       }),
     );
   });
@@ -1199,7 +1199,7 @@ describe("model poller", () => {
     const fetchModelInfo = vi.spyOn(jujuModule, "fetchModelInfo");
     const middleware = await runMiddleware();
     const action = jujuActions.destroyModels({
-      wsControllerURL: "wss://example.com",
+      wsControllerURL: "wss://example.com/api",
       models: [
         {
           "model-tag": "model-123abc",
@@ -1218,7 +1218,7 @@ describe("model poller", () => {
     expect(fakeStore.dispatch).not.toHaveBeenCalledWith(
       jujuActions.updateModelsDestroyed({
         modelUUIDs: ["123abc"],
-        wsControllerURL: "wss://example.com",
+        wsControllerURL: "wss://example.com/api",
       }),
     );
   });
@@ -1239,7 +1239,7 @@ describe("model poller", () => {
     });
     const middleware = await runMiddleware();
     const action = jujuActions.destroyModels({
-      wsControllerURL: "wss://example.com",
+      wsControllerURL: "wss://example.com/api",
       models: [
         {
           "model-tag": "model-123abc",
@@ -1263,7 +1263,7 @@ describe("model poller", () => {
     expect(fakeStore.dispatch).toHaveBeenCalledWith(
       jujuActions.updateModelsDestroyed({
         modelUUIDs: ["456xyz"],
-        wsControllerURL: "wss://example.com",
+        wsControllerURL: "wss://example.com/api",
       }),
     );
   });
@@ -1296,7 +1296,7 @@ describe("model poller", () => {
 
     const middleware = await runMiddleware();
     const action = jujuActions.destroyModels({
-      wsControllerURL: "wss://example.com",
+      wsControllerURL: "wss://example.com/api",
       models: [
         {
           "model-tag": "model-123abc",
@@ -1329,7 +1329,7 @@ describe("model poller", () => {
       expect(fakeStore.dispatch).toHaveBeenCalledWith(
         jujuActions.updateDestroyModelsLoading({
           modelUUIDs: ["123abc", "456xyz"],
-          wsControllerURL: "wss://example.com",
+          wsControllerURL: "wss://example.com/api",
         }),
       );
     });
@@ -1339,7 +1339,7 @@ describe("model poller", () => {
     expect(fakeStore.dispatch).toHaveBeenCalledWith(
       jujuActions.updateModelsDestroyed({
         modelUUIDs: ["123abc"],
-        wsControllerURL: "wss://example.com",
+        wsControllerURL: "wss://example.com/api",
       }),
     );
 
@@ -1355,7 +1355,7 @@ describe("model poller", () => {
     expect(fakeStore.dispatch).toHaveBeenCalledWith(
       jujuActions.updateModelsDestroyed({
         modelUUIDs: ["456xyz"],
-        wsControllerURL: "wss://example.com",
+        wsControllerURL: "wss://example.com/api",
       }),
     );
   });
@@ -1371,7 +1371,7 @@ describe("model poller", () => {
     );
     const middleware = await runMiddleware();
     const action = jujuActions.destroyModels({
-      wsControllerURL: "wss://example.com",
+      wsControllerURL: "wss://example.com/api",
       models: [
         {
           "model-tag": "model-123abc",
@@ -1401,7 +1401,7 @@ describe("model poller", () => {
     }));
     const middleware = await runMiddleware();
     const action = jujuActions.addModel({
-      wsControllerURL: "wss://example.com",
+      wsControllerURL: "wss://example.com/api",
       modelName: "model123",
       userTag: "user-eggman@external",
       cloudTag: "cloud-aws",
@@ -1419,7 +1419,7 @@ describe("model poller", () => {
     expect(fakeStore.dispatch).toHaveBeenCalledWith(
       jujuActions.setAddModelResult({
         success: true,
-        wsControllerURL: "wss://example.com",
+        wsControllerURL: "wss://example.com/api",
       }),
     );
   });
@@ -1451,7 +1451,7 @@ describe("model poller", () => {
     conn.facades.modelManager = undefined;
     const middleware = await runMiddleware();
     const action = jujuActions.addModel({
-      wsControllerURL: "wss://example.com",
+      wsControllerURL: "wss://example.com/api",
       modelName: "model123",
       userTag: "user-eggman@external",
       cloudTag: "cloud-aws",
@@ -1462,7 +1462,7 @@ describe("model poller", () => {
       jujuActions.setAddModelResult({
         errors: "Unsupported facade: modelManager",
         success: false,
-        wsControllerURL: "wss://example.com",
+        wsControllerURL: "wss://example.com/api",
       }),
     );
   });
@@ -1478,7 +1478,7 @@ describe("model poller", () => {
     });
     const middleware = await runMiddleware();
     const action = jujuActions.addModel({
-      wsControllerURL: "wss://example.com",
+      wsControllerURL: "wss://example.com/api",
       modelName: "model123",
       userTag: "user-eggman@external",
       cloudTag: "cloud-aws",
@@ -1489,7 +1489,7 @@ describe("model poller", () => {
       jujuActions.setAddModelResult({
         errors: "Could not add model.",
         success: false,
-        wsControllerURL: "wss://example.com",
+        wsControllerURL: "wss://example.com/api",
       }),
     );
   });
@@ -1505,7 +1505,7 @@ describe("model poller", () => {
     });
     const middleware = await runMiddleware();
     const action = jujuActions.addModel({
-      wsControllerURL: "wss://example.com",
+      wsControllerURL: "wss://example.com/api",
       modelName: "model123",
       userTag: "user-eggman@external",
       cloudTag: "cloud-aws",
@@ -1516,7 +1516,7 @@ describe("model poller", () => {
       jujuActions.setAddModelResult({
         errors: "Could not add model.",
         success: false,
-        wsControllerURL: "wss://example.com",
+        wsControllerURL: "wss://example.com/api",
       }),
     );
   });


### PR DESCRIPTION
Depending on connection URL path, use different connection logic, allowing for different behaviour for models vs controllers.
