### PR TITLE
feat: submit changed configs to facade method

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@canonical/jujulib": "8.1.0",
     "@canonical/macaroon-bakery": "1.3.2",
-    "@canonical/react-components": "4.4.0",
+    "@canonical/react-components": "4.4.1",
     "@canonical/rebac-admin": "0.0.1-alpha.12",
     "@curvenote/ansi-to-react": "7.0.0",
     "@reduxjs/toolkit": "2.11.2",

--- a/src/hooks/useDebounce.test.ts
+++ b/src/hooks/useDebounce.test.ts
@@ -1,0 +1,74 @@
+import { act, renderHook } from "@testing-library/react";
+import { vi } from "vitest";
+
+import useDebounce from "./useDebounce";
+
+describe("useDebounce", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns the initial value immediately", () => {
+    const { result } = renderHook(() => useDebounce("hello", 250));
+    expect(result.current).toBe("hello");
+  });
+
+  it("debounces updates", () => {
+    const { result, rerender } = renderHook(
+      ({ value, delay }: { value: string; delay: number }) =>
+        useDebounce(value, delay),
+      { initialProps: { value: "hello", delay: 250 } },
+    );
+
+    expect(result.current).toBe("hello");
+
+    rerender({ value: "world", delay: 250 });
+    expect(result.current).toBe("hello");
+
+    act(() => {
+      vi.advanceTimersByTime(250);
+    });
+    expect(result.current).toBe("world");
+  });
+
+  it("cancels pending updates on unmount", () => {
+    const { result, rerender, unmount } = renderHook(
+      ({ value, delay }: { value: string; delay: number }) =>
+        useDebounce(value, delay),
+      { initialProps: { value: "hello", delay: 250 } },
+    );
+
+    rerender({ value: "world", delay: 250 });
+    unmount();
+
+    act(() => {
+      vi.advanceTimersByTime(250);
+    });
+    expect(result.current).toBe("hello");
+  });
+
+  it("respects custom delay", () => {
+    const { result, rerender } = renderHook(
+      ({ value, delay }: { value: string; delay: number }) =>
+        useDebounce(value, delay),
+      { initialProps: { value: "hello", delay: 100 } },
+    );
+
+    rerender({ value: "world", delay: 100 });
+    expect(result.current).toBe("hello");
+
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+    expect(result.current).toBe("hello");
+
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+    expect(result.current).toBe("world");
+  });
+});

