### PR TITLE
feat(connection-manager): add `reconnect` callback to managed connections

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -44,5 +44,5 @@
         "microk8s",
         "rebac",
         "snapstore"
-    ],
+    ]
 }

--- a/src/store/middleware/connection/connection-manager.test.ts
+++ b/src/store/middleware/connection/connection-manager.test.ts
@@ -90,6 +90,71 @@ describe("ConnectionManager", () => {
     expect(connections).toContain("wss://example-4.com/");
   });
 
+  describe("reconnect", () => {
+    beforeEach(() => {
+      connectionHandler.mockImplementation(() => ({
+        connection: {},
+        onClose: connectionOnClose,
+      }));
+    });
+
+    it("produces a new connection", async ({ expect }) => {
+      const manager = new ConnectionManager({ getCredentials: vi.fn() });
+      const connection1 = await manager.get("wss://example.com/");
+      expect(connectionHandler).toHaveBeenCalledTimes(1);
+      const connection2 = await connection1.reconnect();
+      expect(connectionHandler).toHaveBeenCalledTimes(2);
+      expect(connectionOnClose).toHaveBeenCalledTimes(1);
+      expect(connection1).not.toEqual(connection2);
+    });
+
+    it("produces the new connection from `get`", async ({ expect }) => {
+      const manager = new ConnectionManager({ getCredentials: vi.fn() });
+      const connection1 = await manager.get("wss://example.com");
+      const connection2 = await connection1.reconnect();
+      const connection3 = await manager.get("wss://example.com");
+      expect(connectionHandler).toBeCalledTimes(2);
+      expect(connection2).toEqual(connection3);
+    });
+
+    it("re-uses existing pending connection", async ({ expect }) => {
+      vi.useFakeTimers();
+      const connectionPromise = Promise.withResolvers();
+      connectionHandler
+        .mockResolvedValueOnce({
+          connection: {},
+          onClose: connectionOnClose,
+        })
+        .mockReturnValueOnce(connectionPromise.promise);
+      const manager = new ConnectionManager({ getCredentials: vi.fn() });
+      const logoutSpy = vi.spyOn(manager, "logout");
+
+      const connection1 = await manager.get("wss://example.com/");
+      expect(connectionHandler).toHaveBeenCalledTimes(1);
+      expect(connectionOnClose).not.toHaveBeenCalled();
+
+      const pendingConnection2 = connection1.reconnect();
+      await vi.runOnlyPendingTimersAsync();
+      expect(connectionOnClose).toHaveBeenCalledTimes(1);
+      expect(connectionHandler).toBeCalledTimes(2);
+      expect(logoutSpy).toHaveBeenCalledTimes(1);
+
+      const pendingConnection3 = connection1.reconnect();
+      await vi.runOnlyPendingTimersAsync();
+      expect(connectionOnClose).toHaveBeenCalledTimes(1);
+      expect(connectionHandler).toBeCalledTimes(2);
+      expect(logoutSpy).toHaveBeenCalledTimes(1);
+
+      const newConnection = {};
+      connectionPromise.resolve({ connection: newConnection });
+      const connection2 = await pendingConnection2;
+      const connection3 = await pendingConnection3;
+
+      expect(connection2).toEqual(newConnection);
+      expect(connection3).toEqual(newConnection);
+    });
+  });
+
   describe("logout", () => {
     it("correctly cleans up", async ({ expect }) => {
       const manager = new ConnectionManager({ getCredentials: vi.fn() });

--- a/src/store/middleware/connection/connection-manager.ts
+++ b/src/store/middleware/connection/connection-manager.ts
@@ -13,19 +13,23 @@ import { Label, type ConnectionWithFacades } from "juju/types";
 import type { AuthCredential } from "store/general/types";
 import { logger } from "utils/logger";
 
+export type ManagedConnection = {
+  reconnect: () => Promise<ManagedConnection>;
+} & ConnectionWithFacades;
+
 type Hooks = {
   getCredentials: (wsURL: string) => AuthCredential | undefined;
   onConnection?: (
     wsURL: string,
-    connection: ConnectionWithFacades,
+    connection: ManagedConnection,
   ) => Promise<void> | void;
 };
 
 /**
  * The result of a connection handler.
  */
-type ConnectionResult = {
-  connection: ConnectionWithFacades;
+type ConnectionResult<Connection = ManagedConnection> = {
+  connection: Connection;
   onClose?: () => PromiseLike<void>;
 };
 
@@ -35,7 +39,7 @@ type ConnectionResult = {
 type ConnectionHandler = (
   wsURL: string,
   credentials: AuthCredential | undefined,
-) => Promise<ConnectionResult>;
+) => Promise<ConnectionResult<ConnectionWithFacades>>;
 
 /**
  * Symbol representing the default handler.
@@ -136,8 +140,9 @@ export const CONNECTION_HANDLERS_BY_PATH: Record<
 export class ConnectionManager {
   private connections = new Map<
     string,
-    ConnectionResult | Promise<ConnectionWithFacades>
+    ConnectionResult | Promise<ManagedConnection>
   >();
+  private reconnecting = new Set();
   private hooks: Hooks;
 
   constructor(hooks: Hooks) {
@@ -148,16 +153,16 @@ export class ConnectionManager {
    * Fetch the connection for a given URL. If the connection doesn't exist, then create it
    * before returning.
    */
-  async get(wsURL: string): Promise<ConnectionWithFacades> {
+  async get(wsURL: string): Promise<ManagedConnection> {
     const existing = this.connections.get(wsURL);
     if (existing !== undefined) {
       if (existing instanceof Promise) {
-        return await existing;
+        return existing;
       } else {
         return existing.connection;
       }
     }
-    return await this.connect(wsURL);
+    return this.connect(wsURL);
   }
 
   /**
@@ -165,10 +170,8 @@ export class ConnectionManager {
    */
   async logout(wsURL: string): Promise<void> {
     // Wait to get the connection;
-    let connection:
-      | ConnectionResult
-      | Promise<ConnectionWithFacades>
-      | undefined = undefined;
+    let connection: ConnectionResult | Promise<ManagedConnection> | undefined =
+      undefined;
     do {
       connection = this.connections.get(wsURL);
       if (!connection) {
@@ -195,8 +198,8 @@ export class ConnectionManager {
   /**
    * Connect to a controller, and save it.
    */
-  private async connect(wsURL: string): Promise<ConnectionWithFacades> {
-    const connectionPromise = Promise.withResolvers<ConnectionWithFacades>();
+  private async connect(wsURL: string): Promise<ManagedConnection> {
+    const connectionPromise = Promise.withResolvers<ManagedConnection>();
     this.connections.set(wsURL, connectionPromise.promise);
 
     const credentials = this.hooks.getCredentials(wsURL);
@@ -219,14 +222,36 @@ export class ConnectionManager {
       CONNECTION_HANDLERS_BY_PATH[path] ??
       CONNECTION_HANDLERS_BY_PATH[DefaultHandler];
 
-    const connectionResult = await connectionHandler(wsURL, credentials);
-    const { connection } = connectionResult;
+    const { connection, onClose } = await connectionHandler(wsURL, credentials);
 
-    this.connections.set(wsURL, connectionResult);
-    connectionPromise.resolve(connection);
+    // Force cast the connection type, then add the extra fields.
+    const managedConnection = Object.assign(connection, {
+      reconnect: async (): Promise<ManagedConnection> => {
+        // Only call logout if the connection isn't already marked as reconnecting.
+        if (!this.reconnecting.has(wsURL)) {
+          this.reconnecting.add(wsURL);
+          await this.logout(wsURL);
+        }
 
-    await this.hooks.onConnection?.(wsURL, connection);
+        // Trigger re-connecting the connection. If it's already being connected, this will be
+        // handled within.
+        const newConnection = await this.get(wsURL);
 
-    return connection;
+        // Connection is finished reconnecting.
+        this.reconnecting.delete(wsURL);
+
+        return newConnection;
+      },
+    });
+
+    this.connections.set(wsURL, {
+      connection: managedConnection,
+      onClose,
+    });
+    connectionPromise.resolve(managedConnection);
+
+    await this.hooks.onConnection?.(wsURL, managedConnection);
+
+    return managedConnection;
   }
 }

--- a/src/store/middleware/connection/middleware.test.ts
+++ b/src/store/middleware/connection/middleware.test.ts
@@ -1,13 +1,13 @@
 import type { UnknownAction } from "@reduxjs/toolkit";
 import type { MockInstance } from "vitest";
 
-import type { ConnectionWithFacades } from "juju/types";
 import type { Store } from "store/store";
 import { rootStateFactory } from "testing/factories";
 import { createStore } from "testing/utils";
 import { logger } from "utils/logger";
 
 import * as connectionManagerModule from "./connection-manager";
+import type { ManagedConnection } from "./connection-manager";
 import {
   connectionMiddleware,
   MISSING_WS_CONTROLLER_URL_ERROR,
@@ -67,7 +67,7 @@ describe("connectionMiddleware", () => {
   });
 
   describe("with `meta.withConnection`", () => {
-    let getPromise: PromiseWithResolvers<ConnectionWithFacades>;
+    let getPromise: PromiseWithResolvers<ManagedConnection>;
     let action: UnknownAction;
     beforeEach(() => {
       getPromise = Promise.withResolvers();
@@ -93,7 +93,7 @@ describe("connectionMiddleware", () => {
       // Next shouldn't be called, as connection hasn't been resolved.
       expect(next).not.toHaveBeenCalled();
 
-      const connection = {} as ConnectionWithFacades;
+      const connection = {} as ManagedConnection;
       getPromise.resolve(connection);
       await vi.runOnlyPendingTimersAsync();
 
@@ -126,8 +126,8 @@ describe("connectionMiddleware", () => {
   });
 
   it("fetches connections from `connections` key", async ({ expect }) => {
-    const connection1 = {} as ConnectionWithFacades;
-    const connection2 = {} as ConnectionWithFacades;
+    const connection1 = {} as ManagedConnection;
+    const connection2 = {} as ManagedConnection;
     getMock
       .mockResolvedValueOnce(connection1)
       .mockResolvedValueOnce(connection2);

--- a/src/store/middleware/connection/middleware.ts
+++ b/src/store/middleware/connection/middleware.ts
@@ -4,7 +4,6 @@ import { isAction, type Middleware } from "redux";
 
 import { Auth } from "auth";
 import { disableControllerUUIDMasking } from "juju/api";
-import type { ConnectionWithFacades } from "juju/types";
 import { actions as generalActions } from "store/general";
 import {
   getAnalyticsEnabled,
@@ -18,6 +17,7 @@ import { isMetaAction, isPayloadAction } from "types";
 import analytics from "utils/analytics";
 import { logger } from "utils/logger";
 
+import type { ManagedConnection } from "./connection-manager";
 import { ConnectionManager } from "./connection-manager";
 import { hasConnectionURL } from "./util";
 
@@ -145,7 +145,7 @@ export function createConnectionMiddleware(): {
           : ["wsControllerURL"];
         const actionConnections: Record<
           (typeof connectionList)[number],
-          ConnectionWithFacades
+          ManagedConnection
         > = {};
 
         for (const connectionKey of connectionList) {

--- a/src/store/middleware/connection/util.ts
+++ b/src/store/middleware/connection/util.ts
@@ -1,7 +1,7 @@
 import { Connection } from "@canonical/jujulib";
 import type { PayloadAction } from "@reduxjs/toolkit";
 
-import type { ConnectionWithFacades } from "juju/types";
+import type { ManagedConnection } from "./connection-manager";
 
 /**
  * Guard to test of an action has a connection URL in the payload.
@@ -19,7 +19,7 @@ export function hasConnectionURL<P extends Record<string, unknown>>(
 export function hasConnections<K extends string>(
   meta: Record<string, unknown>,
   connectionKeys: K[],
-): meta is { connections: Record<K, ConnectionWithFacades> } & Record<
+): meta is { connections: Record<K, ManagedConnection> } & Record<
   string,
   unknown
 > {


### PR DESCRIPTION
This allows a connection user to request the connection to be reconnected. This does not do anything to assist when a connection is closed elsewhere.