### PR TITLE
feat: disable upgrade menu item if there are no upgrades

### DIFF
--- a/src/components/ModelActions/ModelActions.test.tsx
+++ b/src/components/ModelActions/ModelActions.test.tsx
@@ -10,18 +10,28 @@ import {
   controllerFeaturesFactory,
   controllerFeaturesStateFactory,
 } from "testing/factories/general";
+import { modelStatusInfoFactory } from "testing/factories/juju/ClientV8";
 import {
   modelInfoFactory,
   modelUserInfoFactory,
 } from "testing/factories/juju/ModelManagerV10";
-import { rebacAllowedFactory } from "testing/factories/juju/jimm";
 import {
+  modelMigrationTargetFactory,
+  rebacAllowedFactory,
+  relationshipTupleFactory,
+  versionElemFactory,
+} from "testing/factories/juju/jimm";
+import {
+  controllerFactory,
   jujuStateFactory,
   modelDataFactory,
   modelListInfoFactory,
+  modelMigrationTargetsStateFactory,
   rebacState,
+  supportedJujuVersionsStateFactory,
 } from "testing/factories/juju/juju";
 import { rootStateFactory } from "testing/factories/root";
+import { customWithin } from "testing/queries/within";
 import { renderComponent } from "testing/utils";
 
 import ModelActions from "./ModelActions";
@@ -30,9 +40,11 @@ import { Label } from "./types";
 describe("ModelActions", () => {
   let state: RootState;
   beforeEach(() => {
+    localStorage.setItem("flags", JSON.stringify(["rebac"]));
     state = rootStateFactory.build({
       general: generalStateFactory.withConfig().build({
         config: configFactory.build({
+          controllerAPIEndpoint: "wss://jimm.jujucharms.com/api",
           isJuju: true,
         }),
         controllerConnections: {
@@ -42,6 +54,11 @@ describe("ModelActions", () => {
             }),
           },
         },
+        controllerFeatures: controllerFeaturesStateFactory.build({
+          "wss://jimm.jujucharms.com/api": controllerFeaturesFactory.build({
+            rebac: true,
+          }),
+        }),
       }),
       juju: jujuStateFactory.build({
         models: {
@@ -69,8 +86,24 @@ describe("ModelActions", () => {
             uuid: "abc123",
           }),
         },
+        rebac: {
+          allowed: [
+            rebacAllowedFactory.build({
+              tuple: relationshipTupleFactory.build({
+                object: "user-eggman@external",
+                relation: JIMMRelation.ADMINISTRATOR,
+                target_object: JIMMTarget.JIMM_CONTROLLER,
+              }),
+              allowed: true,
+            }),
+          ],
+        },
       }),
     });
+  });
+
+  afterEach(() => {
+    localStorage.removeItem("flags");
   });
 
   it("displays the actions menu", () => {
@@ -285,6 +318,20 @@ describe("ModelActions", () => {
           }),
         }),
         juju: jujuStateFactory.build({
+          controllers: {
+            "wss://example.com/api": [
+              controllerFactory.build({
+                uuid: "controller123",
+                version: "1.2.3",
+                name: "controller1",
+              }),
+              controllerFactory.build({
+                uuid: "controller456",
+                version: "4.6.14",
+                name: "controller2",
+              }),
+            ],
+          },
           modelData: {
             abc123: modelDataFactory.build({
               info: modelInfoFactory.build({
@@ -297,6 +344,9 @@ describe("ModelActions", () => {
                     access: "admin",
                   }),
                 ],
+              }),
+              model: modelStatusInfoFactory.build({
+                version: "1.2.3",
               }),
             }),
           },
@@ -314,11 +364,74 @@ describe("ModelActions", () => {
               }),
             ],
           }),
+          modelMigrationTargets: modelMigrationTargetsStateFactory.build({
+            abc123: modelMigrationTargetFactory.build({
+              data: ["controller123", "controller456"],
+            }),
+          }),
+          supportedJujuVersions: supportedJujuVersionsStateFactory.build({
+            data: [
+              versionElemFactory.build({ version: "1.2.3" }),
+              versionElemFactory.build({ version: "4.6.14" }),
+            ],
+          }),
         }),
       });
     });
 