--- a/src/hooks/useDebounce.test.ts
+++ b/src/hooks/useDebounce.test.ts
@@ -14,61 +14,119 @@ describe("useDebounce", () => {
 
   it("returns the initial value immediately", () => {
     const { result } = renderHook(() => useDebounce("hello", 250));
-    expect(result.current).toBe("hello");
+    expect(result.current[0]).toBe("hello");
   });
 
   it("debounces updates", () => {
-    const { result, rerender } = renderHook(
-      ({ value, delay }: { value: string; delay: number }) =>
-        useDebounce(value, delay),
-      { initialProps: { value: "hello", delay: 250 } },
-    );
+    const { result } = renderHook(() => useDebounce("hello", 250));
 
-    expect(result.current).toBe("hello");
+    expect(result.current[0]).toBe("hello");
 
-    rerender({ value: "world", delay: 250 });
-    expect(result.current).toBe("hello");
+    act(() => {
+      result.current[1]("world");
+    });
+    expect(result.current[0]).toBe("hello");
 
     act(() => {
       vi.advanceTimersByTime(250);
     });
-    expect(result.current).toBe("world");
+    expect(result.current[0]).toBe("world");
+  });
+
+  it("only applies the last value when updates happen during the delay", () => {
+    const { result } = renderHook(() => useDebounce("hello", 250));
+
+    act(() => {
+      result.current[1]("first");
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    act(() => {
+      result.current[1]("second");
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(249);
+    });
+    expect(result.current[0]).toBe("hello");
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(result.current[0]).toBe("second");
   });
 
   it("cancels pending updates on unmount", () => {
-    const { result, rerender, unmount } = renderHook(
-      ({ value, delay }: { value: string; delay: number }) =>
-        useDebounce(value, delay),
-      { initialProps: { value: "hello", delay: 250 } },
-    );
+    const { result, unmount } = renderHook(() => useDebounce("hello", 250));
 
-    rerender({ value: "world", delay: 250 });
+    act(() => {
+      result.current[1]("world");
+    });
     unmount();
 
     act(() => {
       vi.advanceTimersByTime(250);
     });
-    expect(result.current).toBe("hello");
+    expect(result.current[0]).toBe("hello");
   });
 
   it("respects custom delay", () => {
-    const { result, rerender } = renderHook(
-      ({ value, delay }: { value: string; delay: number }) =>
-        useDebounce(value, delay),
-      { initialProps: { value: "hello", delay: 100 } },
-    );
+    const { result } = renderHook(() => useDebounce("hello", 100));
 
-    rerender({ value: "world", delay: 100 });
-    expect(result.current).toBe("hello");
+    act(() => {
+      result.current[1]("world");
+    });
+    expect(result.current[0]).toBe("hello");
 
     act(() => {
       vi.advanceTimersByTime(50);
     });
-    expect(result.current).toBe("hello");
+    expect(result.current[0]).toBe("hello");
 
     act(() => {
       vi.advanceTimersByTime(50);
     });
-    expect(result.current).toBe("world");
+    expect(result.current[0]).toBe("world");
+  });
+
+  it("updates immediately and clears pending debounced updates", () => {
+    const { result } = renderHook(() => useDebounce("hello", 250));
+
+    act(() => {
+      result.current[1]("delayed");
+    });
+
+    act(() => {
+      result.current[1]("", { immediate: true });
+    });
+    expect(result.current[0]).toBe("");
+
+    act(() => {
+      vi.advanceTimersByTime(250);
+    });
+    expect(result.current[0]).toBe("");
+  });
+
+  it("supports function values without invoking them", () => {
+    const initialFn = vi.fn(() => "initial");
+    const nextFn = vi.fn(() => "next");
+    const { result } = renderHook(() => useDebounce(initialFn, 250));
+
+    expect(result.current[0]).toBe(initialFn);
+
+    act(() => {
+      result.current[1](nextFn);
+    });
+    expect(result.current[0]).toBe(initialFn);
+
+    act(() => {
+      vi.advanceTimersByTime(250);
+    });
+    expect(result.current[0]).toBe(nextFn);
+    expect(initialFn).not.toHaveBeenCalled();
+    expect(nextFn).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,22 +1,50 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 /**
- * Hook that debounces a value.
- * @param value - The value to debounce
+ * Hook that debounces state updates.
+ * @param initialValue - The initial value
  * @param delay - The debounce delay in milliseconds
- * @returns The debounced value
+ * @returns Tuple of debounced value and setter
  */
-export default function useDebounce<T>(value: T, delay: number): T {
-  const [debouncedValue, setDebouncedValue] = useState(value);
+export default function useDebounce<T>(
+  initialValue: T,
+  delay: number,
+): [T, (value: T, options?: { immediate?: boolean }) => void] {
+  const [debouncedValue, setDebouncedValue] = useState(() => initialValue);
+  const pendingValueRef = useRef(initialValue);
+  const timeoutRef = useRef<null | ReturnType<typeof setTimeout>>(null);
+
+  const clearPendingTimeout = useCallback((): void => {
+    if (timeoutRef.current !== null && timeoutRef.current !== undefined) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  }, []);
+
+  const setValue = useCallback(
+    (value: T, options?: { immediate?: boolean }): void => {
+      pendingValueRef.current = value;
+
+      clearPendingTimeout();
+
+      if (options?.immediate) {
+        setDebouncedValue(() => value);
+        return;
+      }
+
+      timeoutRef.current = setTimeout(() => {
+        setDebouncedValue(() => pendingValueRef.current);
+        timeoutRef.current = null;
+      }, delay);
+    },
+    [clearPendingTimeout, delay],
+  );
 
   useEffect(() => {
-    const id = setTimeout(() => {
-      setDebouncedValue(value);
-    }, delay);
     return (): void => {
-      clearTimeout(id);
+      clearPendingTimeout();
     };
-  }, [value, delay]);
+  }, [clearPendingTimeout]);
 
-  return debouncedValue;
+  return [debouncedValue, setValue];
 }

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Hook that debounces a value.
+ * @param value - The value to debounce
+ * @param delay - The debounce delay in milliseconds
+ * @returns The debounced value
+ */
+export default function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const id = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+    return (): void => {
+      clearTimeout(id);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/src/pages/AddModel/AddModel.test.tsx
+++ b/src/pages/AddModel/AddModel.test.tsx
@@ -302,6 +302,41 @@ describe("AddModel page", () => {
     });
   });
 
+  it("sends changed configs when model is submitted", async () => {
+    const [store, actions] = createStore(state, { trackActions: true });
+    renderComponent(<AddModel />, { store });
+
+    const addModelAction = jujuActions.addModel({
+      cloudTag: "cloud-aws",
+      credential: "",
+      config: {
+        "default-space": "my-space",
+      },
+      modelName: "my-model",
+      userTag: "user-eggman@external",
+      disabledCommands: DisableType.NONE,
+      wsControllerURL: "wss://controller.example.com",
+    });
+
+    await userEvent.type(
+      screen.getByLabelText(new RegExp(MandatoryDetailsLabel.MODEL_NAME)),
+      "my-model",
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: Label.NEXT_BUTTON }),
+    );
+    await userEvent.type(screen.getByLabelText("default-space"), "my-space");
+    await waitFor(() =>
+      fireEvent.submit(screen.getByTestId(TestId.ADD_MODEL_FORM)),
+    );
+
+    await waitFor(() => {
+      expect(
+        actions.find((dispatch) => dispatch.type === addModelAction.type),
+      ).toMatchObject(addModelAction);
+    });
+  });
+
   it("shows success toast when model creation succeeds", async () => {
     state.juju.addModelState = {
       loading: false,

--- a/src/pages/AddModel/AddModel.tsx
+++ b/src/pages/AddModel/AddModel.tsx
@@ -29,7 +29,10 @@ import { InputMode } from "./ConfigsConstraints/ContentSwitcher/types";
 import { CONFIG_CATEGORIES } from "./ConfigsConstraints/configCatalog";
 import { FieldName as ConfigFieldName } from "./ConfigsConstraints/types";
 import { DisableType } from "./ConfigsConstraints/types";
-import { getConfigInitialValues } from "./ConfigsConstraints/utils";
+import {
+  buildChangedConfigPayload,
+  getConfigInitialValues,
+} from "./ConfigsConstraints/utils";
 import MandatoryDetails from "./MandatoryDetails";
 import { TestId, StepType, Label, type AddModelFormState } from "./types";
 
@@ -89,6 +92,8 @@ const AddModel: FC = () => {
       return;
     }
 
+    const config = buildChangedConfigPayload(CONFIG_CATEGORIES, values);
+
     dispatch(
       jujuActions.addModel({
         wsControllerURL,
@@ -98,6 +103,7 @@ const AddModel: FC = () => {
         userTag,
         disabledCommands: values.disabledCommands,
         region: values.region || undefined,
+        ...(Object.keys(config).length > 0 ? { config } : {}),
       }),
     );
     setModelName(values.modelName);

--- a/src/pages/AddModel/ConfigsConstraints/ConfigsConstraints.test.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/ConfigsConstraints.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from "@testing-library/react";
+import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 import { vi } from "vitest";
@@ -9,6 +9,8 @@ import { externalURLs } from "urls";
 import ConfigsConstraints from "./ConfigsConstraints";
 import { InputMode } from "./ContentSwitcher/types";
 import { DisableType, Label } from "./types";
+
+import { ConfigsConstraintsTestId } from ".";
 
 describe("ConfigsConstraints", () => {
   it("renders properly", () => {
@@ -95,7 +97,7 @@ describe("ConfigsConstraints", () => {
     expect(textarea.value).toContain("apt-http-proxy: http://proxy.example");
   });
 
-  it("hides unchanged rows when changed-configs-only is toggled on", async () => {
+  it("does not toggle and shows a tooltip when there are no changed configs", async () => {
     renderComponent(
       <Formik initialValues={{}} onSubmit={vi.fn()}>
         <ConfigsConstraints />
@@ -107,8 +109,10 @@ describe("ConfigsConstraints", () => {
     ).toBeInTheDocument();
     await userEvent.click(screen.getByLabelText(Label.CHANGED_CONFIGS_ONLY));
     expect(
-      screen.queryByLabelText("container-networking-method"),
-    ).not.toBeInTheDocument();
+      within(
+        screen.getByTestId(ConfigsConstraintsTestId.CONFIGS_CONSTRAINTS_FORM),
+      ).getByText(Label.CHANGED_CONFIGS_ONLY),
+    ).toBeInTheDocument();
   });
 
   it("shows a changed row when toggled on", async () => {
@@ -133,6 +137,74 @@ describe("ConfigsConstraints", () => {
       screen.queryByLabelText("container-networking-method"),
     ).not.toBeInTheDocument();
     expect(screen.queryByLabelText("default-space")).toBeInTheDocument();
+  });
+
+  it("filters configs by field name", async () => {
+    renderComponent(
+      <Formik initialValues={{}} onSubmit={vi.fn()}>
+        <ConfigsConstraints />
+      </Formik>,
+    );
+
+    await userEvent.type(
+      screen.getByRole("searchbox", { name: "Search configurations" }),
+      "default-space",
+    );
+
+    expect(screen.getByLabelText("default-space")).toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("container-networking-method"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("filters configs by description", async () => {
+    renderComponent(
+      <Formik initialValues={{}} onSubmit={vi.fn()}>
+        <ConfigsConstraints />
+      </Formik>,
+    );
+
+    const searchInput = screen.getByRole("searchbox", {
+      name: "Search configurations",
+    });
+
+    await userEvent.type(searchInput, "network firewalling");
+
+    expect(screen.getByLabelText("firewall-mode")).toBeInTheDocument();
+    expect(screen.queryByLabelText("default-space")).not.toBeInTheDocument();
+
+    await userEvent.clear(searchInput);
+    await userEvent.type(searchInput, "Proxy & Mirror");
+
+    expect(
+      screen.getByText('No results found for "Proxy & Mirror"'),
+    ).toBeInTheDocument();
+  });
+
+  it("clears the search and restores the full list", async () => {
+    renderComponent(
+      <Formik initialValues={{}} onSubmit={vi.fn()}>
+        <ConfigsConstraints />
+      </Formik>,
+    );
+
+    const searchInput = screen.getByRole("searchbox", {
+      name: "Search configurations",
+    });
+
+    await userEvent.type(searchInput, "default-space");
+    expect(
+      screen.queryByLabelText("container-networking-method"),
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /clear search field/i }),
+    );
+
+    expect(screen.getByLabelText("default-space")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("container-networking-method"),
+    ).toBeInTheDocument();
   });
 
   it("initialises in YAML mode when configInputMode is yaml", () => {

--- a/src/pages/AddModel/ConfigsConstraints/ConfigsConstraints.test.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/ConfigsConstraints.test.tsx
@@ -1,4 +1,4 @@
-import { screen, within } from "@testing-library/react";
+import { act, fireEvent, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 import { vi } from "vitest";
@@ -140,24 +140,31 @@ describe("ConfigsConstraints", () => {
   });
 
   it("filters configs by field name", async () => {
+    vi.useFakeTimers();
     renderComponent(
       <Formik initialValues={{}} onSubmit={vi.fn()}>
         <ConfigsConstraints />
       </Formik>,
     );
 
-    await userEvent.type(
-      screen.getByRole("searchbox", { name: "Search configurations" }),
-      "default-space",
-    );
+    const searchInput = screen.getByRole("searchbox", {
+      name: "Search configurations",
+    });
+    fireEvent.change(searchInput, { target: { value: "default-space" } });
+
+    act(() => {
+      vi.advanceTimersByTime(250);
+    });
 
     expect(screen.getByLabelText("default-space")).toBeInTheDocument();
     expect(
       screen.queryByLabelText("container-networking-method"),
     ).not.toBeInTheDocument();
+    vi.useRealTimers();
   });
 
   it("filters configs by description", async () => {
+    vi.useFakeTimers();
     renderComponent(
       <Formik initialValues={{}} onSubmit={vi.fn()}>
         <ConfigsConstraints />
@@ -168,20 +175,36 @@ describe("ConfigsConstraints", () => {
       name: "Search configurations",
     });
 
-    await userEvent.type(searchInput, "network firewalling");
+    fireEvent.change(searchInput, {
+      target: { value: "network firewalling" },
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(250);
+    });
 
     expect(screen.getByLabelText("firewall-mode")).toBeInTheDocument();
     expect(screen.queryByLabelText("default-space")).not.toBeInTheDocument();
 
-    await userEvent.clear(searchInput);
-    await userEvent.type(searchInput, "Proxy & Mirror");
+    fireEvent.change(searchInput, { target: { value: "" } });
+    act(() => {
+      vi.advanceTimersByTime(250);
+    });
+
+    fireEvent.change(searchInput, { target: { value: "Proxy & Mirror" } });
+
+    act(() => {
+      vi.advanceTimersByTime(250);
+    });
 
     expect(
       screen.getByText('No results found for "Proxy & Mirror"'),
     ).toBeInTheDocument();
+    vi.useRealTimers();
   });
 
   it("clears the search and restores the full list", async () => {
+    vi.useFakeTimers();
     renderComponent(
       <Formik initialValues={{}} onSubmit={vi.fn()}>
         <ConfigsConstraints />
@@ -192,19 +215,29 @@ describe("ConfigsConstraints", () => {
       name: "Search configurations",
     });
 
-    await userEvent.type(searchInput, "default-space");
+    fireEvent.change(searchInput, { target: { value: "default-space" } });
+
+    act(() => {
+      vi.advanceTimersByTime(250);
+    });
+
     expect(
       screen.queryByLabelText("container-networking-method"),
     ).not.toBeInTheDocument();
 
-    await userEvent.click(
+    fireEvent.click(
       screen.getByRole("button", { name: /clear search field/i }),
     );
+
+    act(() => {
+      vi.advanceTimersByTime(250);
+    });
 
     expect(screen.getByLabelText("default-space")).toBeInTheDocument();
     expect(
       screen.getByLabelText("container-networking-method"),
     ).toBeInTheDocument();
+    vi.useRealTimers();
   });
 
   it("initialises in YAML mode when configInputMode is yaml", () => {

--- a/src/pages/AddModel/ConfigsConstraints/ConfigsConstraints.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/ConfigsConstraints.tsx
@@ -63,24 +63,22 @@ const ConfigsConstraints = (): JSX.Element => {
     ? categoriesWithChangedConfigs
     : filteredCategories;
 
-  const ChangedOnlySwitchWrapper = ({
-    children,
-  }: {
-    children: JSX.Element;
-  }): JSX.Element =>
-    hasChangedConfigs ? (
-      <>{children}</>
-    ) : (
-      <Tooltip message={Label.NO_CHANGED_CONFIGS} position="btm-left">
-        {children}
-      </Tooltip>
-    );
+  const changedOnlySwitch = (
+    <Switch
+      label={Label.CHANGED_CONFIGS_ONLY}
+      checked={changedOnly}
+      onChange={(event: ChangeEvent<HTMLInputElement>): void => {
+        if (!hasChangedConfigs && event.target.checked) {
+          return;
+        }
+
+        setChangedOnly(event.target.checked);
+      }}
+    />
+  );
 
   return (
-    <div
-      {...testId(TestId.CONFIGS_CONSTRAINTS_FORM)}
-      className="configs-constraints"
-    >
+    <div {...testId(TestId.CONFIGS_CONSTRAINTS_FORM)}>
       <ContentSwitcher
         showPrimary={isConfigListMode}
         docsLabel={Label.MODEL_CONFIG_DOCS}
@@ -97,25 +95,19 @@ const ConfigsConstraints = (): JSX.Element => {
                   onClear={() => {
                     setRawSearchQuery("");
                   }}
-                  className="configs__search-input"
+                  className="u-no-margin--bottom"
                   aria-label="Search configurations"
                 />
               </div>
             </div>
-            <ChangedOnlySwitchWrapper>
-              <Switch
-                label={Label.CHANGED_CONFIGS_ONLY}
-                checked={changedOnly}
-                onChange={(event: ChangeEvent<HTMLInputElement>): void => {
-                  if (!hasChangedConfigs && event.target.checked) {
-                    return;
-                  }
-
-                  setChangedOnly(event.target.checked);
-                }}
-              />
-            </ChangedOnlySwitchWrapper>
-            <div className="configs__form-scroll">
+            {hasChangedConfigs ? (
+              changedOnlySwitch
+            ) : (
+              <Tooltip message={Label.NO_CHANGED_CONFIGS} position="btm-left">
+                {changedOnlySwitch}
+              </Tooltip>
+            )}
+            <div className="configs__form-scroll u-sv-1--top">
               {visibleCategories.length > 0 ? (
                 visibleCategories.map(({ category, fields }, index) => (
                   <Row

--- a/src/pages/AddModel/ConfigsConstraints/ConfigsConstraints.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/ConfigsConstraints.tsx
@@ -2,10 +2,13 @@ import {
   Col,
   FormikField,
   Row,
+  SearchBox,
   Switch,
   Textarea,
   List,
+  Tooltip,
 } from "@canonical/react-components";
+import classNames from "classnames";
 import { useFormikContext } from "formik";
 import { useState, type ChangeEvent, type JSX } from "react";
 
@@ -18,7 +21,11 @@ import StackList from "./StackList";
 import { CONFIG_CATEGORIES } from "./configCatalog";
 import { DISABLED_COMMAND_OPTIONS } from "./disabledCommandOptions";
 import { type FormFields, FieldName, Label, TestId } from "./types";
-import { buildConfigYAML, getCategoriesWithVisibleConfigs } from "./utils";
+import {
+  buildConfigYAML,
+  filterConfigsBySearch,
+  getCategoriesWithVisibleConfigs,
+} from "./utils";
 
 const ConfigsConstraints = (): JSX.Element => {
   const { values, setFieldValue } = useFormikContext<
@@ -26,6 +33,7 @@ const ConfigsConstraints = (): JSX.Element => {
   >();
 
   const [changedOnly, setChangedOnly] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
   const isConfigListMode =
     values[FieldName.CONFIG_INPUT_MODE] !== InputMode.YAML;
 
@@ -43,41 +51,93 @@ const ConfigsConstraints = (): JSX.Element => {
     );
   };
 
-  const categoriesWithConfigs = getCategoriesWithVisibleConfigs(
-    CONFIG_CATEGORIES,
-    changedOnly,
+  const filteredCategories = filterConfigsBySearch(searchQuery);
+  const categoriesWithChangedConfigs = getCategoriesWithVisibleConfigs(
+    filteredCategories,
     values,
   );
+  const hasChangedConfigs = categoriesWithChangedConfigs.length > 0;
+  const visibleCategories = changedOnly
+    ? categoriesWithChangedConfigs
+    : filteredCategories;
+
+  const ChangedOnlySwitchWrapper = ({
+    children,
+  }: {
+    children: JSX.Element;
+  }): JSX.Element =>
+    hasChangedConfigs ? (
+      <>{children}</>
+    ) : (
+      <Tooltip message={Label.NO_CHANGED_CONFIGS} position="btm-left">
+        {children}
+      </Tooltip>
+    );
 
   return (
-    <div {...testId(TestId.CONFIGS_CONSTRAINTS_FORM)}>
+    <div
+      {...testId(TestId.CONFIGS_CONSTRAINTS_FORM)}
+      className="configs-constraints"
+    >
       <ContentSwitcher
         showPrimary={isConfigListMode}
         docsLabel={Label.MODEL_CONFIG_DOCS}
         docsLink={externalURLs.configureModel}
         primaryContent={
           <>
-            <Switch
-              label={Label.CHANGED_CONFIGS_ONLY}
-              checked={changedOnly}
-              onChange={(event: ChangeEvent<HTMLInputElement>) => {
-                setChangedOnly(event.target.checked);
-              }}
-            />
+            <div className="row u-no-padding">
+              <div className="col-4">
+                <SearchBox
+                  externallyControlled
+                  name="configSearch"
+                  id="configSearch"
+                  placeholder="Search configurations"
+                  value={searchQuery}
+                  onChange={setSearchQuery}
+                  onClear={() => {
+                    setSearchQuery("");
+                  }}
+                  className="configs__search-input"
+                  aria-label="Search configurations"
+                />
+              </div>
+            </div>
+            <ChangedOnlySwitchWrapper>
+              <Switch
+                label={Label.CHANGED_CONFIGS_ONLY}
+                checked={changedOnly}
+                onChange={(event: ChangeEvent<HTMLInputElement>): void => {
+                  if (!hasChangedConfigs && event.target.checked) {
+                    return;
+                  }
+
+                  setChangedOnly(event.target.checked);
+                }}
+              />
+            </ChangedOnlySwitchWrapper>
             <div className="configs__form-scroll">
-              {categoriesWithConfigs.map(({ category, fields }, index) => (
-                <Row key={category} className="u-no-padding u-sv1--top">
-                  <Col size={3}>
-                    <h5>{category}</h5>
-                  </Col>
-                  <Col size={9}>
-                    <StackList visibleConfigs={fields} />
-                  </Col>
-                  {index < categoriesWithConfigs.length - 1 ? (
-                    <hr className="p-rule--muted" />
-                  ) : null}
-                </Row>
-              ))}
+              {visibleCategories.length > 0 ? (
+                visibleCategories.map(({ category, fields }, index) => (
+                  <Row
+                    key={category}
+                    className={classNames("u-no-padding", {
+                      "u-sv1--top": index !== 0,
+                    })}
+                  >
+                    <Col size={3}>
+                      <h5>{category}</h5>
+                    </Col>
+                    <Col size={9}>
+                      <StackList visibleConfigs={fields} />
+                    </Col>
+                    {index < visibleCategories.length - 1 ? (
+                      <hr className="p-rule--muted" />
+                    ) : null}
+                  </Row>
+                ))
+              ) : (
+                <h5>No results found for {`"${searchQuery}"`}</h5>
+              )}
             </div>
           </>
         }

--- a/src/pages/AddModel/ConfigsConstraints/ConfigsConstraints.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/ConfigsConstraints.tsx
@@ -12,6 +12,7 @@ import classNames from "classnames";
 import { useFormikContext } from "formik";
 import { useState, type ChangeEvent, type JSX } from "react";
 
+import useDebounce from "hooks/useDebounce";
 import { testId } from "testing/utils";
 import { externalURLs } from "urls";
 
@@ -33,7 +34,8 @@ const ConfigsConstraints = (): JSX.Element => {
   >();
 
   const [changedOnly, setChangedOnly] = useState(false);
-  const [searchQuery, setSearchQuery] = useState("");
+  const [rawSearchQuery, setRawSearchQuery] = useState("");
+  const searchQuery = useDebounce(rawSearchQuery, 250);
   const isConfigListMode =
     values[FieldName.CONFIG_INPUT_MODE] !== InputMode.YAML;
 
@@ -88,14 +90,12 @@ const ConfigsConstraints = (): JSX.Element => {
             <div className="row u-no-padding">
               <div className="col-4">
                 <SearchBox
-                  externallyControlled
                   name="configSearch"
                   id="configSearch"
                   placeholder="Search configurations"
-                  value={searchQuery}
-                  onChange={setSearchQuery}
+                  onChange={setRawSearchQuery}
                   onClear={() => {
-                    setSearchQuery("");
+                    setRawSearchQuery("");
                   }}
                   className="configs__search-input"
                   aria-label="Search configurations"

--- a/src/pages/AddModel/ConfigsConstraints/ConfigsConstraints.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/ConfigsConstraints.tsx
@@ -34,8 +34,7 @@ const ConfigsConstraints = (): JSX.Element => {
   >();
 
   const [changedOnly, setChangedOnly] = useState(false);
-  const [rawSearchQuery, setRawSearchQuery] = useState("");
-  const searchQuery = useDebounce(rawSearchQuery, 250);
+  const [searchQuery, setSearchQuery] = useDebounce("", 250);
   const isConfigListMode =
     values[FieldName.CONFIG_INPUT_MODE] !== InputMode.YAML;
 
@@ -91,9 +90,9 @@ const ConfigsConstraints = (): JSX.Element => {
                   name="configSearch"
                   id="configSearch"
                   placeholder="Search configurations"
-                  onChange={setRawSearchQuery}
+                  onChange={setSearchQuery}
                   onClear={() => {
-                    setRawSearchQuery("");
+                    setSearchQuery("", { immediate: true });
                   }}
                   className="u-no-margin--bottom"
                   aria-label="Search configurations"

--- a/src/pages/AddModel/ConfigsConstraints/_configs-constraints.scss
+++ b/src/pages/AddModel/ConfigsConstraints/_configs-constraints.scss
@@ -1,19 +1,34 @@
-.configs__form-scroll {
-  margin-bottom: 1rem;
-  max-height: min(40rem, calc(100dvh - 24rem));
-  min-height: 10rem;
-  overflow-y: auto;
+.configs-constraints {
+  .configs__form-scroll {
+    margin-bottom: 1rem;
+    max-height: min(40rem, calc(100dvh - 26rem));
+    min-height: 10rem;
+    overflow-y: auto;
 
-  @media (min-height >= 900px) {
-    .configs__form-scroll {
-      max-height: min(40rem, calc(100dvh - 24rem));
+    @media (min-height >= 900px) {
+      .configs__form-scroll {
+        max-height: min(40rem, calc(100dvh - 25rem));
+      }
+    }
+
+    @media (min-height >= 1100px) {
+      .configs__form-scroll {
+        max-height: min(40rem, calc(100dvh - 23rem));
+      }
     }
   }
 
-  @media (min-height >= 1100px) {
-    .configs__form-scroll {
-      max-height: min(40rem, calc(100dvh - 21rem));
-    }
+  .configs__yaml-input {
+    min-height: 10rem;
+  }
+
+  .configs__search-input {
+    margin-bottom: $sph--small;
+  }
+
+  .p-switch {
+    margin-bottom: 0;
+    padding-bottom: $sph--small;
   }
 }
 

--- a/src/pages/AddModel/ConfigsConstraints/_configs-constraints.scss
+++ b/src/pages/AddModel/ConfigsConstraints/_configs-constraints.scss
@@ -1,34 +1,19 @@
-.configs-constraints {
-  .configs__form-scroll {
-    margin-bottom: 1rem;
-    max-height: min(40rem, calc(100dvh - 26rem));
-    min-height: 10rem;
-    overflow-y: auto;
+.configs__form-scroll {
+  margin-bottom: 1rem;
+  max-height: min(40rem, calc(100dvh - 26rem));
+  min-height: 10rem;
+  overflow-y: auto;
 
-    @media (min-height >= 900px) {
-      .configs__form-scroll {
-        max-height: min(40rem, calc(100dvh - 25rem));
-      }
-    }
-
-    @media (min-height >= 1100px) {
-      .configs__form-scroll {
-        max-height: min(40rem, calc(100dvh - 23rem));
-      }
+  @media (min-height >= 900px) {
+    .configs__form-scroll {
+      max-height: min(40rem, calc(100dvh - 25rem));
     }
   }
 
-  .configs__yaml-input {
-    min-height: 10rem;
-  }
-
-  .configs__search-input {
-    margin-bottom: $sph--small;
-  }
-
-  .p-switch {
-    margin-bottom: 0;
-    padding-bottom: $sph--small;
+  @media (min-height >= 1100px) {
+    .configs__form-scroll {
+      max-height: min(40rem, calc(100dvh - 23rem));
+    }
   }
 }
 

--- a/src/pages/AddModel/ConfigsConstraints/configCatalog.ts
+++ b/src/pages/AddModel/ConfigsConstraints/configCatalog.ts
@@ -12,6 +12,11 @@ export type CategoryDefinition = {
   }[];
 };
 
+const BOOLEAN_OPTIONS = [
+  { label: "True", value: "true" },
+  { label: "False", value: "false" },
+];
+
 export const CONFIG_CATEGORIES: CategoryDefinition[] = [
   {
     category: "Networking & Firewall",
@@ -39,10 +44,7 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         defaultValue: "false",
         input: {
           type: "select",
-          options: [
-            { label: "True", value: "true" },
-            { label: "False", value: "false" },
-          ],
+          options: BOOLEAN_OPTIONS,
         },
       },
       {
@@ -74,10 +76,7 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         defaultValue: "false",
         input: {
           type: "select",
-          options: [
-            { label: "True", value: "true" },
-            { label: "False", value: "false" },
-          ],
+          options: BOOLEAN_OPTIONS,
         },
       },
       {
@@ -104,10 +103,7 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         defaultValue: "true",
         input: {
           type: "select",
-          options: [
-            { label: "True", value: "true" },
-            { label: "False", value: "false" },
-          ],
+          options: BOOLEAN_OPTIONS,
         },
       },
     ],
@@ -185,10 +181,7 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         defaultValue: "false",
         input: {
           type: "select",
-          options: [
-            { label: "True", value: "true" },
-            { label: "False", value: "false" },
-          ],
+          options: BOOLEAN_OPTIONS,
         },
       },
       {
@@ -210,6 +203,294 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
       {
         label: "snap-store-proxy-url",
         description: "The URL for the defined snap store proxy",
+      },
+    ],
+  },
+  {
+    category: "Provisioning & Machines",
+    fields: [
+      {
+        label: "cloudinit-userdata",
+        description:
+          "Cloud-init user-data (in yaml format) to be added to userdata for new machines created in this model",
+      },
+      {
+        label: "container-image-metadata-defaults-disabled",
+        description:
+          "Determines whether default simplestreams sources are used for image metadata with containers",
+        defaultValue: "false",
+        input: {
+          type: "select",
+          options: BOOLEAN_OPTIONS,
+        },
+      },
+      {
+        label: "container-image-metadata-url",
+        description:
+          "The URL at which the metadata used to locate container OS image ids is located",
+      },
+      {
+        label: "container-image-stream",
+        description:
+          "The simplestreams stream used to identify which image ids to search when starting a container",
+        defaultValue: "released",
+      },
+      {
+        label: "container-inherit-properties",
+        description:
+          "The list of properties to be copied from the host machine to new containers created in this model (comma-separated)",
+      },
+      {
+        label: "default-base",
+        description:
+          "The default base image to use for deploying charms, will act like --base when deploying charms",
+      },
+      {
+        label: "default-series",
+        description:
+          "The default OS series to use for deploying charms (deprecated in favour of default-base)",
+      },
+      {
+        label: "enable-os-refresh-update",
+        description:
+          "Determines whether newly provisioned instances should run their respective OS's update capability",
+        defaultValue: "true",
+        input: {
+          type: "select",
+          options: BOOLEAN_OPTIONS,
+        },
+      },
+      {
+        label: "enable-os-upgrade",
+        description:
+          "Determines whether newly provisioned instances should run their respective OS's upgrade capability",
+        defaultValue: "true",
+        input: {
+          type: "select",
+          options: BOOLEAN_OPTIONS,
+        },
+      },
+      {
+        label: "image-metadata-defaults-disabled",
+        description:
+          "Determines whether default simplestreams sources are used for image metadata",
+        defaultValue: "false",
+        input: {
+          type: "select",
+          options: BOOLEAN_OPTIONS,
+        },
+      },
+      {
+        label: "image-metadata-url",
+        description:
+          "The URL at which the metadata used to locate OS image ids is located",
+      },
+      {
+        label: "image-stream",
+        description:
+          "The simplestreams stream used to identify which image ids to search when starting an instance",
+        defaultValue: "released",
+      },
+      {
+        label: "lxd-snap-channel",
+        description:
+          "The channel to use when installing LXD from a snap (cosmic and later)",
+        defaultValue: "5.0/stable",
+      },
+      {
+        label: "num-container-provision-workers",
+        description:
+          "The number of container provisioning workers to use per machine",
+        defaultValue: "4",
+      },
+      {
+        label: "num-provision-workers",
+        description: "The number of provisioning workers to use per model",
+        defaultValue: "16",
+      },
+      {
+        label: "project",
+        description:
+          "The name of the cloud project or namespace to use for this model",
+        defaultValue: "default",
+      },
+      {
+        label: "provisioner-harvest-mode",
+        description:
+          "Sets what to do with unknown machines. Valid values: all, none, unknown, destroyed",
+        defaultValue: "destroyed",
+        input: {
+          type: "select",
+          options: [
+            { label: "all", value: "all" },
+            { label: "none", value: "none" },
+            { label: "unknown", value: "unknown" },
+            { label: "destroyed", value: "destroyed" },
+          ],
+        },
+      },
+      {
+        label: "resource-tags",
+        description:
+          "A space-separated list of key=value pairs used to apply as tags on supported cloud models",
+        defaultValue: "{}",
+      },
+    ],
+  },
+  {
+    category: "Logging",
+    fields: [
+      {
+        label: "logforward-enabled",
+        description: "Determines whether syslog forwarding is enabled",
+        defaultValue: "false",
+        input: {
+          type: "select",
+          options: BOOLEAN_OPTIONS,
+        },
+      },
+      {
+        label: "logging-config",
+        description:
+          "The configuration string to use when configuring Juju agent logging",
+        defaultValue: "<root>=INFO",
+      },
+      {
+        label: "logging-output",
+        description: "The logging output destination: database and/or syslog",
+      },
+    ],
+  },
+  {
+    category: "Agents & Workloads",
+    fields: [
+      {
+        label: "agent-metadata-url",
+        description: "The URL of the private stream",
+      },
+      {
+        label: "agent-stream",
+        description: "The version of Juju to use for deploy/upgrades",
+        defaultValue: "released",
+      },
+      {
+        label: "agent-version",
+        description: "The desired Juju agent version to use",
+        defaultValue: "3.6.20",
+      },
+      {
+        label: "automatically-retry-hooks",
+        description:
+          "Determines whether the uniter should automatically retry failed hooks",
+        defaultValue: "true",
+        input: {
+          type: "select",
+          options: BOOLEAN_OPTIONS,
+        },
+      },
+      {
+        label: "charmhub-url",
+        description: "The url for Charmhub API calls",
+        defaultValue: "https://api.charmhub.io",
+      },
+      {
+        label: "transmit-vendor-metrics",
+        description:
+          "Determines whether metrics declared by charms deployed into this model are sent for anonymized aggregate analytics",
+        defaultValue: "true",
+        input: {
+          type: "select",
+          options: BOOLEAN_OPTIONS,
+        },
+      },
+      {
+        label: "update-status-hook-interval",
+        description:
+          "Sets how often to run the charm update-status hook, in human-readable time format (default 5m, range 1-60m)",
+        defaultValue: "5m",
+      },
+    ],
+  },
+  {
+    category: "Storage & Secrets",
+    fields: [
+      {
+        label: "backup-dir",
+        description: "The directory used to store the backup working directory",
+      },
+      {
+        label: "secret-backend",
+        description:
+          "The name of the secret store backend. Valid values: internal, auto, or a backend name",
+        defaultValue: "auto",
+      },
+      {
+        label: "storage-default-filesystem-source",
+        description: "The default filesystem storage source for the model",
+        defaultValue: "lxd",
+      },
+      {
+        label: "max-action-results-age",
+        description:
+          "The maximum age for action entries before they are pruned, in human-readable time format",
+        defaultValue: "336h",
+      },
+      {
+        label: "max-action-results-size",
+        description:
+          "The maximum size for the action collection, in human-readable memory format",
+        defaultValue: "5G",
+      },
+      {
+        label: "max-status-history-age",
+        description:
+          "The maximum age for status history entries before they are pruned, in human-readable time format",
+        defaultValue: "336h",
+      },
+      {
+        label: "max-status-history-size",
+        description:
+          "The maximum size for the status history collection, in human-readable memory format",
+        defaultValue: "5G",
+      },
+    ],
+  },
+  {
+    category: "Operations & Miscellaneous",
+    fields: [
+      {
+        label: "development",
+        description:
+          "Determines whether development mode is enabled for this model",
+        defaultValue: "false",
+        input: {
+          type: "select",
+          options: BOOLEAN_OPTIONS,
+        },
+      },
+      {
+        label: "disable-telemetry",
+        description:
+          "Determines whether telemetry collection is disabled for this model",
+        defaultValue: "false",
+        input: {
+          type: "select",
+          options: BOOLEAN_OPTIONS,
+        },
+      },
+      {
+        label: "mode",
+        description: "The operation mode for model commands",
+        defaultValue: "requires-prompts",
+      },
+      {
+        label: "test-mode",
+        description: "Determines whether test mode is enabled for this model",
+        defaultValue: "false",
+        input: {
+          type: "select",
+          options: BOOLEAN_OPTIONS,
+        },
       },
     ],
   },

--- a/src/pages/AddModel/ConfigsConstraints/types.ts
+++ b/src/pages/AddModel/ConfigsConstraints/types.ts
@@ -16,6 +16,7 @@ export enum Label {
   DISABLE_REMOVE_OBJECT_DESC = "Prevents destruction of the model and removal of applications, machines, units, relations, and storage.",
   DISABLE_ALL_COMMANDS = "Disable all commands",
   DISABLE_ALL_COMMANDS_DESC = "Disables every command that can modify a Juju controller, model, or workload.",
+  NO_CHANGED_CONFIGS = "No configs were changed from default",
 }
 
 export enum FieldName {

--- a/src/pages/AddModel/ConfigsConstraints/utils.test.ts
+++ b/src/pages/AddModel/ConfigsConstraints/utils.test.ts
@@ -1,5 +1,6 @@
 import type { CategoryDefinition } from "./configCatalog";
 import {
+  buildChangedConfigPayload,
   buildConfigYAML,
   filterConfigsBySearch,
   getChangedFields,
@@ -168,6 +169,59 @@ describe("utils", () => {
       expect(result).not.toContain("container-networking-method");
       expect(result).toContain("logging-config: debug");
       expect(result).not.toContain("logging-level");
+    });
+  });
+
+  describe("buildChangedConfigPayload", () => {
+    const categories: CategoryDefinition[] = [
+      {
+        category: "Networking",
+        fields: [
+          {
+            label: "default-space",
+            defaultValue: "alpha",
+            description: "Default space",
+          },
+          {
+            label: "container-networking-method",
+            defaultValue: "provider",
+            description: "Networking method",
+          },
+        ],
+      },
+      {
+        category: "Logging",
+        fields: [
+          {
+            label: "logging-config",
+            defaultValue: "",
+            description: "Logging config",
+          },
+        ],
+      },
+    ];
+
+    it("returns empty object when no fields have changed", () => {
+      const result = buildChangedConfigPayload(categories, {
+        "default-space": "alpha",
+        "container-networking-method": "provider",
+        "logging-config": "",
+      });
+
+      expect(result).toEqual({});
+    });
+
+    it("returns only changed field labels and values", () => {
+      const result = buildChangedConfigPayload(categories, {
+        "default-space": "custom-space",
+        "container-networking-method": "provider",
+        "logging-config": "debug",
+      });
+
+      expect(result).toEqual({
+        "default-space": "custom-space",
+        "logging-config": "debug",
+      });
     });
   });
 

--- a/src/pages/AddModel/ConfigsConstraints/utils.test.ts
+++ b/src/pages/AddModel/ConfigsConstraints/utils.test.ts
@@ -1,5 +1,12 @@
 import type { CategoryDefinition } from "./configCatalog";
-import { buildConfigYAML, getChangedFields, isConfigChanged } from "./utils";
+import {
+  buildConfigYAML,
+  filterConfigsBySearch,
+  getChangedFields,
+  getCategoriesWithVisibleConfigs,
+  getConfigInitialValues,
+  isConfigChanged,
+} from "./utils";
 
 describe("utils", () => {
   describe("isConfigChanged", () => {
@@ -62,17 +69,18 @@ describe("utils", () => {
       ],
     };
 
-    it("returns all fields when onlyChanged is false", () => {
-      const result = getChangedFields(category, false, {
-        "default-space": "modified-space",
+    it("returns empty array when nothing has changed", () => {
+      const result = getChangedFields(category, {
+        "default-space": "alpha",
+        "container-networking-method": "provider",
+        "logging-config": "",
       });
 
-      expect(result).toHaveLength(3);
-      expect(result).toEqual(category.fields);
+      expect(result).toEqual([]);
     });
 
-    it("filters to only changed fields when onlyChanged is true", () => {
-      const result = getChangedFields(category, true, {
+    it("filters changed fields", () => {
+      const result = getChangedFields(category, {
         "default-space": "modified-space",
         "container-networking-method": "provider",
         "logging-config": "debug",
@@ -83,16 +91,6 @@ describe("utils", () => {
         "default-space",
         "logging-config",
       ]);
-    });
-
-    it("returns empty array when no fields have changed", () => {
-      const result = getChangedFields(category, true, {
-        "default-space": "alpha",
-        "container-networking-method": "provider",
-        "logging-config": "",
-      });
-
-      expect(result).toHaveLength(0);
     });
   });
 
@@ -170,6 +168,170 @@ describe("utils", () => {
       expect(result).not.toContain("container-networking-method");
       expect(result).toContain("logging-config: debug");
       expect(result).not.toContain("logging-level");
+    });
+  });
+
+  describe("getCategoriesWithVisibleConfigs", () => {
+    const categories: CategoryDefinition[] = [
+      {
+        category: "Networking",
+        fields: [
+          {
+            label: "default-space",
+            defaultValue: "alpha",
+            description: "Default space",
+          },
+          {
+            label: "container-networking-method",
+            defaultValue: "provider",
+            description: "Networking method",
+          },
+        ],
+      },
+      {
+        category: "Logging",
+        fields: [
+          {
+            label: "logging-config",
+            defaultValue: "",
+            description: "Logging config",
+          },
+        ],
+      },
+    ];
+
+    it("returns empty array when no fields have changed", () => {
+      const result = getCategoriesWithVisibleConfigs(categories, {});
+
+      expect(result).toHaveLength(0);
+    });
+
+    it("returns categories with only changed fields visible", () => {
+      const result = getCategoriesWithVisibleConfigs(categories, {
+        "default-space": "modified-space",
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].category).toBe("Networking");
+      expect(result[0].fields).toHaveLength(1);
+      expect(result[0].fields[0].label).toBe("default-space");
+    });
+  });
+
+  describe("getConfigInitialValues", () => {
+    const categories: CategoryDefinition[] = [
+      {
+        category: "Networking",
+        fields: [
+          {
+            label: "default-space",
+            defaultValue: "alpha",
+            description: "Default space",
+          },
+          {
+            label: "container-networking-method",
+            defaultValue: "provider",
+            description: "Networking method",
+          },
+        ],
+      },
+      {
+        category: "Logging",
+        fields: [
+          {
+            label: "logging-config",
+            defaultValue: "",
+            description: "Logging config",
+          },
+        ],
+      },
+    ];
+
+    it("returns object with all fields and their default values", () => {
+      const result = getConfigInitialValues(categories);
+
+      expect(result).toEqual({
+        "default-space": "alpha",
+        "container-networking-method": "provider",
+        "logging-config": "",
+      });
+    });
+
+    it("handles fields with undefined default values", () => {
+      const categoriesWithUndefinedDefaults: CategoryDefinition[] = [
+        {
+          category: "Test",
+          fields: [
+            {
+              label: "test-field",
+              defaultValue: undefined,
+              description: "Test",
+            },
+          ],
+        },
+      ];
+
+      const result = getConfigInitialValues(categoriesWithUndefinedDefaults);
+
+      expect(result["test-field"]).toBe("");
+    });
+
+    it("returns empty object when categories are empty", () => {
+      const result = getConfigInitialValues([]);
+
+      expect(result).toEqual({});
+    });
+  });
+
+  describe("filterConfigsBySearch", () => {
+    it("returns all categories when query is empty", () => {
+      const result = filterConfigsBySearch("");
+
+      expect(result.length).toBeGreaterThan(0);
+    });
+
+    it("filters fields by label", () => {
+      const result = filterConfigsBySearch("proxy");
+
+      expect(result.length).toBeGreaterThan(0);
+      const allLabels = result.flatMap((cat) =>
+        cat.fields.map((field) => field.label.toLowerCase()),
+      );
+
+      const hasMatch = allLabels.some((label) => label.includes("proxy"));
+      expect(hasMatch).toBe(true);
+    });
+
+    it("filters fields by description", () => {
+      const result = filterConfigsBySearch("method");
+
+      expect(result.length).toBeGreaterThan(0);
+      const allDescriptions = result.flatMap((cat) =>
+        cat.fields.map((field) => field.description.toLowerCase()),
+      );
+
+      const hasMatch = allDescriptions.some((desc) => desc.includes("method"));
+      expect(hasMatch).toBe(true);
+    });
+
+    it("returns empty array when no fields match", () => {
+      const result = filterConfigsBySearch("non-existent-query123456");
+
+      expect(result).toEqual([]);
+    });
+
+    it("filters out categories with no matching fields", () => {
+      const result = filterConfigsBySearch("proxy");
+
+      // All returned categories should have at least one field matching the query
+      result.forEach((category) => {
+        const hasMatch = category.fields.some(
+          (field) =>
+            field.label.toLowerCase().includes("proxy") ||
+            field.description.toLowerCase().includes("proxy"),
+        );
+        expect(hasMatch).toBe(true);
+      });
     });
   });
 });

--- a/src/pages/AddModel/ConfigsConstraints/utils.ts
+++ b/src/pages/AddModel/ConfigsConstraints/utils.ts
@@ -64,6 +64,17 @@ export const buildConfigYAML = (
   return yamlSections.join("\n\n");
 };
 
+export const buildChangedConfigPayload = (
+  categories: CategoryDefinition[],
+  values: Record<string, string>,
+): Record<string, string> =>
+  categories.reduce<Record<string, string>>((config, category) => {
+    getChangedFields(category, values).forEach((field) => {
+      config[field.label] = values[field.label];
+    });
+    return config;
+  }, {});
+
 export const getConfigInitialValues = (
   categories: CategoryDefinition[],
 ): Record<string, string> =>

--- a/src/pages/AddModel/ConfigsConstraints/utils.ts
+++ b/src/pages/AddModel/ConfigsConstraints/utils.ts
@@ -1,4 +1,4 @@
-import type { CategoryDefinition } from "./configCatalog";
+import { CONFIG_CATEGORIES, type CategoryDefinition } from "./configCatalog";
 
 export const isConfigChanged = (
   label: string,
@@ -24,24 +24,20 @@ export const isConfigChanged = (
 
 export const getChangedFields = (
   category: CategoryDefinition,
-  onlyChanged: boolean,
   values: Record<string, string>,
 ): CategoryDefinition["fields"] =>
-  onlyChanged
-    ? category.fields.filter((field) =>
-        isConfigChanged(field.label, values, field.defaultValue),
-      )
-    : category.fields;
+  category.fields.filter((field) =>
+    isConfigChanged(field.label, values, field.defaultValue),
+  );
 
 export const getCategoriesWithVisibleConfigs = (
   categories: CategoryDefinition[],
-  onlyChanged: boolean,
   values: Record<string, string>,
 ): Array<{ category: string; fields: CategoryDefinition["fields"] }> =>
   categories
     .map((cat) => ({
       category: cat.category,
-      fields: getChangedFields(cat, onlyChanged, values),
+      fields: getChangedFields(cat, values),
     }))
     .filter(({ fields }) => fields.length > 0);
 
@@ -51,13 +47,11 @@ export const buildConfigYAML = (
 ): string => {
   const yamlSections = categories
     .map((category) => {
-      const changedFields = getChangedFields(category, true, values).map(
-        (field) => {
-          const value = values[field.label];
-          const quotedValue = value === "" ? '""' : value;
-          return `${field.label}: ${quotedValue}`;
-        },
-      );
+      const changedFields = getChangedFields(category, values).map((field) => {
+        const value = values[field.label];
+        const quotedValue = value === "" ? '""' : value;
+        return `${field.label}: ${quotedValue}`;
+      });
 
       if (changedFields.length === 0) {
         return null;
@@ -79,3 +73,18 @@ export const getConfigInitialValues = (
     });
     return values;
   }, {});
+
+export const filterConfigsBySearch = (query: string): CategoryDefinition[] => {
+  if (!query.trim()) {
+    return CONFIG_CATEGORIES;
+  }
+  const lowerQuery = query.toLowerCase();
+  return CONFIG_CATEGORIES.map((category) => ({
+    ...category,
+    fields: category.fields.filter(
+      (field) =>
+        field.label.toLowerCase().includes(lowerQuery) ||
+        field.description.toLowerCase().includes(lowerQuery),
+    ),
+  })).filter(({ fields }) => fields.length > 0);
+};

--- a/src/pages/AddModel/ConfigsConstraints/utils.ts
+++ b/src/pages/AddModel/ConfigsConstraints/utils.ts
@@ -86,10 +86,10 @@ export const getConfigInitialValues = (
   }, {});
 
 export const filterConfigsBySearch = (query: string): CategoryDefinition[] => {
-  if (!query.trim()) {
+  const lowerQuery = query.toLowerCase().trim();
+  if (!lowerQuery) {
     return CONFIG_CATEGORIES;
   }
-  const lowerQuery = query.toLowerCase();
   return CONFIG_CATEGORIES.map((category) => ({
     ...category,
     fields: category.fields.filter(

--- a/src/pages/AddModel/ConfigsConstraints/utils.ts
+++ b/src/pages/AddModel/ConfigsConstraints/utils.ts
@@ -97,5 +97,5 @@ export const filterConfigsBySearch = (query: string): CategoryDefinition[] => {
         field.label.toLowerCase().includes(lowerQuery) ||
         field.description.toLowerCase().includes(lowerQuery),
     ),
-  })).filter(({ fields }) => fields.length > 0);
+  })).filter((category) => category.fields.length > 0);
 };

--- a/src/pages/AddModel/_add-model.scss
+++ b/src/pages/AddModel/_add-model.scss
@@ -23,6 +23,7 @@
     padding: $spv--large $sph--small 0;
     position: sticky;
     text-align: right;
+    z-index: 2;
 
     .navigation-buttons {
       border-left: 1px solid $color-mid-light;

--- a/src/pages/AddModel/_add-model.scss
+++ b/src/pages/AddModel/_add-model.scss
@@ -23,7 +23,7 @@
     padding: $spv--large $sph--small 0;
     position: sticky;
     text-align: right;
-    z-index: 2;
+    z-index: z("gamma");
 
     .navigation-buttons {
       border-left: 1px solid $color-mid-light;

--- a/src/pages/AddModel/_add-model.scss
+++ b/src/pages/AddModel/_add-model.scss
@@ -23,6 +23,7 @@
     padding: $spv--large $sph--small 0;
     position: sticky;
     text-align: right;
+    // To ensure the footer appears above StackList items.
     z-index: z("gamma");
 
     .navigation-buttons {

--- a/src/store/juju/types.ts
+++ b/src/store/juju/types.ts
@@ -151,6 +151,7 @@ export type AddModel = {
   userTag: string;
   disabledCommands: DisableType;
   region?: string;
+  config?: Record<string, string>;
 };
 
 export type AddModelState = {

--- a/src/store/middleware/model-poller.ts
+++ b/src/store/middleware/model-poller.ts
@@ -510,6 +510,7 @@ function runModelPoller(
         region,
         userTag,
         disabledCommands,
+        config,
       } = action.payload;
       // Immediately pass the action along so that it can be handled by the
       // reducer to update the loading state.
@@ -532,6 +533,7 @@ function runModelPoller(
           "cloud-tag": cloudTag,
           credential,
           region,
+          ...(config && Object.keys(config).length > 0 ? { config } : {}),
         });
 
         if (response) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -261,9 +261,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@canonical/react-components@npm:4.4.0":
-  version: 4.4.0
-  resolution: "@canonical/react-components@npm:4.4.0"
+"@canonical/react-components@npm:4.4.1":
+  version: 4.4.1
+  resolution: "@canonical/react-components@npm:4.4.1"
   dependencies:
     "@types/jest": "npm:30.0.0"
     "@types/node": "npm:20.19.30"
@@ -282,7 +282,7 @@ __metadata:
     react: ^18.0.0 || ^19.0.0
     react-dom: ^18.0.0 || ^19.0.0
     vanilla-framework: ^3.15.1 || ^4.0.0
-  checksum: 10c0/677bbec3ebcfbdd6d40886398c98ecdada723ee966b93f8330d1dfc78d3bf259227009a857344a35ee7db82ae90c0bf815b348e64ca6a3d97846a6b9cb77dd87
+  checksum: 10c0/eb6239ae5baa487d7bf40826c86abf37618fb5abbfbfcb83277a845bfa3f2d386a2bb5d63f27d6e5b87919ad7a6dafc0c3886503abcbe02bc4df4f01bf257c21
   languageName: node
   linkType: hard
 
@@ -8946,7 +8946,7 @@ __metadata:
   dependencies:
     "@canonical/jujulib": "npm:8.1.0"
     "@canonical/macaroon-bakery": "npm:1.3.2"
-    "@canonical/react-components": "npm:4.4.0"
+    "@canonical/react-components": "npm:4.4.1"
     "@canonical/rebac-admin": "npm:0.0.1-alpha.12"
     "@cspell/eslint-plugin": "npm:9.4.0"
     "@curvenote/ansi-to-react": "npm:7.0.0"


### PR DESCRIPTION
## Done

- Added search bar to configs list allowing filtering based on config name and description
- Added `useDebounce` hook to optimise search
- Added tooltip to `changed-configs-only` toggle for when no configs have been changed from default
- Search works for all as well as changed configs
- Added `config` key to `createModel` payload

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Try changing the `changed-configs-only` toggle without any changes, it should stay disabled with a tooltip message
- Try doing the same after changing something, it should get enabled and work as expected
- Try searching for configs based on config name and description
- Search should show a no results found message when no results match the query
- Change some configs and create a model
- Verify that the model was created with this changed value by either monitoring the websocket or simply running `juju model-config` within the model context

## Details

https://warthogs.atlassian.net/browse/JUJU-9680

## Screenshots

<img width="1352" height="660" alt="Screenshot 2026-04-27 at 4 43 52 PM" src="https://github.com/user-attachments/assets/59093a5a-deb5-4958-9ee1-874017074a67" />