-    it("displays the upgrade model option", async () => {
+    it("displays the loading state", async () => {
+      state.juju.modelMigrationTargets = {
+        abc123: modelMigrationTargetFactory.build({
+          data: undefined,
+        }),
+      };
+      state.juju.supportedJujuVersions =
+        supportedJujuVersionsStateFactory.build({
+          data: undefined,
+        });
+      renderComponent(
+        <ModelActions
+          qualifier="eggman@external"
+          modelUUID="abc123"
+          modelName="test1"
+        />,
+        {
+          state,
+        },
+      );
+      await userEvent.click(screen.getByRole("button", { name: Label.TOGGLE }));
+      const upgrade = screen.getByRole("menuitem", {
+        name: new RegExp(Label.UPGRADE),
+      });
+      expect(
+        customWithin(upgrade).getSpinnerByLabel("Loading"),
+      ).toBeInTheDocument();
+      expect(upgrade).toHaveAttribute("aria-disabled", "true");
+    });
+
+    it("disables the upgrade option if there are no upgrades", async () => {
+      state.juju.modelMigrationTargets = {
+        abc123: modelMigrationTargetFactory.build({
+          data: [],
+        }),
+      };
+      renderComponent(
+        <ModelActions
+          qualifier="eggman@external"
+          modelUUID="abc123"
+          modelName="test1"
+        />,
+        {
+          state,
+        },
+      );
+      await userEvent.click(screen.getByRole("button", { name: Label.TOGGLE }));
+      expect(
+        screen.getByRole("menuitem", { name: Label.NO_UPGRADE }),
+      ).toHaveAttribute("aria-disabled", "true");
+    });
+
+    it("enables the upgrade option if there are upgrades", async () => {
       renderComponent(
         <ModelActions
           qualifier="eggman@external"
@@ -332,7 +445,7 @@ describe("ModelActions", () => {
       await userEvent.click(screen.getByRole("button", { name: Label.TOGGLE }));
       expect(
         screen.getByRole("menuitem", { name: Label.UPGRADE }),
-      ).toBeInTheDocument();
+      ).not.toHaveAttribute("aria-disabled");
     });
 
     it("opens the upgrade model panel", async () => {

--- a/src/components/ModelActions/ModelActions.test.tsx
+++ b/src/components/ModelActions/ModelActions.test.tsx
@@ -1,4 +1,5 @@
-import { screen } from "@testing-library/react";
+import { act, screen } from "@testing-library/react";
+import type { UserEvent } from "@testing-library/user-event";
 import userEvent from "@testing-library/user-event";
 
 import { JIMMRelation, JIMMTarget } from "juju/jimm/JIMMV4";
@@ -299,7 +300,12 @@ describe("ModelActions", () => {
   });
 
   describe("upgrade model", () => {
+    let userEventWithTimers: UserEvent;
+
     beforeEach(() => {
+      userEventWithTimers = userEvent.setup({
+        advanceTimers: vi.advanceTimersByTime,
+      });
       state = rootStateFactory.build({
         general: generalStateFactory.build({
           config: configFactory.build({
@@ -379,6 +385,10 @@ describe("ModelActions", () => {
       });
     });
 
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
     it("displays the loading state", async () => {
       state.juju.modelMigrationTargets = {
         abc123: modelMigrationTargetFactory.build({
@@ -409,7 +419,8 @@ describe("ModelActions", () => {
       expect(upgrade).toHaveAttribute("aria-disabled", "true");
     });
 
-    it("disables the upgrade option if there are no upgrades", async () => {
+    it("disables the upgrade option if there are no available controllers", async () => {
+      vi.useFakeTimers();
       state.juju.modelMigrationTargets = {
         abc123: modelMigrationTargetFactory.build({
           data: [],
@@ -425,10 +436,53 @@ describe("ModelActions", () => {
           state,
         },
       );
-      await userEvent.click(screen.getByRole("button", { name: Label.TOGGLE }));
-      expect(
-        screen.getByRole("menuitem", { name: Label.NO_UPGRADE }),
-      ).toHaveAttribute("aria-disabled", "true");
+      await userEventWithTimers.click(
+        screen.getByRole("button", { name: Label.TOGGLE }),
+      );
+      const menuItem = screen.getByRole("menuitem", { name: Label.UPGRADE });
+      expect(menuItem).toHaveAttribute("aria-disabled", "true");
+      await act(async () => {
+        await userEventWithTimers.hover(menuItem);
+        vi.runAllTimers();
+      });
+      expect(menuItem).toHaveAccessibleDescription(
+        "No upgrade available. Bootstrap a controller >=4.6.14 version first, to enable upgrades.",
+      );
+    });
+
+    it("disables the upgrade option if it is on the latest version", async () => {
+      vi.useFakeTimers();
+      state.juju.modelData.abc123.model.version = "4.6.14";
+      if (state.juju.modelData.abc123.info) {
+        state.juju.modelData.abc123.info["controller-uuid"] = "controller456";
+      } else {
+        assert.fail("Model info is undefined");
+      }
+      state.juju.modelMigrationTargets = {
+        abc123: modelMigrationTargetFactory.build({
+          data: [],
+        }),
+      };
+      renderComponent(
+        <ModelActions
+          qualifier="eggman@external"
+          modelUUID="abc123"
+          modelName="test1"
+        />,
+        {
+          state,
+        },
+      );
+      await userEventWithTimers.click(
+        screen.getByRole("button", { name: Label.TOGGLE }),
+      );
+      const menuItem = screen.getByRole("menuitem", { name: Label.UPGRADE });
+      expect(menuItem).toHaveAttribute("aria-disabled", "true");
+      await act(async () => {
+        await userEventWithTimers.hover(menuItem);
+        vi.runAllTimers();
+      });
+      expect(menuItem).toHaveAccessibleDescription(Label.UPGRADE_LATEST);
     });
 
     it("enables the upgrade option if there are upgrades", async () => {

--- a/src/components/ModelActions/ModelActions.tsx
+++ b/src/components/ModelActions/ModelActions.tsx
@@ -1,16 +1,27 @@
 import type { MenuLink } from "@canonical/react-components";
-import { ContextualMenu, Icon, usePortal } from "@canonical/react-components";
-import type { FC } from "react";
+import {
+  ContextualMenu,
+  Icon,
+  Spinner,
+  usePortal,
+} from "@canonical/react-components";
+import { useState, type FC } from "react";
 import type { LinkProps } from "react-router";
 import { Link } from "react-router";
 
 import DestroyModelDialog from "components/DestroyModelDialog";
+import useCanAccessReBACAdmin from "hooks/useCanAccessReBACAdmin";
 import { useCanConfigureModelWithUUID } from "hooks/useCanConfigureModel";
+import useModelMigrationData from "hooks/useModelMigrationData";
 import useModelStatus from "hooks/useModelStatus";
 import type { SetParams } from "hooks/useQueryParams";
 import { useQueryParams } from "hooks/useQueryParams";
 import { useIsJIMMAdmin } from "juju/api-hooks/permissions";
 import { getIsJuju } from "store/general/selectors";
+import {
+  getModelUpgradeDataLoaded,
+  getModelUpgradeVersions,
+} from "store/juju/selectors";
 import { useAppSelector } from "store/store";
 import { testId } from "testing/utils";
 import { rebacURLS } from "urls";
@@ -35,14 +46,26 @@ const generateLinks = (
   ) => void,
   qualifier: null | string,
   setPanelQs: SetParams<QueryParams>,
+  hasUpgrades: boolean,
+  upgradeDataLoaded: boolean,
+  rebacAllowed: boolean,
 ): MenuLink<LinkProps & React.RefAttributes<HTMLAnchorElement>>[] => {
   return [
     ...(isJuju
       ? []
       : [
           {
-            children: Label.UPGRADE,
-            disabled: !isJIMMControllerAdmin,
+            children: (
+              <>
+                {upgradeDataLoaded ? null : (
+                  <Spinner className="u-sh1--right" />
+                )}
+                {upgradeDataLoaded && !hasUpgrades
+                  ? Label.NO_UPGRADE
+                  : Label.UPGRADE}
+              </>
+            ),
+            disabled: !isJIMMControllerAdmin || !hasUpgrades,
             onClick: (
               event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
             ): void => {
@@ -60,7 +83,7 @@ const generateLinks = (
         ]),
     {
       children: Label.ACCESS,
-      disabled: !canConfigureModel,
+      disabled: !canConfigureModel || (!isJuju && !rebacAllowed),
       ...(isJuju
         ? {
             onClick: (
@@ -99,6 +122,7 @@ const ModelActions: FC<Props> = ({
   position,
   qualifier,
 }: Props) => {
+  const [fetchUpgrades, setFetchUpgrades] = useState(false);
   const [_panelQs, setPanelQs] = useQueryParams<QueryParams>({
     model: null,
     modelName: null,
@@ -109,6 +133,14 @@ const ModelActions: FC<Props> = ({
   const modelStatusData = useModelStatus(modelUUID);
   const isController = modelStatusData?.info?.["is-controller"];
   const isJuju = useAppSelector(getIsJuju);
+  const upgrades = useAppSelector((state) =>
+    getModelUpgradeVersions(state, modelUUID),
+  );
+  const upgradeDataLoaded = useAppSelector((state) =>
+    getModelUpgradeDataLoaded(state, modelUUID),
+  );
+  const hasUpgrades = !!upgrades.length;
+  const rebacAllowed = useCanAccessReBACAdmin();
   const { permitted: isJIMMControllerAdmin } = useIsJIMMAdmin();
   const {
     openPortal,
@@ -116,6 +148,7 @@ const ModelActions: FC<Props> = ({
     isOpen: showDestroyModel,
     Portal,
   } = usePortal();
+  useModelMigrationData(modelName, qualifier, fetchUpgrades);
 
   return (
     <>
@@ -143,6 +176,7 @@ const ModelActions: FC<Props> = ({
           hasIcon: true,
           "aria-label": Label.TOGGLE,
         }}
+        onToggleMenu={setFetchUpgrades}
         links={generateLinks(
           canConfigureModel,
           isController,
@@ -152,6 +186,9 @@ const ModelActions: FC<Props> = ({
           openPortal,
           qualifier,
           setPanelQs,
+          hasUpgrades,
+          upgradeDataLoaded,
+          rebacAllowed,
         )}
         position={position}
       />

--- a/src/components/ModelActions/ModelActions.tsx
+++ b/src/components/ModelActions/ModelActions.tsx
@@ -1,12 +1,13 @@
-import type { MenuLink } from "@canonical/react-components";
+import type { ContextualMenuDropdownProps } from "@canonical/react-components";
+import { Button, Tooltip } from "@canonical/react-components";
 import {
   ContextualMenu,
   Icon,
   Spinner,
   usePortal,
 } from "@canonical/react-components";
+import type { ReactNode } from "react";
 import { useState, type FC } from "react";
-import type { LinkProps } from "react-router";
 import { Link } from "react-router";
 
 import DestroyModelDialog from "components/DestroyModelDialog";
@@ -21,6 +22,8 @@ import { getIsJuju } from "store/general/selectors";
 import {
   getModelUpgradeDataLoaded,
   getModelUpgradeVersions,
+  getHighestSupportedVersion,
+  getNextSupportedVersion,
 } from "store/juju/selectors";
 import { useAppSelector } from "store/store";
 import { testId } from "testing/utils";
@@ -49,70 +52,88 @@ const generateLinks = (
   hasUpgrades: boolean,
   upgradeDataLoaded: boolean,
   rebacAllowed: boolean,
-): MenuLink<LinkProps & React.RefAttributes<HTMLAnchorElement>>[] => {
-  return [
-    ...(isJuju
-      ? []
-      : [
-          {
-            children: (
-              <>
-                {upgradeDataLoaded ? null : (
-                  <Spinner className="u-sh1--right" />
-                )}
-                {upgradeDataLoaded && !hasUpgrades
-                  ? Label.NO_UPGRADE
-                  : Label.UPGRADE}
-              </>
-            ),
-            disabled: !isJIMMControllerAdmin || !hasUpgrades,
-            onClick: (
-              event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
-            ): void => {
-              event.stopPropagation();
-              setPanelQs(
-                {
-                  modelName,
-                  panel: "upgrade-model",
-                  qualifier,
-                },
-                { replace: true },
-              );
-            },
-          },
-        ]),
-    {
-      children: Label.ACCESS,
-      disabled: !canConfigureModel || (!isJuju && !rebacAllowed),
-      ...(isJuju
-        ? {
-            onClick: (
-              event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
-            ): void => {
-              event.stopPropagation();
-              setPanelQs(
-                {
-                  model: modelName,
-                  panel: "share-model",
-                },
-                { replace: true },
-              );
-            },
-          }
-        : {
-            element: Link,
-            to: rebacURLS.groups.index,
-          }),
-    },
-    {
-      children: Label.DESTROY,
-      disabled: isController || !canConfigureModel,
-      onClick: (event: React.MouseEvent<HTMLButtonElement>): void => {
+  isLatest: boolean,
+  nextVersion: string | undefined,
+  handleClose: NonNullable<ContextualMenuDropdownProps["handleClose"]>,
+): React.JSX.Element => {
+  const upgradeButton: ReactNode = isJuju ? null : (
+    <Button
+      className="p-contextual-menu__link"
+      disabled={!isJIMMControllerAdmin || !hasUpgrades}
+      role="menuitem"
+      onClick={(event) => {
         event.stopPropagation();
-        openPortal(event);
-      },
-    },
-  ];
+        handleClose(event);
+        setPanelQs(
+          {
+            modelName,
+            panel: "upgrade-model",
+            qualifier,
+          },
+          { replace: true },
+        );
+      }}
+    >
+      {Label.UPGRADE}
+      {upgradeDataLoaded ? null : <Spinner className="u-sh1" />}
+    </Button>
+  );
+  let upgradeTooltip: null | string = null;
+  if (upgradeDataLoaded && !hasUpgrades) {
+    if (isLatest) {
+      upgradeTooltip = Label.UPGRADE_LATEST;
+    } else if (nextVersion) {
+      upgradeTooltip = `No upgrade available. Bootstrap a controller >=${nextVersion} version first, to enable upgrades.`;
+    }
+  }
+  return (
+    <>
+      {upgradeTooltip ? (
+        <Tooltip message={upgradeTooltip}>{upgradeButton}</Tooltip>
+      ) : (
+        upgradeButton
+      )}
+      <Button
+        className="p-contextual-menu__link"
+        disabled={!canConfigureModel || (!isJuju && !rebacAllowed)}
+        role="menuitem"
+        {...(isJuju
+          ? {
+              onClick: (
+                event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+              ): void => {
+                event.stopPropagation();
+                handleClose(event);
+                setPanelQs(
+                  {
+                    model: modelName,
+                    panel: "share-model",
+                  },
+                  { replace: true },
+                );
+              },
+            }
+          : {
+              element: Link,
+              to: rebacURLS.groups.index,
+            })}
+      >
+        {Label.ACCESS}
+      </Button>
+      <Button
+        className="p-contextual-menu__link"
+        disabled={isController || !canConfigureModel}
+        role="menuitem"
+        onClick={(event) => {
+          event.stopPropagation();
+          handleClose(event);
+          openPortal(event);
+        }}
+      >
+        {Label.DESTROY}
+      </Button>
+    </>
+  );
 };
 
 const ModelActions: FC<Props> = ({
@@ -136,6 +157,13 @@ const ModelActions: FC<Props> = ({
   const upgrades = useAppSelector((state) =>
     getModelUpgradeVersions(state, modelUUID),
   );
+  const modelVersion = modelStatusData?.model.version;
+  const nextVersion = useAppSelector((state) =>
+    getNextSupportedVersion(state, modelVersion),
+  );
+  const highestVersion = useAppSelector(getHighestSupportedVersion);
+  const isLatest =
+    !!highestVersion?.version && highestVersion.version === modelVersion;
   const upgradeDataLoaded = useAppSelector((state) =>
     getModelUpgradeDataLoaded(state, modelUUID),
   );
@@ -177,19 +205,24 @@ const ModelActions: FC<Props> = ({
           "aria-label": Label.TOGGLE,
         }}
         onToggleMenu={setFetchUpgrades}
-        links={generateLinks(
-          canConfigureModel,
-          isController,
-          isJIMMControllerAdmin,
-          isJuju,
-          modelName,
-          openPortal,
-          qualifier,
-          setPanelQs,
-          hasUpgrades,
-          upgradeDataLoaded,
-          rebacAllowed,
-        )}
+        children={(handleClose) =>
+          generateLinks(
+            canConfigureModel,
+            isController,
+            isJIMMControllerAdmin,
+            isJuju,
+            modelName,
+            openPortal,
+            qualifier,
+            setPanelQs,
+            hasUpgrades,
+            upgradeDataLoaded,
+            rebacAllowed,
+            isLatest,
+            nextVersion?.version,
+            handleClose,
+          )
+        }
         position={position}
       />
     </>

--- a/src/components/ModelActions/types.ts
+++ b/src/components/ModelActions/types.ts
@@ -18,6 +18,7 @@ export enum Label {
   DESTROY = "Destroy model",
   TOGGLE = "Toggle model actions menu",
   UPGRADE = "Upgrade",
+  NO_UPGRADE = "Upgrade (no upgrade available)",
 }
 
 export enum TestId {

--- a/src/components/ModelActions/types.ts
+++ b/src/components/ModelActions/types.ts
@@ -18,7 +18,7 @@ export enum Label {
   DESTROY = "Destroy model",
   TOGGLE = "Toggle model actions menu",
   UPGRADE = "Upgrade",
-  NO_UPGRADE = "Upgrade (no upgrade available)",
+  UPGRADE_LATEST = "Model is on the latest version",
 }
 
 export enum TestId {

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -14,15 +14,12 @@ import { NavLink } from "react-router";
 
 import UserMenu from "components/UserMenu/UserMenu";
 import { DARK_THEME } from "consts";
-import {
-  useAuditLogsPermitted,
-  useIsJIMMAdmin,
-} from "juju/api-hooks/permissions";
+import useCanAccessReBACAdmin from "hooks/useCanAccessReBACAdmin";
+import { useAuditLogsPermitted } from "juju/api-hooks/permissions";
 import {
   getAppVersion,
   isCrossModelQueriesEnabled,
   getVisitURLs,
-  isReBACEnabled,
 } from "store/general/selectors";
 import {
   getControllerData,
@@ -31,9 +28,7 @@ import {
 import type { Controllers } from "store/juju/types";
 import { useAppSelector } from "store/store";
 import { testId } from "testing/utils";
-import { FeatureFlags } from "types";
 import urls, { externalURLs, rebacURLS } from "urls";
-import isFeatureFlagEnabled from "utils/isFeatureFlagEnabled";
 
 import { Label, TestId } from "./types";
 
@@ -93,16 +88,12 @@ const PrimaryNav: FC = () => {
   const [updateAvailable, setUpdateAvailable] = useState(false);
   const versionRequested = useRef(false);
   const crossModelQueriesEnabled = useAppSelector(isCrossModelQueriesEnabled);
-  const rebacEnabled = useAppSelector(isReBACEnabled);
-  const rebacFlagEnabled = isFeatureFlagEnabled(FeatureFlags.REBAC);
   const { blocked: blockedModels } = useAppSelector(
     getGroupedModelStatusCounts,
   );
-  const { permitted: isJIMMControllerAdmin } = useIsJIMMAdmin();
   const { permitted: auditLogsAllowed } = useAuditLogsPermitted();
   const controllersLink = useControllersLink();
-  const rebacAllowed =
-    rebacEnabled && rebacFlagEnabled && isJIMMControllerAdmin;
+  const rebacAllowed = useCanAccessReBACAdmin();
 
   useEffect(() => {
     if (appVersion && !versionRequested.current) {

--- a/src/hooks/useCanAccessReBACAdmin.test.ts
+++ b/src/hooks/useCanAccessReBACAdmin.test.ts
@@ -1,0 +1,103 @@
+import { JIMMRelation, JIMMTarget } from "juju/jimm/JIMMV4";
+import type { RootState } from "store/store";
+import {
+  generalStateFactory,
+  configFactory,
+  authUserInfoFactory,
+  controllerFeaturesFactory,
+  controllerFeaturesStateFactory,
+} from "testing/factories/general";
+import {
+  rebacAllowedFactory,
+  relationshipTupleFactory,
+} from "testing/factories/juju/jimm";
+import { jujuStateFactory } from "testing/factories/juju/juju";
+import { rootStateFactory } from "testing/factories/root";
+import { renderWrappedHook } from "testing/utils";
+
+import useCanAccessReBACAdmin from "./useCanAccessReBACAdmin";
+
+describe("useCanAccessReBACAdmin", () => {
+  let state: RootState;
+
+  beforeEach(() => {
+    localStorage.setItem("flags", JSON.stringify(["rebac"]));
+    state = rootStateFactory.build({
+      general: generalStateFactory.build({
+        config: configFactory.build({
+          controllerAPIEndpoint: "wss://controller.example.com",
+          isJuju: false,
+        }),
+        controllerConnections: {
+          "wss://controller.example.com": {
+            user: authUserInfoFactory.build(),
+          },
+        },
+        controllerFeatures: controllerFeaturesStateFactory.build({
+          "wss://controller.example.com": controllerFeaturesFactory.build({
+            rebac: true,
+          }),
+        }),
+      }),
+      juju: jujuStateFactory.build({
+        rebac: {
+          allowed: [
+            rebacAllowedFactory.build({
+              tuple: relationshipTupleFactory.build({
+                object: "user-eggman@external",
+                relation: JIMMRelation.ADMINISTRATOR,
+                target_object: JIMMTarget.JIMM_CONTROLLER,
+              }),
+              allowed: true,
+              loaded: true,
+            }),
+          ],
+        },
+      }),
+    });
+  });
+
+  afterEach(() => {
+    localStorage.removeItem("flags");
+  });
+
+  it("allows access", () => {
+    localStorage.setItem("flags", JSON.stringify(["rebac"]));
+    const { result } = renderWrappedHook(() => useCanAccessReBACAdmin(), {
+      state,
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it("does not allow access under Juju", () => {
+    if (state.general.config) {
+      state.general.config.isJuju = true;
+    } else {
+      assert.fail("config not defined");
+    }
+    const { result } = renderWrappedHook(() => useCanAccessReBACAdmin(), {
+      state,
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it("does not allow access if the controller doesn't support rebac", () => {
+    state.general.controllerFeatures = controllerFeaturesStateFactory.build({
+      "wss://controller.example.com": controllerFeaturesFactory.build({
+        rebac: false,
+      }),
+    });
+    const { result } = renderWrappedHook(() => useCanAccessReBACAdmin(), {
+      state,
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it("does not allow access if the feature flag is not enabled", () => {
+    localStorage.removeItem("flags");
+    const { result } = renderWrappedHook(() => useCanAccessReBACAdmin(), {
+      state,
+    });
+    expect(result.current).toBe(false);
+  });
+});

--- a/src/hooks/useCanAccessReBACAdmin.ts
+++ b/src/hooks/useCanAccessReBACAdmin.ts
@@ -1,0 +1,20 @@
+import { useIsJIMMAdmin } from "juju/api-hooks/permissions";
+import { isReBACEnabled } from "store/general/selectors";
+import { useAppSelector } from "store/store";
+import { FeatureFlags } from "types";
+import isFeatureFlagEnabled from "utils/isFeatureFlagEnabled";
+
+/**
+ * Check whether a user can access rebac admin.
+ */
+const useCanAccessReBACAdmin = (): boolean => {
+  const rebacEnabled = useAppSelector(isReBACEnabled);
+  const { permitted: isJIMMControllerAdmin } = useIsJIMMAdmin();
+  return !!(
+    rebacEnabled &&
+    isJIMMControllerAdmin &&
+    isFeatureFlagEnabled(FeatureFlags.REBAC)
+  );
+};
+
+export default useCanAccessReBACAdmin;

--- a/src/hooks/useModelMigrationData.test.ts
+++ b/src/hooks/useModelMigrationData.test.ts
@@ -1,0 +1,101 @@
+import type { RootState } from "store/store";
+import { generalStateFactory, configFactory } from "testing/factories/general";
+import {
+  jujuStateFactory,
+  modelListInfoFactory,
+} from "testing/factories/juju/juju";
+import { rootStateFactory } from "testing/factories/root";
+import { createStore, renderWrappedHook } from "testing/utils";
+
+import useModelMigrationData from "./useModelMigrationData";
+
+describe("useModelMigrationData", () => {
+  let state: RootState;
+
+  beforeEach(() => {
+    state = rootStateFactory.build({
+      general: generalStateFactory.build({
+        config: configFactory.build({
+          controllerAPIEndpoint: "wss://example.com/api",
+        }),
+      }),
+      juju: jujuStateFactory.build({
+        models: {
+          abc123: modelListInfoFactory.build({
+            uuid: "abc123",
+            name: "test1",
+          }),
+        },
+      }),
+    });
+  });
+
+  it("starts polling for data when the hook is mounted", () => {
+    const [store, actions] = createStore(state, {
+      trackActions: true,
+    });
+    renderWrappedHook(
+      () => {
+        useModelMigrationData("test1", "eggman@external");
+      },
+      {
+        store,
+      },
+    );
+    const supportedVersionsStart = {
+      type: "source/jimm-supported-versions/start",
+      payload: { wsControllerURL: "wss://example.com/api" },
+      meta: { withConnection: true },
+    };
+    expect(
+      actions.find((dispatch) => dispatch.type === supportedVersionsStart.type),
+    ).toMatchObject(supportedVersionsStart);
+    const modelMigrationTargetsStart = {
+      type: "source/migration-targets/start",
+      payload: {
+        modelUUID: "abc123",
+        wsControllerURL: "wss://example.com/api",
+      },
+      meta: { withConnection: true },
+    };
+    expect(
+      actions.find(
+        (dispatch) => dispatch.type === modelMigrationTargetsStart.type,
+      ),
+    ).toMatchObject(modelMigrationTargetsStart);
+  });
+
+  it("stops polling for data when the hook is mounted", () => {
+    const [store, actions] = createStore(state, {
+      trackActions: true,
+    });
+    const { unmount } = renderWrappedHook(
+      () => {
+        useModelMigrationData("test1", "eggman@external");
+      },
+      {
+        store,
+      },
+    );
+    unmount();
+    const supportedVersionsStop = {
+      type: "source/jimm-supported-versions/stop",
+      payload: { wsControllerURL: "wss://example.com/api" },
+    };
+    expect(
+      actions.find((dispatch) => dispatch.type === supportedVersionsStop.type),
+    ).toMatchObject(supportedVersionsStop);
+    const modelMigrationTargetsStop = {
+      type: "source/migration-targets/stop",
+      payload: {
+        modelUUID: "abc123",
+        wsControllerURL: "wss://example.com/api",
+      },
+    };
+    expect(
+      actions.find(
+        (dispatch) => dispatch.type === modelMigrationTargetsStop.type,
+      ),
+    ).toMatchObject(modelMigrationTargetsStop);
+  });
+});

--- a/src/hooks/useModelMigrationData.ts
+++ b/src/hooks/useModelMigrationData.ts
@@ -1,0 +1,45 @@
+import { useEffect } from "react";
+
+import { getWSControllerURL } from "store/general/selectors";
+import { getModelUUIDFromList } from "store/juju/selectors";
+import jimmSupportedVersions from "store/middleware/source/jimm-supported-versions";
+import modelMigrationTargets from "store/middleware/source/migration-targets";
+import { useAppDispatch, useAppSelector } from "store/store";
+
+/**
+ * Fetch the data needed for model migrations.
+ */
+const useModelMigrationData = (
+  modelName: null | string,
+  qualifier: null | string,
+  fetchData = true,
+): void => {
+  const dispatch = useAppDispatch();
+  const wsControllerURL = useAppSelector(getWSControllerURL);
+  const modelUUID = useAppSelector((state) =>
+    getModelUUIDFromList(state, modelName, qualifier),
+  );
+
+  useEffect(() => {
+    if (wsControllerURL && fetchData) {
+      dispatch(jimmSupportedVersions.actions.start({ wsControllerURL }));
+      if (modelUUID) {
+        dispatch(
+          modelMigrationTargets.actions.start({ modelUUID, wsControllerURL }),
+        );
+      }
+    }
+    return (): void => {
+      if (wsControllerURL) {
+        dispatch(jimmSupportedVersions.actions.stop({ wsControllerURL }));
+        if (modelUUID) {
+          dispatch(
+            modelMigrationTargets.actions.stop({ modelUUID, wsControllerURL }),
+          );
+        }
+      }
+    };
+  }, [dispatch, fetchData, modelUUID, wsControllerURL]);
+};
+
+export default useModelMigrationData;

--- a/src/pages/Permissions/Permissions.tsx
+++ b/src/pages/Permissions/Permissions.tsx
@@ -6,16 +6,13 @@ import { NavLink } from "react-router";
 
 import { axiosInstance } from "axios-instance";
 import CheckPermissions from "components/CheckPermissions";
+import useCanAccessReBACAdmin from "hooks/useCanAccessReBACAdmin";
 import useLogout from "hooks/useLogout";
 import { useIsJIMMAdmin } from "juju/api-hooks/permissions";
 import { endpoints } from "juju/jimm/api";
 import MainContent from "layout/MainContent";
-import { isReBACEnabled } from "store/general/selectors";
-import { useAppSelector } from "store/store";
 import { testId } from "testing/utils";
-import { FeatureFlags } from "types";
 import { rebacURLS } from "urls";
-import isFeatureFlagEnabled from "utils/isFeatureFlagEnabled";
 
 import { Label, TestId } from "./types";
 
@@ -44,9 +41,8 @@ const navItems = [
 
 const PermissionsPage = (): JSX.Element => {
   const logout = useLogout();
-  const rebacEnabled = useAppSelector(isReBACEnabled);
-  const rebacFlagEnabled = isFeatureFlagEnabled(FeatureFlags.REBAC);
-  const { permitted, loading } = useIsJIMMAdmin();
+  const { loading } = useIsJIMMAdmin();
+  const rebacAllowed = useCanAccessReBACAdmin();
 
   useRef(
     axiosInstance.interceptors.response.use(
@@ -70,7 +66,7 @@ const PermissionsPage = (): JSX.Element => {
 
   return (
     <CheckPermissions
-      allowed={rebacEnabled && rebacFlagEnabled && permitted}
+      allowed={rebacAllowed}
       {...testId(TestId.COMPONENT)}
       loading={loading}
     >

--- a/src/panels/UpgradeModelPanel/UpgradeModelPanel.test.tsx
+++ b/src/panels/UpgradeModelPanel/UpgradeModelPanel.test.tsx
@@ -24,7 +24,7 @@ import {
   modelMigrationTargetsStateFactory,
   supportedJujuVersionsStateFactory,
 } from "testing/factories/juju/juju";
-import { createStore, renderComponent } from "testing/utils";
+import { renderComponent } from "testing/utils";
 import urls from "urls";
 
 import UpgradeModelPanel from "./UpgradeModelPanel";
@@ -109,63 +109,6 @@ describe("UpgradeModelPanel", () => {
     expect(
       screen.getByRole("dialog", { name: UpgradeModelPanelHeaderLabel.TITLE }),
     ).toBeVisible();
-  });
-
-  it("starts the pollers for versions and targets on mount", async () => {
-    const [store, actions] = createStore(state, {
-      trackActions: true,
-    });
-    renderComponent(<UpgradeModelPanel />, { store, url, path });
-    const supportedVersionsStart = {
-      type: "source/jimm-supported-versions/start",
-      payload: { wsControllerURL: "wss://example.com/api" },
-      meta: { withConnection: true },
-    };
-    expect(
-      actions.find((dispatch) => dispatch.type === supportedVersionsStart.type),
-    ).toMatchObject(supportedVersionsStart);
-    const modelMigrationTargetsStart = {
-      type: "source/migration-targets/start",
-      payload: {
-        modelUUID: "abc123",
-        wsControllerURL: "wss://example.com/api",
-      },
-      meta: { withConnection: true },
-    };
-    expect(
-      actions.find(
-        (dispatch) => dispatch.type === modelMigrationTargetsStart.type,
-      ),
-    ).toMatchObject(modelMigrationTargetsStart);
-  });
-
-  it("stops the pollers for versions and targets when unmounted", async () => {
-    const [store, actions] = createStore(state, {
-      trackActions: true,
-    });
-    const {
-      result: { unmount },
-    } = renderComponent(<UpgradeModelPanel />, { store, url, path });
-    unmount();
-    const supportedVersionsStop = {
-      type: "source/jimm-supported-versions/stop",
-      payload: { wsControllerURL: "wss://example.com/api" },
-    };
-    expect(
-      actions.find((dispatch) => dispatch.type === supportedVersionsStop.type),
-    ).toMatchObject(supportedVersionsStop);
-    const modelMigrationTargetsStop = {
-      type: "source/migration-targets/stop",
-      payload: {
-        modelUUID: "abc123",
-        wsControllerURL: "wss://example.com/api",
-      },
-    };
-    expect(
-      actions.find(
-        (dispatch) => dispatch.type === modelMigrationTargetsStop.type,
-      ),
-    ).toMatchObject(modelMigrationTargetsStop);
   });
 
   it("can transition to the confirmation panel", async () => {

--- a/src/panels/UpgradeModelPanel/UpgradeModelPanel.tsx
+++ b/src/panels/UpgradeModelPanel/UpgradeModelPanel.tsx
@@ -1,21 +1,15 @@
 import type { FC } from "react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
+import useModelMigrationData from "hooks/useModelMigrationData";
 import type { VersionElem } from "juju/jimm/JIMMV4";
 import { usePanelQueryParams } from "panels/hooks";
-import { getWSControllerURL } from "store/general/selectors";
-import { getModelUUIDFromList } from "store/juju/selectors";
-import jimmSupportedVersions from "store/middleware/source/jimm-supported-versions";
-import modelMigrationTargets from "store/middleware/source/migration-targets";
-import { useAppDispatch, useAppSelector } from "store/store";
 
 import UpgradeModelController from "./UpgradeModelController";
 import UpgradeModelVersion from "./UpgradeModelVersion";
 import type { QueryParams } from "./types";
 
 const UpgradeModelPanel: FC = () => {
-  const dispatch = useAppDispatch();
-  const wsControllerURL = useAppSelector(getWSControllerURL);
   const [version, setVersion] = useState<null | VersionElem>(null);
   const [restarted, setRestarted] = useState(false);
   const [
@@ -27,30 +21,7 @@ const UpgradeModelPanel: FC = () => {
     qualifier: null,
     modelName: null,
   });
-  const modelUUID = useAppSelector((state) =>
-    getModelUUIDFromList(state, modelName, qualifier),
-  );
-
-  useEffect(() => {
-    if (wsControllerURL) {
-      dispatch(jimmSupportedVersions.actions.start({ wsControllerURL }));
-      if (modelUUID) {
-        dispatch(
-          modelMigrationTargets.actions.start({ modelUUID, wsControllerURL }),
-        );
-      }
-    }
-    return (): void => {
-      if (wsControllerURL) {
-        dispatch(jimmSupportedVersions.actions.stop({ wsControllerURL }));
-        if (modelUUID) {
-          dispatch(
-            modelMigrationTargets.actions.stop({ modelUUID, wsControllerURL }),
-          );
-        }
-      }
-    };
-  }, [dispatch, modelUUID, wsControllerURL]);
+  useModelMigrationData(modelName, qualifier);
 
   return (
     <>

--- a/src/panels/UpgradeModelPanel/UpgradeModelVersion/UpgradeModelVersion.test.tsx
+++ b/src/panels/UpgradeModelPanel/UpgradeModelVersion/UpgradeModelVersion.test.tsx
@@ -230,6 +230,9 @@ describe("UpgradeModelVersion", () => {
   });
 
   it("displays an error if the manual version does not match any controllers", async () => {
+    state.juju.supportedJujuVersions.data?.push(
+      versionElemFactory.build({ version: "1.2.4" }),
+    );
     renderComponent(
       <UpgradeModelVersion
         firstRender
@@ -247,7 +250,30 @@ describe("UpgradeModelVersion", () => {
     await userEvent.type(input, "1.2.4");
     // Vanilla doesn't display validation until the field loses focus.
     await act(() => fireEvent.blur(input));
-    expect(input).toHaveAccessibleErrorMessage(Label.ERROR_NO_CONTROLLERS);
+    expect(input).toHaveAccessibleErrorMessage(
+      "No 1.2.4 controllers exist. Bootstrap a 1.2.4 controller before upgrading to this version.",
+    );
+  });
+
+  it("displays an error if the manual version does not match any Juju versions", async () => {
+    renderComponent(
+      <UpgradeModelVersion
+        firstRender
+        modelName="test1"
+        onRemovePanelQueryParams={vi.fn()}
+        qualifier="eggman@external"
+        setVersion={vi.fn()}
+      />,
+      { state },
+    );
+    await userEvent.click(
+      screen.getByRole("radio", { name: FieldsLabel.MANUAL }),
+    );
+    const input = screen.getByRole("textbox", { name: FieldsLabel.VERSION });
+    await userEvent.type(input, "1.2.4");
+    // Vanilla doesn't display validation until the field loses focus.
+    await act(() => fireEvent.blur(input));
+    expect(input).toHaveAccessibleErrorMessage(Label.ERROR_NO_VERSION);
   });
 
   it("displays an error if the manual version is older than the current version", async () => {

--- a/src/panels/UpgradeModelPanel/UpgradeModelVersion/UpgradeModelVersion.tsx
+++ b/src/panels/UpgradeModelPanel/UpgradeModelVersion/UpgradeModelVersion.tsx
@@ -18,8 +18,8 @@ import {
   getSupportedJujuVersions,
   getRecommendedVersions,
   getModelListLoaded,
-  getModelMigrationTargets,
   getModelDataByUUID,
+  getModelUpgradeDataLoaded,
 } from "store/juju/selectors";
 import { useAppSelector } from "store/store";
 import { testId } from "testing/utils";
@@ -54,9 +54,8 @@ const UpgradeModelVersion: FC<Props> = ({
     getModelUUIDFromList(state, modelName, qualifier),
   );
   const model = useAppSelector((state) => getModelDataByUUID(state, modelUUID));
-  const supportedJujuVersions = useAppSelector(getSupportedJujuVersions);
-  const modelMigrationTargets = useAppSelector((state) =>
-    getModelMigrationTargets(state, modelUUID),
+  const upgradeDataLoaded = useAppSelector((state) =>
+    getModelUpgradeDataLoaded(state, modelUUID),
   );
   const recommendedVersions = useAppSelector((state) =>
     getRecommendedVersions(state, modelUUID),
@@ -64,6 +63,7 @@ const UpgradeModelVersion: FC<Props> = ({
   const availableVersions = useAppSelector((state) =>
     getModelUpgradeVersions(state, modelUUID),
   );
+  const jujuVersions = useAppSelector(getSupportedJujuVersions);
   const modelsLoaded = useAppSelector(getModelListLoaded);
   let content: ReactNode = null;
   if (!model) {
@@ -94,18 +94,26 @@ const UpgradeModelVersion: FC<Props> = ({
               test: (value) => !currentVersion || value !== currentVersion,
             })
             .test({
-              message: Label.ERROR_NO_CONTROLLERS,
-              test: (value) =>
-                !!availableVersions?.find(
-                  (versionData) => !value || versionData.version === value,
-                ),
-            })
-            .test({
               message: Label.ERROR_OLDER,
               test: (value) =>
                 !currentVersion ||
                 !value ||
                 isHigherSemver(value, currentVersion),
+            })
+            .test({
+              message: Label.ERROR_NO_VERSION,
+              test: (value) =>
+                !!jujuVersions.data?.find(
+                  (versionData) => !value || versionData.version === value,
+                ),
+            })
+            .test({
+              message: ({ value }) =>
+                `No ${value} controllers exist. Bootstrap a ${value} controller before upgrading to this version.`,
+              test: (value) =>
+                !!availableVersions?.find(
+                  (versionData) => !value || versionData.version === value,
+                ),
             }),
       }),
     });
@@ -159,13 +167,7 @@ const UpgradeModelVersion: FC<Props> = ({
     <Panel
       animateMount={firstRender}
       contentClassName="no-indent"
-      loading={
-        !modelsLoaded ||
-        // This checks the existence of the data instead of using the loading state otherwise,
-        // each time it fetches data in the background the form would be replaced with the spinner.
-        !supportedJujuVersions.data ||
-        (!!model && !modelMigrationTargets.data)
-      }
+      loading={!modelsLoaded || !upgradeDataLoaded}
       drawer={
         <>
           <Button

--- a/src/panels/UpgradeModelPanel/UpgradeModelVersion/types.ts
+++ b/src/panels/UpgradeModelPanel/UpgradeModelVersion/types.ts
@@ -1,7 +1,7 @@
 export enum Label {
   CANCEL = "Cancel",
   ERROR_FORMAT = "A version is required in the format major.minor.patch",
-  ERROR_NO_CONTROLLERS = "There are no controllers with this version.",
+  ERROR_NO_VERSION = "This version does not exist",
   ERROR_OLDER = "The selected version is older than your current version. Downgrades are not supported.",
   ERROR_SAME = "The selected version is the same as your current version.",
   NOT_FOUND = "Model not found",

--- a/src/store/juju/selectors.test.ts
+++ b/src/store/juju/selectors.test.ts
@@ -154,6 +154,7 @@ import {
   getModelUpgradeVersions,
   getRecommendedVersions,
   getModelUpgrades,
+  getModelUpgradeDataLoaded,
 } from "./selectors";
 
 describe("selectors", () => {
@@ -3532,6 +3533,58 @@ describe("getModelUpgradeVersions", () => {
     ]);
   });
 
+  it("does not include target controllers with the same version as the model", () => {
+    const versions = [
+      versionElemFactory.build({ version: "1.2.3" }),
+      versionElemFactory.build({ version: "4.5.6" }),
+    ];
+    const state = rootStateFactory.build({
+      juju: {
+        controllers: {
+          "wss://example.com/api": [
+            controllerFactory.build({
+              uuid: "controller123",
+              version: "1.2.3",
+              name: "controller1",
+            }),
+            controllerFactory.build({
+              uuid: "controller456",
+              version: "4.5.6",
+              name: "controller1",
+            }),
+            controllerFactory.build({
+              uuid: "controller789",
+              version: "1.2.3",
+              name: "controller1",
+            }),
+          ],
+        },
+        supportedJujuVersions: supportedJujuVersionsStateFactory.build({
+          data: versions,
+        }),
+        modelData: {
+          abc123: modelDataFactory.build({
+            info: modelInfoFactory.build({
+              uuid: "abc123",
+              "controller-uuid": "controller123",
+            }),
+            model: modelStatusInfoFactory.build({
+              version: "1.2.3",
+            }),
+          }),
+        },
+        modelMigrationTargets: modelMigrationTargetsStateFactory.build({
+          abc123: modelMigrationTargetFactory.build({
+            data: ["controller456", "controller789"],
+          }),
+        }),
+      },
+    });
+    expect(getModelUpgradeVersions(state, "abc123")).toStrictEqual([
+      versions[1],
+    ]);
+  });
+
   it("includes the current controller version if it does not require a migration", () => {
     const versions = [
       versionElemFactory.build({ version: "1.2.3" }),
@@ -3627,6 +3680,89 @@ describe("getModelUpgradeVersions", () => {
     expect(getModelUpgradeVersions(state, "abc123")).toStrictEqual([
       versions[0],
     ]);
+  });
+});
+
+describe("getModelUpgradeDataLoaded", () => {
+  it("is loaded when data exists", () => {
+    const state = rootStateFactory.build({
+      juju: {
+        supportedJujuVersions: supportedJujuVersionsStateFactory.build({
+          data: [versionElemFactory.build({ version: "1.2.2" })],
+        }),
+        modelData: {
+          abc123: modelDataFactory.build({
+            info: modelInfoFactory.build({
+              uuid: "abc123",
+            }),
+          }),
+        },
+        modelMigrationTargets: modelMigrationTargetsStateFactory.build({
+          abc123: modelMigrationTargetFactory.build({
+            data: ["controller456"],
+          }),
+        }),
+      },
+    });
+    expect(getModelUpgradeDataLoaded(state, "abc123")).toBe(true);
+  });
+
+  it("is not loaded when there is no version data", () => {
+    const state = rootStateFactory.build({
+      juju: {
+        supportedJujuVersions: supportedJujuVersionsStateFactory.build({
+          data: undefined,
+        }),
+        modelData: {
+          abc123: modelDataFactory.build({
+            info: modelInfoFactory.build({
+              uuid: "abc123",
+            }),
+          }),
+        },
+        modelMigrationTargets: modelMigrationTargetsStateFactory.build({
+          abc123: modelMigrationTargetFactory.build({
+            data: ["controller456"],
+          }),
+        }),
+      },
+    });
+    expect(getModelUpgradeDataLoaded(state, "abc123")).toBe(false);
+  });
+
+  it("is not loaded when there is no target data", () => {
+    const state = rootStateFactory.build({
+      juju: {
+        supportedJujuVersions: supportedJujuVersionsStateFactory.build({
+          data: [versionElemFactory.build({ version: "1.2.2" })],
+        }),
+        modelData: {
+          abc123: modelDataFactory.build({
+            info: modelInfoFactory.build({
+              uuid: "abc123",
+            }),
+          }),
+        },
+        modelMigrationTargets: modelMigrationTargetsStateFactory.build({
+          abc123: modelMigrationTargetFactory.build({
+            data: undefined,
+          }),
+        }),
+      },
+    });
+    expect(getModelUpgradeDataLoaded(state, "abc123")).toBe(false);
+  });
+
+  it("is loaded if there is a model but no target data", () => {
+    const state = rootStateFactory.build({
+      juju: {
+        supportedJujuVersions: supportedJujuVersionsStateFactory.build({
+          data: [versionElemFactory.build({ version: "1.2.2" })],
+        }),
+        modelMigrationTargets: modelMigrationTargetsStateFactory.build({}),
+      },
+    });
+    expect(getModelUpgradeDataLoaded(state, "abc123")).toBe(true);
   });
 });
 

--- a/src/store/juju/selectors.test.ts
+++ b/src/store/juju/selectors.test.ts
@@ -155,6 +155,8 @@ import {
   getRecommendedVersions,
   getModelUpgrades,
   getModelUpgradeDataLoaded,
+  getHighestSupportedVersion,
+  getNextSupportedVersion,
 } from "./selectors";
 
 describe("selectors", () => {
@@ -3354,6 +3356,63 @@ describe("getModelUpgrade", () => {
       }),
     });
     expect(getModelUpgrade(state, "abc123")).toStrictEqual(upgrade);
+  });
+});
+
+describe("getHighestSupportedVersion", () => {
+  it("gets the highest version", () => {
+    const state = rootStateFactory.build({
+      juju: {
+        supportedJujuVersions: supportedJujuVersionsStateFactory.build({
+          data: [
+            versionElemFactory.build({ version: "1.2.2" }),
+            versionElemFactory.build({ version: "1.2.3" }),
+            versionElemFactory.build({ version: "4.5.6" }),
+          ],
+        }),
+      },
+    });
+    expect(getHighestSupportedVersion(state)).toStrictEqual(
+      versionElemFactory.build({ version: "4.5.6" }),
+    );
+  });
+
+  it("handles no versions", () => {
+    const state = rootStateFactory.build();
+    expect(getHighestSupportedVersion(state)).toBeNull();
+  });
+});
+
+describe("getNextSupportedVersion", () => {
+  it("gets the highest version", () => {
+    const state = rootStateFactory.build({
+      juju: {
+        supportedJujuVersions: supportedJujuVersionsStateFactory.build({
+          data: [
+            versionElemFactory.build({ version: "1.2.2" }),
+            versionElemFactory.build({ version: "1.2.3" }),
+            versionElemFactory.build({ version: "4.5.6" }),
+          ],
+        }),
+      },
+    });
+    expect(getNextSupportedVersion(state, "1.2.2")).toStrictEqual(
+      versionElemFactory.build({ version: "1.2.3" }),
+    );
+  });
+
+  it("handles no higher versions", () => {
+    const state = rootStateFactory.build({
+      juju: {
+        supportedJujuVersions: supportedJujuVersionsStateFactory.build({
+          data: [
+            versionElemFactory.build({ version: "1.2.2" }),
+            versionElemFactory.build({ version: "1.2.3" }),
+          ],
+        }),
+      },
+    });
+    expect(getNextSupportedVersion(state, "1.2.3")).toBeNull();
   });
 });
 

--- a/src/store/juju/selectors.test.ts
+++ b/src/store/juju/selectors.test.ts
@@ -3770,7 +3770,7 @@ describe("getModelUpgradeDataLoaded", () => {
     const state = rootStateFactory.build({
       juju: {
         supportedJujuVersions: supportedJujuVersionsStateFactory.build({
-          data: undefined,
+          data: null,
         }),
         modelData: {
           abc123: modelDataFactory.build({

--- a/src/store/juju/selectors.ts
+++ b/src/store/juju/selectors.ts
@@ -1481,13 +1481,14 @@ export const getModelUpgradeVersions = createSelector(
     if (!controllers) {
       return [];
     }
+    const modelVersion = model?.model.version;
     const upgradeVersions = (migrationTargets.data ?? []).reduce<VersionElem[]>(
       (versions, controllerUUID) => {
         const controller = getControllerByUUIDUtil(controllers, controllerUUID);
         const controllerVersion = controller
           ? getControllerVersion(controller)
           : null;
-        if (controllerVersion) {
+        if (controllerVersion && controllerVersion !== modelVersion) {
           const version = supportedVersions.data?.find(
             (supportedVersion) =>
               supportedVersion.version === controllerVersion,
@@ -1509,7 +1510,6 @@ export const getModelUpgradeVersions = createSelector(
     const controllerVersion = modelController
       ? getControllerVersion(modelController)
       : null;
-    const modelVersion = model?.model.version;
     if (
       modelVersion &&
       controllerVersion &&
@@ -1525,6 +1525,20 @@ export const getModelUpgradeVersions = createSelector(
     }
     return upgradeVersions;
   },
+);
+
+/**
+ * Get the version objects filtered by versions that have corresponding
+ * model migration targets.
+ */
+export const getModelUpgradeDataLoaded = createSelector(
+  [getSupportedJujuVersions, getModelMigrationTargets, getModelDataByUUID],
+  (supportedVersions, migrationTargets, model) =>
+    // This checks the existence of the data instead of using the loading state otherwise,
+    // each time it polls data in the background it will be marked as not loaded.
+    !!supportedVersions.data &&
+    // If there is no model (e.g. if it's using an invalid UUID) then the migration targets won't exist.
+    (!model || (!!model && !!migrationTargets.data)),
 );
 
 /**

--- a/src/store/juju/selectors.ts
+++ b/src/store/juju/selectors.ts
@@ -1427,6 +1427,44 @@ export const getModelMigrationTargets = createSelector(
     },
 );
 
+export const getHighestSupportedVersion = createSelector(
+  [getSupportedJujuVersions],
+  (versions) =>
+    versions.data?.reduce<null | VersionElem>((highest, version) => {
+      if (!highest || isHigherSemver(version.version, highest.version)) {
+        highest = version;
+      }
+      return highest;
+    }, null) ?? null,
+);
+
+export const getNextSupportedVersion = createSelector(
+  [
+    getSupportedJujuVersions,
+    (_state, version?: null | string): null | string | undefined => version,
+  ],
+  (versions, version) => {
+    if (!version) {
+      return null;
+    }
+    return (
+      versions.data?.reduce<null | VersionElem>((next, supportedVersion) => {
+        const higherThanCurrent = isHigherSemver(
+          supportedVersion.version,
+          version,
+        );
+        if (
+          higherThanCurrent &&
+          (!next || isHigherSemver(next.version, supportedVersion.version))
+        ) {
+          next = supportedVersion;
+        }
+        return next;
+      }, null) ?? null
+    );
+  },
+);
+
 /**
  * Get the controller objects for model migration targets that have a specific version.
  */


### PR DESCRIPTION
## Done

- Created a hook for fetching upgrades data and a selector for the loading state.
- Disable upgrade menu item if there are no upgrades.

## QA

- Create a model that can be upgraded and a model that has no upgrades.
- In the model list open the action menu next to the model that can't be upgraded and the upgrade menu item should be disabled.
- For the model that can be upgraded the menu item should be enabled.

## Details

https://warthogs.atlassian.net/browse/JUJU-9696

