### PR TITLE
feat(process): create `upgrade-to` process

### DIFF
--- a/src/components/ToastCard/_toast-card.scss
+++ b/src/components/ToastCard/_toast-card.scss
@@ -45,7 +45,7 @@
     border-left: 3px solid $color-negative;
   }
 
-  &[data-type="info"] {
+  &[data-type="information"] {
     border-left: 3px solid $color-information;
   }
 

--- a/src/data/sourceBase.test.ts
+++ b/src/data/sourceBase.test.ts
@@ -918,6 +918,46 @@ describe("createSource", () => {
         expect(await next).toStrictEqual({ value: undefined, done: true });
       });
 
+      it("doesn't produce unhandled error after finishing", async ({
+        onTestFinished,
+      }) => {
+        vi.useFakeTimers();
+
+        // Install a listener on the process to detect when an unhandled error is raised.
+        const unhandledRejectionListener = vi.fn();
+        process.on("unhandledRejection", unhandledRejectionListener);
+        onTestFinished(() => {
+          process.off("unhandledRejection", unhandledRejectionListener);
+        });
+
+        // Ensure the hook is correctly installed.
+        const testError = new Error("test error");
+        void Promise.reject(testError);
+        await vi.runAllTimersAsync();
+        expect(unhandledRejectionListener).toHaveBeenCalledExactlyOnceWith(
+          testError,
+          expect.any(Promise),
+        );
+        unhandledRejectionListener.mockReset();
+
+        const source = createSource(({ load }) => {
+          load(Promise.resolve(1));
+          return DUMMY_HOOKS;
+        });
+
+        // Begin iterator, and immediately stop it.
+        for await (const _ of source) {
+          break;
+        }
+
+        // Clean up source
+        source.done();
+
+        // Give unhandled rejection a chance to propagate.
+        await vi.runAllTimersAsync();
+        expect(unhandledRejectionListener).not.toHaveBeenCalled();
+      });
+
       describe("cleans up listener", () => {
         let promise: PromiseWithResolvers<number>;
         let source: Source<number>;

--- a/src/data/sourceBase.ts
+++ b/src/data/sourceBase.ts
@@ -31,6 +31,12 @@ export type SourceHooks = {
   refetch: () => void;
 };
 
+class SourceIteratorStopped extends Error {
+  constructor() {
+    super(`This error was used to stop a source`);
+  }
+}
+
 export function createSource<T>(
   setup: (base: SourceBase<T>) => SourceHooks,
 ): Source<T> {
@@ -88,16 +94,22 @@ export function createSource<T>(
       };
     },
     async *[Symbol.asyncIterator]() {
+      // Create the stop error here to capture the stacktrace.
+      const sourceStoppedError = new SourceIteratorStopped();
+
       let promise = Promise.withResolvers<T>();
       // Capture incoming data, and resolve the current promise.
       const unsubscribe = this.on("data", (data) => {
         promise.resolve(data);
       });
+      let running = true;
       // When the source is complete, reject the existing promise.
       sourceDone.signal.addEventListener(
         "abort",
         () => {
-          promise.reject();
+          if (running) {
+            promise.reject(sourceStoppedError);
+          }
         },
         { once: true },
       );
@@ -110,13 +122,14 @@ export function createSource<T>(
           yield value;
         }
       } catch (error) {
-        // Promise should only reject (with no value) when the source is complete.
-        if (error) {
+        // Ignore the specific error used to stop the source.
+        if (error !== sourceStoppedError) {
           throw error;
         }
       } finally {
         // Ensure the event listener is unsubscribed.
         unsubscribe();
+        running = false;
       }
     },
   };

--- a/src/juju/jimm/JIMMV4.test.ts
+++ b/src/juju/jimm/JIMMV4.test.ts
@@ -177,4 +177,22 @@ describe("JIMMV4", () => {
       );
     },
   );
+
+  it("upgradeTo", async () => {
+    const jimm = new JIMMV4(transport, connectionInfo);
+    void jimm.upgradeTo("model-abc123", "controller123");
+    expect(transport.write).toHaveBeenCalledWith(
+      {
+        type: "JIMM",
+        request: "UpgradeTo",
+        version: 4,
+        params: {
+          "model-tag": "model-abc123",
+          "target-controller-name": "controller123",
+        },
+      },
+      expect.any(Function),
+      expect.any(Function),
+    );
+  });
 });

--- a/src/juju/jimm/JIMMV4.ts
+++ b/src/juju/jimm/JIMMV4.ts
@@ -193,6 +193,32 @@ class JIMMV4 extends JIMMV3 {
       this._transport.write(req, resolve, reject);
     });
   }
+
+  /**
+   * Initiate a model upgrade.
+   *
+   * @param modelTag Tag of the model which will be upgraded.
+   * @param targetController Name of controller to migrate the model to.
+   *
+   * @see {@link https://github.com/canonical/jimm/blob/53c606aa41ae6339c7b6cf430c7051bf489b9238/internal/jujuapi/jimm.go#L738}
+   */
+  async upgradeTo(
+    modelTag: string,
+    targetController: string,
+  ): Promise<boolean | undefined> {
+    return new Promise((resolve, reject) => {
+      const req = {
+        type: "JIMM",
+        request: "UpgradeTo",
+        version: 4,
+        params: {
+          "model-tag": modelTag,
+          "target-controller-name": targetController,
+        },
+      };
+      this._transport.write(req, resolve, reject);
+    });
+  }
 }
 
 JIMMV4.NAME = "JIMM";

--- a/src/juju/jimm/api.test.ts
+++ b/src/juju/jimm/api.test.ts
@@ -18,6 +18,7 @@ import {
   Label,
   listMigrationTargets,
   supportedJujuVersions,
+  upgradeTo,
 } from "./api";
 
 describe("JIMM API", () => {
@@ -446,6 +447,46 @@ describe("JIMM API", () => {
       await expect(supportedJujuVersions(conn)).rejects.toThrow(
         new Error("Uh oh!"),
       );
+    });
+  });
+
+  describe("upgradeTo", () => {
+    it("makes and upgrade call", async () => {
+      const conn = {
+        facades: {
+          jimM: {
+            upgradeTo: vi.fn().mockResolvedValue(true),
+          },
+        },
+      } as unknown as Connection;
+      const response = await upgradeTo(conn, "model-abc123", "controller123");
+      expect(conn.facades.jimM.upgradeTo).toHaveBeenCalledExactlyOnceWith(
+        "model-abc123",
+        "controller123",
+      );
+      expect(response).toBe(true);
+    });
+
+    it("handles no JIMM connection", async () => {
+      const conn = {
+        facades: {},
+      } as unknown as Connection;
+      await expect(
+        upgradeTo(conn, "model-abc123", "controller123"),
+      ).rejects.toThrow(new Error(Label.NO_JIMM));
+    });
+
+    it("should handle exceptions", async () => {
+      const conn = {
+        facades: {
+          jimM: {
+            upgradeTo: vi.fn().mockRejectedValue(new Error("Uh oh!")),
+          },
+        },
+      } as unknown as Connection;
+      await expect(
+        upgradeTo(conn, "model-abc123", "controller123"),
+      ).rejects.toThrow(new Error("Uh oh!"));
     });
   });
 });

--- a/src/juju/jimm/api.ts
+++ b/src/juju/jimm/api.ts
@@ -125,3 +125,17 @@ export const supportedJujuVersions = async (
     jimm.supportedJujuVersions(minVersion),
   );
 };
+
+/*
+ * Initiate a model upgrade.
+ */
+export const upgradeTo = async (
+  conn: ConnectionWithFacades,
+  modelTag: string,
+  targetController: string,
+): Promise<boolean> => {
+  return withJimmCheck(
+    conn,
+    async (jimm) => (await jimm.upgradeTo(modelTag, targetController)) ?? false,
+  );
+};

--- a/src/panels/UpgradeModelPanel/UpgradeModelController/Fields/Fields.tsx
+++ b/src/panels/UpgradeModelPanel/UpgradeModelController/Fields/Fields.tsx
@@ -127,31 +127,40 @@ const Fields: FC<Props> = ({
                         void setFieldValue(FieldName.TARGET_CONTROLLER, value);
                       }}
                       options={[
-                        ...(targetControllers?.map((controller) => {
-                          const optionVersion =
-                            getControllerVersion(controller);
-                          return {
-                            label: (
-                              <span className="u-flex">
-                                <span className="u-flex-grow">
-                                  {controller.name}
+                        ...(targetControllers
+                          ?.filter(
+                            (
+                              controller,
+                            ): controller is {
+                              name: string;
+                            } & typeof controller =>
+                              controller.name !== undefined,
+                          )
+                          .map((controller) => {
+                            const optionVersion =
+                              getControllerVersion(controller);
+                            return {
+                              label: (
+                                <span className="u-flex">
+                                  <span className="u-flex-grow">
+                                    {controller.name}
+                                  </span>
+                                  <span>
+                                    {optionVersion ? (
+                                      <Chip
+                                        isReadOnly
+                                        isDense
+                                        isInline
+                                        value={optionVersion}
+                                      />
+                                    ) : null}
+                                  </span>
                                 </span>
-                                <span>
-                                  {optionVersion ? (
-                                    <Chip
-                                      isReadOnly
-                                      isDense
-                                      isInline
-                                      value={optionVersion}
-                                    />
-                                  ) : null}
-                                </span>
-                              </span>
-                            ),
-                            text: controller.name,
-                            value: controller.uuid,
-                          };
-                        }) ?? []),
+                              ),
+                              text: controller.name,
+                              value: controller.name,
+                            };
+                          }) ?? []),
                       ]}
                     />
                   </>

--- a/src/panels/UpgradeModelPanel/UpgradeModelController/UpgradeModelController.tsx
+++ b/src/panels/UpgradeModelPanel/UpgradeModelController/UpgradeModelController.tsx
@@ -73,8 +73,6 @@ const UpgradeModelController: FC<Props> = ({
   });
   function triggerMigration(values: FormFields): void {
     const currentVersion = model?.info?.["agent-version"];
-
-    // TODO: Properly handle
     if (!wsControllerURL) {
       throw new Error("wsControllerURL is required");
     }
@@ -92,8 +90,10 @@ const UpgradeModelController: FC<Props> = ({
         currentVersion,
         wsControllerURL,
         modelUUID,
+        // TODO: Use the getModelURL util here once it lands:
+        // https://github.com/canonical/juju-dashboard/pull/2285/changes#diff-b8618585b6c69654e35b6b6a0f188d72b59777badd2798cfd1d027a396ed0566R1
         modelURL: wsControllerURL.replace("/api", `/model/${modelUUID}/api`),
-        modelName: model?.info?.name ?? "Unknown model",
+        modelName: modelName,
       });
       dispatch(action);
     }

--- a/src/panels/UpgradeModelPanel/UpgradeModelController/UpgradeModelController.tsx
+++ b/src/panels/UpgradeModelPanel/UpgradeModelController/UpgradeModelController.tsx
@@ -7,6 +7,7 @@ import FormikFormData from "components/FormikFormData";
 import Panel from "components/Panel";
 import type { VersionElem } from "juju/jimm/JIMMV4";
 import { CharmsAndActionsPanelTestId } from "panels/CharmsAndActionsPanel";
+import { getWSControllerURL } from "store/general/selectors";
 import {
   getControllerByUUID,
   getModelDataByUUID,
@@ -14,7 +15,8 @@ import {
 } from "store/juju/selectors";
 import { getControllerVersion } from "store/juju/utils/controllers";
 import { requiresMigration } from "store/juju/utils/upgrades";
-import { useAppSelector } from "store/store";
+import { upgradeTo } from "store/middleware/process";
+import { useAppDispatch, useAppSelector } from "store/store";
 import { testId } from "testing/utils";
 
 import UpgradeModelPanelHeader from "../UpgradeModelPanelHeader";
@@ -38,6 +40,7 @@ const UpgradeModelController: FC<Props> = ({
   version,
   qualifier,
 }) => {
+  const dispatch = useAppDispatch();
   const formId = useId();
   const [isValid, setIsValid] = useState(false);
   const modelUUID = useAppSelector((state) =>
@@ -55,6 +58,7 @@ const UpgradeModelController: FC<Props> = ({
     (controllerVersion &&
       requiresMigration(controllerVersion, version.version)) ||
     false;
+  const wsControllerURL = useAppSelector(getWSControllerURL);
   const schema = Yup.object().shape({
     [FieldName.TARGET_CONTROLLER]: Yup.string().test({
       name: "required",
@@ -67,6 +71,33 @@ const UpgradeModelController: FC<Props> = ({
       message: "You must confirm to be able to upgrade.",
     }),
   });
+  function triggerMigration(values: FormFields): void {
+    const currentVersion = model?.info?.["agent-version"];
+
+    // TODO: Properly handle
+    if (!wsControllerURL) {
+      throw new Error("wsControllerURL is required");
+    }
+    if (!modelUUID) {
+      throw new Error("modelUUID is missing");
+    }
+    if (!currentVersion) {
+      throw new Error("currentVersion is missing");
+    }
+
+    if (needsMigration) {
+      const action = upgradeTo.run({
+        targetVersion: version.version,
+        targetController: values[FieldName.TARGET_CONTROLLER],
+        currentVersion,
+        wsControllerURL,
+        modelUUID,
+        modelURL: wsControllerURL.replace("/api", `/model/${modelUUID}/api`),
+        modelName: model?.info?.name ?? "Unknown model",
+      });
+      dispatch(action);
+    }
+  }
   return (
     <Panel
       animateMount={false}
@@ -117,8 +148,8 @@ const UpgradeModelController: FC<Props> = ({
             [FieldName.TARGET_CONTROLLER]: "",
             [FieldName.CONFIRM]: false,
           }}
-          onSubmit={(_values) => {
-            // TODO: start the upgrade: https://warthogs.atlassian.net/browse/JUJU-9503
+          onSubmit={(values) => {
+            triggerMigration(values);
             onRemovePanelQueryParams();
           }}
           validationSchema={schema}

--- a/src/store/middleware/connection/connection-manager.test.ts
+++ b/src/store/middleware/connection/connection-manager.test.ts
@@ -268,13 +268,6 @@ describe("ConnectionManager", () => {
 });
 
 describe("connection handlers", () => {
-  window.WebSocket = {
-    CONNECTING: 0,
-    OPEN: 1,
-    CLOSING: 2,
-    CLOSED: 3,
-  } as unknown as (typeof window)["WebSocket"];
-
   describe("default", () => {
     let logout: Mock;
     let logoutCb: Mock;

--- a/src/store/middleware/connection/connection-manager.test.ts
+++ b/src/store/middleware/connection/connection-manager.test.ts
@@ -76,6 +76,51 @@ describe("ConnectionManager", () => {
     await expect(connect2).resolves.toBe(connection);
   });
 
+  describe("failed connections", () => {
+    it("propagates error to `get` caller", async ({ expect }) => {
+      const error = new Error("unable to connect");
+      connectionHandler.mockRejectedValue(error);
+
+      const manager = new ConnectionManager({ getCredentials: vi.fn() });
+      await expect(manager.get("wss://example.com/")).rejects.toThrowError(
+        error,
+      );
+    });
+
+    it("propagates error to all pending callers", async ({ expect }) => {
+      const promise = Promise.withResolvers();
+      connectionHandler.mockReturnValue(promise.promise);
+
+      const manager = new ConnectionManager({ getCredentials: vi.fn() });
+      const req1 = manager.get("wss://example.com/");
+      const req2 = manager.get("wss://example.com/");
+      const req3 = manager.get("wss://example.com/");
+
+      const error = new Error("unable to connect");
+      promise.reject(error);
+
+      await expect(req1).rejects.toThrowError(error);
+      await expect(req2).rejects.toThrowError(error);
+      await expect(req3).rejects.toThrowError(error);
+
+      expect(connectionHandler).toHaveBeenCalledTimes(1);
+    });
+
+    it("doesn't block connection on failed handler", async ({ expect }) => {
+      const error = new Error("unable to connect");
+      connectionHandler.mockRejectedValue(error);
+
+      const manager = new ConnectionManager({ getCredentials: vi.fn() });
+      await expect(manager.get("wss://example.com/")).rejects.toThrowError(
+        error,
+      );
+      await expect(manager.get("wss://example.com/")).rejects.toThrowError(
+        error,
+      );
+      expect(connectionHandler).toHaveBeenCalledTimes(2);
+    });
+  });
+
   it("produces iterator of all connections", async ({ expect }) => {
     const manager = new ConnectionManager({ getCredentials: vi.fn() });
     await manager.get("wss://example-1.com/");
@@ -153,6 +198,31 @@ describe("ConnectionManager", () => {
       expect(connection2).toEqual(newConnection);
       expect(connection3).toEqual(newConnection);
     });
+
+    it("recovers if reconnection fails", async ({ expect }) => {
+      const error = new Error("couldn't create connection");
+      connectionHandler
+        .mockResolvedValueOnce({
+          connection: {},
+          onClose: connectionOnClose,
+        })
+        .mockRejectedValueOnce(error)
+        .mockResolvedValueOnce({
+          connection: {},
+          onClose: connectionOnClose,
+        });
+
+      const manager = new ConnectionManager({ getCredentials: vi.fn() });
+
+      const connection1 = await manager.get("wss://example.com/");
+      expect(connectionHandler).toHaveBeenCalledTimes(1);
+
+      await expect(connection1.reconnect()).rejects.toThrowError(error);
+      expect(connectionHandler).toHaveBeenCalledTimes(2);
+
+      await connection1.reconnect();
+      expect(connectionHandler).toHaveBeenCalledTimes(3);
+    });
   });
 
   describe("logout", () => {
@@ -198,10 +268,23 @@ describe("ConnectionManager", () => {
 });
 
 describe("connection handlers", () => {
+  window.WebSocket = {
+    CONNECTING: 0,
+    OPEN: 1,
+    CLOSING: 2,
+    CLOSED: 3,
+  } as unknown as (typeof window)["WebSocket"];
+
   describe("default", () => {
     let logout: Mock;
     let logoutCb: Mock;
-    const connection = {} as ConnectionWithFacades;
+    const connection = {
+      transport: {
+        _ws: {
+          readyState: WebSocket.CONNECTING,
+        },
+      },
+    } as unknown as ConnectionWithFacades;
     let connectAndLoginSpy: MockInstance;
     let startPingerLoopSpy: MockInstance;
     let stopPingerLoopSpy: MockInstance;
@@ -244,17 +327,6 @@ describe("connection handlers", () => {
       expect(result.connection).toEqual(connection);
     });
 
-    it("calls connection logout on close", async ({ expect }) => {
-      const result = await defaultHandler("wss://example.com", undefined);
-      expect(result.onClose).not.toBeUndefined();
-      expect(logout).not.toHaveBeenCalled();
-      await result.onClose?.();
-
-      expect(logout).toHaveBeenCalledTimes(1);
-      expect(logoutCb).toHaveBeenCalledTimes(1);
-      expect(stopPingerLoopSpy).toHaveBeenCalledExactlyOnceWith(1234);
-    });
-
     it("throws error on timeout", async ({ expect }) => {
       vi.useFakeTimers();
       connectAndLoginSpy.mockReturnValue(new Promise(() => {}));
@@ -264,10 +336,47 @@ describe("connection handlers", () => {
         Label.LOGIN_TIMEOUT_ERROR,
       );
     });
+
+    describe("on close", () => {
+      let onClose: Awaited<ReturnType<typeof defaultHandler>>["onClose"];
+
+      beforeEach(async () => {
+        const result = await defaultHandler("wss://example.com", undefined);
+        ({ onClose } = result);
+      });
+
+      it("calls connection logout", async ({ expect }) => {
+        expect(onClose).not.toBeUndefined();
+        expect(logout).not.toHaveBeenCalled();
+        await onClose?.();
+
+        expect(logout).toHaveBeenCalledTimes(1);
+        expect(logoutCb).toHaveBeenCalledTimes(1);
+        expect(stopPingerLoopSpy).toHaveBeenCalledExactlyOnceWith(1234);
+      });
+
+      it("doesn't block if connection already closed", async ({ expect }) => {
+        // @ts-expect-error - Re-assigning mocked readonly property.
+        connection.transport._ws.readyState = WebSocket.CLOSED;
+        // Mock to never call the callback, as if logout never completes.
+        logout.mockImplementation(() => {});
+
+        expect(onClose).not.toBeUndefined();
+        await onClose?.();
+        expect(stopPingerLoopSpy).toHaveBeenCalledTimes(1);
+        expect(logout).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe("controller", () => {
-    const connection = {} as ConnectionWithFacades;
+    const connection = {
+      transport: {
+        _ws: {
+          readyState: WebSocket.OPEN,
+        },
+      },
+    } as unknown as ConnectionWithFacades;
     const intervalId = 1234;
     let bakeryResult: Awaited<
       ReturnType<(typeof jujuModule)["loginWithBakery"]>
@@ -333,6 +442,14 @@ describe("connection handlers", () => {
         expect(onClose).not.toBeUndefined();
         await onClose?.();
         expect(clearIntervalSpy).toHaveBeenCalledExactlyOnceWith(intervalId);
+      });
+
+      it("doesn't block if connection already closed", async ({ expect }) => {
+        // @ts-expect-error - Re-assigning mocked readonly property.
+        connection.transport._ws.readyState = WebSocket.CLOSED;
+        expect(onClose).not.toBeUndefined();
+        await onClose?.();
+        expect(juju.logout).not.toHaveBeenCalled();
       });
     });
   });

--- a/src/store/middleware/connection/connection-manager.ts
+++ b/src/store/middleware/connection/connection-manager.ts
@@ -80,6 +80,11 @@ export const CONNECTION_HANDLERS_BY_PATH: Record<
       onClose: async (): Promise<void> => {
         await new Promise<void>((resolve) => {
           stopPingerLoop(intervalId);
+          if (conn.transport._ws.readyState === WebSocket.CLOSED) {
+            logger.warn("connection has already closed");
+            resolve();
+            return;
+          }
           logout((code, cb) => {
             resolve();
             cb(code);
@@ -126,6 +131,11 @@ export const CONNECTION_HANDLERS_BY_PATH: Record<
         }
         if (juju) {
           await new Promise<void>((resolve) => {
+            if (connection.transport._ws.readyState === WebSocket.CLOSED) {
+              logger.warn("connection has already closed");
+              resolve();
+              return;
+            }
             juju.logout((code, cb) => {
               resolve();
               cb(code);
@@ -202,6 +212,9 @@ export class ConnectionManager {
     const connectionPromise = Promise.withResolvers<ManagedConnection>();
     this.connections.set(wsURL, connectionPromise.promise);
 
+    // Always have something handling the error, so that it doesn't become unhandled.
+    connectionPromise.promise.catch(() => {});
+
     const credentials = this.hooks.getCredentials(wsURL);
 
     // Extract the path to determine the connection handler.
@@ -222,7 +235,17 @@ export class ConnectionManager {
       CONNECTION_HANDLERS_BY_PATH[path] ??
       CONNECTION_HANDLERS_BY_PATH[DefaultHandler];
 
-    const { connection, onClose } = await connectionHandler(wsURL, credentials);
+    let connectionResult = null;
+    try {
+      connectionResult = await connectionHandler(wsURL, credentials);
+    } catch (error) {
+      // If an error is thrown when connecting, clear this connection and continue throwing it.
+      logger.warn(`failed to connect to ${wsURL}`, error);
+      this.connections.delete(wsURL);
+      connectionPromise.reject(error);
+      throw error;
+    }
+    const { connection, onClose } = connectionResult;
 
     // Force cast the connection type, then add the extra fields.
     const managedConnection = Object.assign(connection, {
@@ -233,14 +256,15 @@ export class ConnectionManager {
           await this.logout(wsURL);
         }
 
-        // Trigger re-connecting the connection. If it's already being connected, this will be
-        // handled within.
-        const newConnection = await this.get(wsURL);
-
-        // Connection is finished reconnecting.
-        this.reconnecting.delete(wsURL);
-
-        return newConnection;
+        try {
+          // Trigger re-connecting the connection. If it's already being connected, this will be
+          // handled within.
+          const newConnection = await this.get(wsURL);
+          return newConnection;
+        } finally {
+          // Connection is finished reconnecting, successfully or not.
+          this.reconnecting.delete(wsURL);
+        }
       },
     });
 

--- a/src/store/middleware/model-poller.test.ts
+++ b/src/store/middleware/model-poller.test.ts
@@ -1,4 +1,4 @@
-import type { Client, Transport } from "@canonical/jujulib";
+import type { Client } from "@canonical/jujulib";
 import { Connection } from "@canonical/jujulib";
 import { waitFor } from "@testing-library/dom";
 import type { UnknownAction, MiddlewareAPI, Dispatch } from "redux";
@@ -132,7 +132,6 @@ describe("model poller", () => {
         identity: "user-eggman",
       },
     };
-    conn.transport = {} as Transport;
     juju = {
       logout: vi.fn(),
     } as unknown as Client;

--- a/src/store/middleware/process/createProcess.ts
+++ b/src/store/middleware/process/createProcess.ts
@@ -45,7 +45,10 @@ export function createProcess<Payload, Status, Result>(
         return true;
       } else {
         // Status update.
-        dispatch(processActions.setStatus(payload, result.value));
+        const action = processActions.setStatus?.(payload, result.value);
+        if (action) {
+          dispatch(action);
+        }
         return false;
       }
     }

--- a/src/store/middleware/process/createProcess.ts
+++ b/src/store/middleware/process/createProcess.ts
@@ -74,6 +74,9 @@ export function createProcess<Payload, Status, Result>(
 
     // Mark process as not running.
     dispatch(processActions.setRunning(payload, false));
+
+    // Call any callback function.
+    hooks?.after?.(payload, dispatch);
   };
 
   return { actions, start };

--- a/src/store/middleware/process/index.ts
+++ b/src/store/middleware/process/index.ts
@@ -1,11 +1,16 @@
 import disableCommandProcess from "./block/disable-command";
 import createMiddleware from "./middleware";
+import { upgradeToProcess } from "./model-upgrade";
 import type { Process } from "./types";
 
 export type { ProcessOutcome, ProcessActions, Process } from "./types";
 
 // Re-export actions to trigger processes.
 export const disableCommand = disableCommandProcess.actions;
+export const upgradeTo = upgradeToProcess.actions;
 
 // Construct the middleware with process handlers.
-export default createMiddleware([disableCommandProcess as Process<unknown>]);
+export default createMiddleware([
+  disableCommandProcess as Process<unknown>,
+  upgradeToProcess as Process<unknown>,
+]);

--- a/src/store/middleware/process/model-upgrade/index.ts
+++ b/src/store/middleware/process/model-upgrade/index.ts
@@ -1,0 +1,1 @@
+export { default as upgradeToProcess } from "./upgrade-to";

--- a/src/store/middleware/process/model-upgrade/model-connection-retry-source.test.ts
+++ b/src/store/middleware/process/model-upgrade/model-connection-retry-source.test.ts
@@ -79,4 +79,29 @@ describe("modelConnectionRetrySource", () => {
 
     expect(reconnectMock).toHaveBeenCalledTimes(1);
   });
+
+  it("handles error thrown from reconnect", async ({ expect }) => {
+    fullStatusMock
+      .mockRejectedValueOnce(new Error("connection closed"))
+      .mockResolvedValueOnce({ model: { version: "1.2.3" } });
+    const error = new Error("couldn't connect");
+    reconnectMock
+      .mockRejectedValueOnce(error)
+      .mockResolvedValueOnce(connection);
+
+    const tryConnection = createModelConnectionRetry(connection);
+
+    // Will clear the connection.
+    await expect(tryConnection()).resolves.toEqual({ reconnecting: true });
+    expect(fullStatusMock).toHaveBeenCalledTimes(1);
+    expect(reconnectMock).not.toHaveBeenCalled();
+
+    await expect(tryConnection()).resolves.toEqual({ reconnecting: true });
+    expect(fullStatusMock).toHaveBeenCalledTimes(1);
+    expect(reconnectMock).toHaveBeenCalledTimes(1);
+
+    await expect(tryConnection()).resolves.toEqual({ version: "1.2.3" });
+    expect(fullStatusMock).toHaveBeenCalledTimes(2);
+    expect(reconnectMock).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/store/middleware/process/model-upgrade/model-connection-retry-source.test.ts
+++ b/src/store/middleware/process/model-upgrade/model-connection-retry-source.test.ts
@@ -1,0 +1,82 @@
+import type { Mock } from "vitest";
+
+import type { ManagedConnection } from "store/middleware/connection/connection-manager";
+
+import { createModelConnectionRetry } from "./model-connection-retry-source";
+
+describe("modelConnectionRetrySource", () => {
+  let connection: ManagedConnection;
+  let fullStatusMock: Mock;
+  let reconnectMock: Mock;
+
+  beforeEach(() => {
+    fullStatusMock = vi.fn().mockResolvedValue({
+      model: {
+        version: "1.2.3",
+      },
+    });
+    reconnectMock = vi.fn().mockImplementation(async () => connection);
+    connection = {
+      facades: {
+        client: {
+          fullStatus: fullStatusMock,
+        },
+      },
+      reconnect: reconnectMock,
+    } as unknown as ManagedConnection;
+  });
+
+  it("calls `fullStatus` method on provided connection", async ({ expect }) => {
+    const tryConnection = createModelConnectionRetry(connection);
+    expect(fullStatusMock).not.toHaveBeenCalled();
+
+    await expect(tryConnection()).resolves.toEqual({ version: "1.2.3" });
+    expect(fullStatusMock).toHaveBeenCalledTimes(1);
+
+    await expect(tryConnection()).resolves.toEqual({ version: "1.2.3" });
+    expect(fullStatusMock).toHaveBeenCalledTimes(2);
+
+    await expect(tryConnection()).resolves.toEqual({ version: "1.2.3" });
+    expect(fullStatusMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("throws error if `client` facade isn't present", async ({ expect }) => {
+    delete connection.facades.client;
+
+    const tryConnection = createModelConnectionRetry(connection);
+    await expect(tryConnection()).rejects.toThrowError(
+      "missing client facade on connection",
+    );
+  });
+
+  it("attempts reconnection if request fails", async ({ expect }) => {
+    fullStatusMock.mockRejectedValue(new Error("connection closed"));
+
+    const tryConnection = createModelConnectionRetry(connection);
+    expect(reconnectMock).toHaveBeenCalledTimes(0);
+    await expect(tryConnection()).resolves.toEqual({ reconnecting: true });
+    expect(reconnectMock).toHaveBeenCalledTimes(0);
+
+    // Trigger re-connection
+    await tryConnection();
+    expect(reconnectMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("doesn't initiate multiple reconnect attempts", async ({ expect }) => {
+    fullStatusMock.mockRejectedValue(new Error("connection closed"));
+    const reconnectPromise = Promise.withResolvers();
+    reconnectMock.mockReturnValue(reconnectPromise.promise);
+
+    const tryConnection = createModelConnectionRetry(connection);
+
+    // Will clear the connection.
+    await expect(tryConnection()).resolves.toEqual({ reconnecting: true });
+
+    // Trigger re-connection
+    void tryConnection();
+    void tryConnection();
+    void tryConnection();
+
+    expect(reconnectMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/store/middleware/process/model-upgrade/model-connection-retry-source.ts
+++ b/src/store/middleware/process/model-upgrade/model-connection-retry-source.ts
@@ -32,7 +32,14 @@ export function createModelConnectionRetry(modelConnection: ManagedConnection) {
       connection = modelConnection.reconnect();
     }
 
-    const currentConnection = await connection;
+    let currentConnection: ManagedConnection | null = null;
+    try {
+      currentConnection = await connection;
+    } catch (error) {
+      logger.warn("caught error, assuming reconnecting", error);
+      connection = null;
+      return { reconnecting: true };
+    }
 
     if (!currentConnection.facades.client) {
       throw new Error("missing client facade on connection");

--- a/src/store/middleware/process/model-upgrade/model-connection-retry-source.ts
+++ b/src/store/middleware/process/model-upgrade/model-connection-retry-source.ts
@@ -1,0 +1,44 @@
+import type { FullStatus } from "@canonical/jujulib/dist/api/facades/client/ClientV8";
+
+import type { Source } from "data";
+import { createPollingSource } from "data/pollingSource";
+import type { ManagedConnection } from "store/middleware/connection/connection-manager";
+import { logger } from "utils/logger";
+
+/**
+ * Timeout in seconds to poll the model status.
+ */
+const MODEL_STATUS_POLL_S = 5;
+
+export default function createModelConnectionRetrySource(
+  modelConnection: ManagedConnection,
+): Source<{ reconnecting: true } | { version: string }> {
+  let connection: ManagedConnection | null = modelConnection;
+  return createPollingSource(
+    async () => {
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+      if (!connection) {
+        connection = await modelConnection.reconnect();
+      }
+
+      let status: FullStatus | undefined = undefined;
+      try {
+        status = await connection.facades.client?.fullStatus({
+          patterns: [],
+        });
+      } catch (error) {
+        // Client throws an error if the socket is closed. Begin reconnecting.
+        logger.warn("caught error, assuming disconnected", error);
+        connection = null;
+        return { reconnecting: true };
+      }
+
+      if (!status) {
+        throw new Error("Status not produced");
+      }
+
+      return { version: status.model.version };
+    },
+    { interval: { seconds: MODEL_STATUS_POLL_S } },
+  );
+}

--- a/src/store/middleware/process/model-upgrade/model-connection-retry-source.ts
+++ b/src/store/middleware/process/model-upgrade/model-connection-retry-source.ts
@@ -26,11 +26,8 @@ export function createModelConnectionRetry(modelConnection: ManagedConnection) {
     Promise.resolve(modelConnection);
 
   return async (): Promise<ConnectionRetryResult> => {
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    if (!connection) {
-      // Only initiate a connection if there isn't an existing one.
-      connection = modelConnection.reconnect();
-    }
+    // Only initiate a connection if there isn't an existing one.
+    connection ??= modelConnection.reconnect();
 
     let currentConnection: ManagedConnection | null = null;
     try {

--- a/src/store/middleware/process/model-upgrade/model-connection-retry-source.ts
+++ b/src/store/middleware/process/model-upgrade/model-connection-retry-source.ts
@@ -10,35 +10,58 @@ import { logger } from "utils/logger";
  */
 const MODEL_STATUS_POLL_S = 5;
 
+type ConnectionRetryResult = { reconnecting: true } | { version: string };
+
+/**
+ * Internal logic for `createModelConnectionRetrySource`.
+ *
+ * Saves a connection, and whenever the returned function is called, it will try to call the
+ * `fullStatus` facade method. If the call fails, it will clear the connection, and attempt to
+ * reconnect on the next call.
+ */
+export function createModelConnectionRetry(modelConnection: ManagedConnection) {
+  // A promise which will resolve to the current connection, or `null` if a connection needs to be
+  // initiated.
+  let connection: null | Promise<ManagedConnection> =
+    Promise.resolve(modelConnection);
+
+  return async (): Promise<ConnectionRetryResult> => {
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+    if (!connection) {
+      // Only initiate a connection if there isn't an existing one.
+      connection = modelConnection.reconnect();
+    }
+
+    const currentConnection = await connection;
+
+    if (!currentConnection.facades.client) {
+      throw new Error("missing client facade on connection");
+    }
+
+    let status: FullStatus | undefined = undefined;
+    try {
+      status = await currentConnection.facades.client.fullStatus({
+        patterns: [],
+      });
+    } catch (error) {
+      // Client throws an error if the socket is closed. Begin reconnecting.
+      logger.warn("caught error, assuming disconnected", error);
+      connection = null;
+      return { reconnecting: true };
+    }
+
+    return { version: status.model.version };
+  };
+}
+
+/**
+ * A source which will produce the version of a model, or an indication that it's being reconnected
+ * to.
+ */
 export default function createModelConnectionRetrySource(
   modelConnection: ManagedConnection,
-): Source<{ reconnecting: true } | { version: string }> {
-  let connection: ManagedConnection | null = modelConnection;
-  return createPollingSource(
-    async () => {
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-      if (!connection) {
-        connection = await modelConnection.reconnect();
-      }
-
-      let status: FullStatus | undefined = undefined;
-      try {
-        status = await connection.facades.client?.fullStatus({
-          patterns: [],
-        });
-      } catch (error) {
-        // Client throws an error if the socket is closed. Begin reconnecting.
-        logger.warn("caught error, assuming disconnected", error);
-        connection = null;
-        return { reconnecting: true };
-      }
-
-      if (!status) {
-        throw new Error("Status not produced");
-      }
-
-      return { version: status.model.version };
-    },
-    { interval: { seconds: MODEL_STATUS_POLL_S } },
-  );
+): Source<ConnectionRetryResult> {
+  return createPollingSource(createModelConnectionRetry(modelConnection), {
+    interval: { seconds: MODEL_STATUS_POLL_S },
+  });
 }

--- a/src/store/middleware/process/model-upgrade/upgrade-to.test.ts
+++ b/src/store/middleware/process/model-upgrade/upgrade-to.test.ts
@@ -1,0 +1,266 @@
+import type { Mock, MockInstance } from "vitest";
+
+import type { Source } from "data";
+import * as jimmApi from "juju/jimm/api";
+import type { ManagedConnection } from "store/middleware/connection/connection-manager";
+
+import * as modelConnectionRetrySourceModule from "./model-connection-retry-source";
+import { upgradeTo, default as upgradeToProcess } from "./upgrade-to";
+
+describe("upgradeTo", () => {
+  let controllerConnection: ManagedConnection;
+  let modelConnection: ManagedConnection;
+
+  let upgradeToMock: MockInstance;
+  let modelStatusSourceDoneMock: Mock;
+  let modelStatusSource: MockInstance;
+  let modelStatusSourceImplementation: Source<
+    { reconnecting: true } | { version: string }
+  >;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+
+    controllerConnection = {} as ManagedConnection;
+    modelConnection = {} as ManagedConnection;
+
+    upgradeToMock = vi.spyOn(jimmApi, "upgradeTo").mockResolvedValue(true);
+    modelStatusSourceDoneMock = vi.fn();
+    modelStatusSourceImplementation = {
+      done: modelStatusSourceDoneMock,
+      [Symbol.asyncIterator]: async function* () {
+        yield { version: "1.2.3" };
+      },
+    } as unknown as Source<{ reconnecting: true } | { version: string }>;
+    modelStatusSource = vi
+      .spyOn(modelConnectionRetrySourceModule, "default")
+      .mockReturnValue(modelStatusSourceImplementation);
+  });
+
+  describe("JIMM `upgradeTo` request", () => {
+    it("calls on controller connection with correct model tag", async ({
+      expect,
+    }) => {
+      expect.assertions(2);
+      const progress = upgradeTo(
+        "abc123",
+        "some-controller",
+        "1.2.3",
+        controllerConnection,
+        modelConnection,
+      );
+
+      await expect(progress.next()).resolves.toEqual({
+        done: false,
+        value: { status: "pending" },
+      });
+      expect(upgradeToMock).toHaveBeenCalledExactlyOnceWith(
+        controllerConnection,
+        "model-abc123",
+        "some-controller",
+      );
+    });
+
+    it("throws an error if request isn't successful", async ({ expect }) => {
+      expect.assertions(3);
+      upgradeToMock.mockResolvedValue(false);
+      const progress = upgradeTo(
+        "abc123",
+        "some-controller",
+        "1.2.3",
+        controllerConnection,
+        modelConnection,
+      );
+
+      await expect(progress.next()).resolves.toEqual({
+        done: false,
+        value: { status: "pending" },
+      });
+      expect(upgradeToMock).toHaveBeenCalledExactlyOnceWith(
+        controllerConnection,
+        "model-abc123",
+        "some-controller",
+      );
+
+      await expect(progress.next()).rejects.toThrowError(
+        "migration request rejected",
+      );
+    });
+  });
+
+  describe("model `fullStatus` polling", () => {
+    it("begins polling model after success", async ({ expect }) => {
+      expect.assertions(1);
+      const progress = upgradeTo(
+        "abc123",
+        "some-controller",
+        "1.2.3",
+        controllerConnection,
+        modelConnection,
+      );
+
+      await progress.next(); // Pending
+      await progress.next(); // Initiating
+
+      void progress.next();
+      expect(modelStatusSource).toHaveBeenCalledExactlyOnceWith(
+        modelConnection,
+      );
+    });
+
+    describe("while polling", () => {
+      let promises: PromiseWithResolvers<
+        { reconnecting: true } | { version: string }
+      >[];
+
+      beforeEach(() => {
+        promises = new Array(10).fill(null).map(() => Promise.withResolvers());
+        modelStatusSourceImplementation[Symbol.asyncIterator] =
+          async function* (): AsyncGenerator<
+            { reconnecting: true } | { version: string },
+            void,
+            void
+          > {
+            for (const { promise } of promises) {
+              yield await promise;
+            }
+          };
+      });
+
+      it("doesn't advance until version matches", async ({ expect }) => {
+        expect.assertions(4);
+        const progress = upgradeTo(
+          "abc123",
+          "some-controller",
+          "1.2.3",
+          controllerConnection,
+          modelConnection,
+        );
+
+        await progress.next(); // Pending
+        await progress.next(); // Initiating
+
+        const statusResolvedMock = vi.fn();
+        const nextStatus = progress
+          .next()
+          .then(statusResolvedMock.mockImplementation((value) => value));
+
+        promises[0].resolve({ version: "0.0.0" });
+        await vi.runOnlyPendingTimersAsync();
+        expect(statusResolvedMock).not.toHaveBeenCalled();
+
+        promises[1].resolve({ version: "0.0.0" });
+        await vi.runOnlyPendingTimersAsync();
+        expect(statusResolvedMock).not.toHaveBeenCalled();
+
+        promises[2].resolve({ version: "1.2.3" });
+        await vi.runOnlyPendingTimersAsync();
+        expect(statusResolvedMock).toHaveBeenCalledOnce();
+
+        await expect(nextStatus).resolves.toEqual({ done: true });
+      });
+
+      it("calls `done` on source after completion", async ({ expect }) => {
+        expect.assertions(1);
+        const progress = upgradeTo(
+          "abc123",
+          "some-controller",
+          "1.2.3",
+          controllerConnection,
+          modelConnection,
+        );
+
+        promises[0].resolve({ version: "1.2.3" });
+
+        await progress.next(); // Pending
+        await progress.next(); // Initiating
+        await progress.next(); // Done
+
+        expect(modelStatusSourceDoneMock).toHaveBeenCalledOnce();
+      });
+
+      it("emits status when reconnecting", async ({ expect }) => {
+        expect.assertions(3);
+        const progress = upgradeTo(
+          "abc123",
+          "some-controller",
+          "1.2.3",
+          controllerConnection,
+          modelConnection,
+        );
+
+        await progress.next(); // Pending
+        await progress.next(); // Initiating
+
+        const statusResolvedMock = vi.fn();
+        const nextStatus = progress
+          .next()
+          .then(statusResolvedMock.mockImplementation((value) => value));
+
+        promises[0].resolve({ version: "0.0.0" });
+        await vi.runOnlyPendingTimersAsync();
+        expect(statusResolvedMock).not.toHaveBeenCalled();
+
+        promises[1].resolve({ reconnecting: true });
+        await vi.runOnlyPendingTimersAsync();
+        expect(statusResolvedMock).toHaveBeenCalled();
+
+        await expect(nextStatus).resolves.toEqual({
+          value: { status: "reconnecting" },
+          done: false,
+        });
+      });
+
+      it("emits loading status at an interval", async ({ expect }) => {
+        expect.assertions(2);
+        const progress = upgradeTo(
+          "abc123",
+          "some-controller",
+          "1.2.3",
+          controllerConnection,
+          modelConnection,
+        );
+
+        await progress.next(); // Pending
+        await progress.next(); // Initiating
+
+        promises.slice(0, promises.length - 1).map(({ resolve }) => {
+          resolve({ version: "0.0.0" });
+        });
+        promises[promises.length - 1].resolve({ version: "1.2.3" });
+
+        await expect(progress.next()).resolves.toEqual({
+          value: { status: "loading" },
+          done: false,
+        });
+
+        await expect(progress.next()).resolves.toEqual({
+          done: true,
+        });
+      });
+    });
+  });
+});
+
+describe("action", () => {
+  it("contains meta properties", ({ expect }) => {
+    const action = upgradeToProcess.actions.run({
+      wsControllerURL: "wss://example.com/api",
+      modelName: "some-model",
+      modelUUID: "abc123",
+      modelURL: "wss://example.com/model/abc123/api",
+      currentVersion: "0.0.0",
+      targetVersion: "1.2.3",
+      targetController: "some-controller",
+    });
+
+    expect(action).toEqual(
+      expect.objectContaining({
+        meta: {
+          withConnection: true,
+          connectionList: ["wsControllerURL", "modelURL"],
+        },
+      }),
+    );
+  });
+});

--- a/src/store/middleware/process/model-upgrade/upgrade-to.ts
+++ b/src/store/middleware/process/model-upgrade/upgrade-to.ts
@@ -1,0 +1,212 @@
+import type { FullStatus } from "@canonical/jujulib/dist/api/facades/client/ClientV8";
+import type { PayloadAction } from "@reduxjs/toolkit";
+
+import { createPollingSource } from "data/pollingSource";
+import type { Source } from "data/source";
+import * as jimmApi from "juju/jimm/api";
+import { createToast } from "store/app/actions";
+import { actions as jujuActions } from "store/juju";
+import type { ManagedConnection } from "store/middleware/connection/connection-manager";
+import { hasConnections } from "store/middleware/connection/util";
+import modelList from "store/middleware/source/model-list";
+import { logger } from "utils/logger";
+
+import { createProcess } from "../createProcess";
+
+export type UpgradeStatus =
+  | { status: "initiated" }
+  | { status: "loading" }
+  | { status: "pending" }
+  | { status: "reconnecting" };
+
+const REQUIRED_CONNECTIONS = ["wsControllerURL", "modelURL"];
+/**
+ * Timeout in seconds to poll the model status.
+ */
+const MODEL_STATUS_POLL_S = 5;
+/**
+ * Number of poll requests between each toast.
+ */
+const STATUS_TOAST_INTERVAL = 5;
+
+type Params = {
+  wsControllerURL: string;
+  modelName: string;
+  modelUUID: string;
+  modelURL: string;
+  currentVersion: string;
+  targetVersion: string;
+  targetController: string;
+};
+
+export function createModelConnectionRetrySource(
+  modelConnection: ManagedConnection,
+): Source<{ reconnecting: true } | { version: string }> {
+  let connection: ManagedConnection | null = modelConnection;
+  return createPollingSource(
+    async () => {
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+      if (!connection) {
+        connection = await modelConnection.reconnect();
+      }
+
+      let status: FullStatus | undefined = undefined;
+      try {
+        status = await connection.facades.client?.fullStatus({
+          patterns: [],
+        });
+      } catch (error) {
+        // Client throws an error if the socket is closed. Begin reconnecting.
+        logger.warn("caught error, assuming disconnected", error);
+        connection = null;
+        return { reconnecting: true };
+      }
+
+      if (!status) {
+        throw new Error("Status not produced");
+      }
+
+      return { version: status.model.version };
+    },
+    { interval: { seconds: MODEL_STATUS_POLL_S } },
+  );
+}
+
+export async function* upgradeTo(
+  modelUUID: string,
+  targetController: string,
+  targetVersion: string,
+  controllerConnection: ManagedConnection,
+  modelConnection: ManagedConnection,
+): AsyncGenerator<UpgradeStatus, void, void> {
+  const modelTag = `model-${modelUUID}`;
+
+  const request = jimmApi.upgradeTo(
+    controllerConnection,
+    modelTag,
+    targetController,
+  );
+  yield { status: "pending" };
+  const result = await request;
+
+  if (!result) {
+    throw new Error("migration request rejected");
+  }
+
+  yield { status: "initiated" };
+
+  // Poll for model version.
+  const source = createModelConnectionRetrySource(modelConnection);
+  let statusCount = 0;
+  for await (const retry of source) {
+    if ("version" in retry) {
+      if (retry.version === targetVersion) {
+        break;
+      }
+      // Send a toast to to inform the user that it's in progress.
+      statusCount += 1;
+      if (statusCount % STATUS_TOAST_INTERVAL === 0) {
+        yield { status: "loading" };
+      }
+    } else {
+      statusCount = 0;
+      yield { status: "reconnecting" };
+    }
+  }
+  source.done();
+}
+
+export default createProcess<Params, UpgradeStatus, void>(
+  "model-upgrade/upgrade-to",
+  async function* ({
+    modelUUID,
+    targetController,
+    targetVersion,
+    meta,
+  }): AsyncGenerator<UpgradeStatus, void, void> {
+    if (!hasConnections(meta, REQUIRED_CONNECTIONS)) {
+      throw new Error("missing connections");
+    }
+
+    const controllerConnection = meta.connections.wsControllerURL;
+    const modelConnection = meta.connections.modelURL;
+
+    return yield* upgradeTo(
+      modelUUID,
+      targetController,
+      targetVersion,
+      controllerConnection,
+      modelConnection,
+    );
+  },
+  {
+    setOutcome: (
+      { modelUUID, modelName, targetController, targetVersion },
+      outcome,
+    ) => {
+      if ("error" in outcome) {
+        logger.error(
+          "An error occurred during model upgrade",
+          modelUUID,
+          outcome.error,
+        );
+        return createToast({
+          message: `Error during upgrade of '${modelName}': ${outcome.error.message}`,
+          severity: "negative",
+        });
+      } else {
+        return createToast({
+          message: `Upgrade of '${modelName}' to version ${targetVersion} on ${targetController} completed.`,
+          severity: "positive",
+        });
+      }
+    },
+    setStatus: ({ modelUUID, modelName }, status) => {
+      let message: string | undefined = undefined;
+      switch (status.status) {
+        case "pending":
+          message = `Upgrade of '${modelName}' requested`;
+          break;
+        case "initiated":
+          message = `Upgrade of '${modelName}' initiated`;
+          break;
+        case "loading":
+          message = `Upgrade of '${modelName}' in progress`;
+          break;
+        case "reconnecting":
+          message = `Attempting to reconnect to '${modelName}'`;
+          break;
+        default:
+          logger.warn("An unknown status was emitted", modelUUID, status);
+          break;
+      }
+
+      if (!message) {
+        // Don't toast anything if there's no message.
+        return {} as PayloadAction;
+      }
+
+      return createToast({ message, severity: "information" });
+    },
+    setRunning: ({ modelUUID, targetVersion, currentVersion }, running) => {
+      if (running) {
+        return jujuActions.addModelUpgrade({
+          modelUUID,
+          currentVersion,
+          upgradeVersion: targetVersion,
+        });
+      } else {
+        return jujuActions.removeModelUpgrade({ modelUUID });
+      }
+    },
+  },
+  {
+    addActionMeta: () => ({
+      withConnection: true,
+      connectionList: REQUIRED_CONNECTIONS,
+    }),
+    after: ({ wsControllerURL }, dispatch) => {
+      dispatch(modelList.actions.invalidate({ wsControllerURL }));
+    },
+  },
+);

--- a/src/store/middleware/process/model-upgrade/upgrade-to.ts
+++ b/src/store/middleware/process/model-upgrade/upgrade-to.ts
@@ -1,8 +1,5 @@
-import type { FullStatus } from "@canonical/jujulib/dist/api/facades/client/ClientV8";
 import type { PayloadAction } from "@reduxjs/toolkit";
 
-import { createPollingSource } from "data/pollingSource";
-import type { Source } from "data/source";
 import * as jimmApi from "juju/jimm/api";
 import { createToast } from "store/app/actions";
 import { actions as jujuActions } from "store/juju";
@@ -13,6 +10,8 @@ import { logger } from "utils/logger";
 
 import { createProcess } from "../createProcess";
 
+import createModelConnectionRetrySource from "./model-connection-retry-source";
+
 export type UpgradeStatus =
   | { status: "initiated" }
   | { status: "loading" }
@@ -20,10 +19,6 @@ export type UpgradeStatus =
   | { status: "reconnecting" };
 
 const REQUIRED_CONNECTIONS = ["wsControllerURL", "modelURL"];
-/**
- * Timeout in seconds to poll the model status.
- */
-const MODEL_STATUS_POLL_S = 5;
 /**
  * Number of poll requests between each toast.
  */
@@ -38,39 +33,6 @@ type Params = {
   targetVersion: string;
   targetController: string;
 };
-
-export function createModelConnectionRetrySource(
-  modelConnection: ManagedConnection,
-): Source<{ reconnecting: true } | { version: string }> {
-  let connection: ManagedConnection | null = modelConnection;
-  return createPollingSource(
-    async () => {
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-      if (!connection) {
-        connection = await modelConnection.reconnect();
-      }
-
-      let status: FullStatus | undefined = undefined;
-      try {
-        status = await connection.facades.client?.fullStatus({
-          patterns: [],
-        });
-      } catch (error) {
-        // Client throws an error if the socket is closed. Begin reconnecting.
-        logger.warn("caught error, assuming disconnected", error);
-        connection = null;
-        return { reconnecting: true };
-      }
-
-      if (!status) {
-        throw new Error("Status not produced");
-      }
-
-      return { version: status.model.version };
-    },
-    { interval: { seconds: MODEL_STATUS_POLL_S } },
-  );
-}
 
 export async function* upgradeTo(
   modelUUID: string,

--- a/src/store/middleware/process/model-upgrade/upgrade-to.ts
+++ b/src/store/middleware/process/model-upgrade/upgrade-to.ts
@@ -1,5 +1,3 @@
-import type { PayloadAction } from "@reduxjs/toolkit";
-
 import * as jimmApi from "juju/jimm/api";
 import { createToast } from "store/app/actions";
 import { actions as jujuActions } from "store/juju";
@@ -12,11 +10,16 @@ import { createProcess } from "../createProcess";
 
 import createModelConnectionRetrySource from "./model-connection-retry-source";
 
-export type UpgradeStatus =
-  | { status: "initiated" }
-  | { status: "loading" }
-  | { status: "pending" }
-  | { status: "reconnecting" };
+enum UpgradeStatus {
+  INITIATED = "initiated",
+  LOADING = "loading",
+  PENDING = "pending",
+  RECONNECTING = "reconnecting",
+}
+
+type UpgradeState = {
+  status: UpgradeStatus;
+};
 
 const REQUIRED_CONNECTIONS = ["wsControllerURL", "modelURL"];
 /**
@@ -40,7 +43,7 @@ export async function* upgradeTo(
   targetVersion: string,
   controllerConnection: ManagedConnection,
   modelConnection: ManagedConnection,
-): AsyncGenerator<UpgradeStatus, void, void> {
+): AsyncGenerator<UpgradeState, void, void> {
   const modelTag = `model-${modelUUID}`;
 
   const request = jimmApi.upgradeTo(
@@ -48,14 +51,14 @@ export async function* upgradeTo(
     modelTag,
     targetController,
   );
-  yield { status: "pending" };
+  yield { status: UpgradeStatus.PENDING };
   const result = await request;
 
   if (!result) {
     throw new Error("migration request rejected");
   }
 
-  yield { status: "initiated" };
+  yield { status: UpgradeStatus.INITIATED };
 
   // Poll for model version.
   const source = createModelConnectionRetrySource(modelConnection);
@@ -63,29 +66,30 @@ export async function* upgradeTo(
   for await (const retry of source) {
     if ("version" in retry) {
       if (retry.version === targetVersion) {
+        // The model has reached the target version so the source can now finish.
         break;
       }
       // Send a toast to to inform the user that it's in progress.
       statusCount += 1;
       if (statusCount % STATUS_TOAST_INTERVAL === 0) {
-        yield { status: "loading" };
+        yield { status: UpgradeStatus.LOADING };
       }
     } else {
       statusCount = 0;
-      yield { status: "reconnecting" };
+      yield { status: UpgradeStatus.RECONNECTING };
     }
   }
   source.done();
 }
 
-export default createProcess<Params, UpgradeStatus, void>(
+export default createProcess<Params, UpgradeState, void>(
   "model-upgrade/upgrade-to",
   async function* ({
     modelUUID,
     targetController,
     targetVersion,
     meta,
-  }): AsyncGenerator<UpgradeStatus, void, void> {
+  }): AsyncGenerator<UpgradeState, void, void> {
     if (!hasConnections(meta, REQUIRED_CONNECTIONS)) {
       throw new Error("missing connections");
     }
@@ -121,20 +125,22 @@ export default createProcess<Params, UpgradeStatus, void>(
       }
     },
     setStatus: ({ modelUUID, modelName }, status) => {
-      let message: string | undefined = undefined;
+      let message: null | string = null;
       switch (status.status) {
-        case "pending":
-          logger.info(`${modelName} (${modelUUID}) upgrade pending`);
+        case UpgradeStatus.PENDING:
+          logger.debug(`${modelName} (${modelUUID}) upgrade pending`);
           message = `Upgrading model "${modelName}"…`;
           break;
-        case "initiated":
-          logger.info(`${modelName} (${modelUUID}) upgrade initiated`);
+        case UpgradeStatus.INITIATED:
+          logger.debug(`${modelName} (${modelUUID}) upgrade initiated`);
           break;
-        case "loading":
-          logger.info(`${modelName} (${modelUUID}) upgrade loading`);
+        case UpgradeStatus.LOADING:
+          logger.debug(`${modelName} (${modelUUID}) upgrade loading`);
           break;
-        case "reconnecting":
-          logger.info(`Attempting to reconnect to ${modelName} (${modelUUID})`);
+        case UpgradeStatus.RECONNECTING:
+          logger.debug(
+            `Attempting to reconnect to ${modelName} (${modelUUID})`,
+          );
           break;
         default:
           logger.warn("An unknown status was emitted", modelUUID, status);
@@ -143,7 +149,7 @@ export default createProcess<Params, UpgradeStatus, void>(
 
       if (!message) {
         // Don't toast anything if there's no message.
-        return {} as PayloadAction;
+        return;
       }
 
       return createToast({ message, severity: "information" });

--- a/src/store/middleware/process/model-upgrade/upgrade-to.ts
+++ b/src/store/middleware/process/model-upgrade/upgrade-to.ts
@@ -102,10 +102,7 @@ export default createProcess<Params, UpgradeStatus, void>(
     );
   },
   {
-    setOutcome: (
-      { modelUUID, modelName, targetController, targetVersion },
-      outcome,
-    ) => {
+    setOutcome: ({ modelUUID, modelName, targetVersion }, outcome) => {
       if ("error" in outcome) {
         logger.error(
           "An error occurred during model upgrade",
@@ -113,12 +110,12 @@ export default createProcess<Params, UpgradeStatus, void>(
           outcome.error,
         );
         return createToast({
-          message: `Error during upgrade of '${modelName}': ${outcome.error.message}`,
+          message: `Error during upgrade of "${modelName}": ${outcome.error.message}`,
           severity: "negative",
         });
       } else {
         return createToast({
-          message: `Upgrade of '${modelName}' to version ${targetVersion} on ${targetController} completed.`,
+          message: `Model "${modelName}" upgraded to ${targetVersion}`,
           severity: "positive",
         });
       }
@@ -127,16 +124,17 @@ export default createProcess<Params, UpgradeStatus, void>(
       let message: string | undefined = undefined;
       switch (status.status) {
         case "pending":
-          message = `Upgrade of '${modelName}' requested`;
+          logger.info(`${modelName} (${modelUUID}) upgrade pending`);
+          message = `Upgrading model "${modelName}"…`;
           break;
         case "initiated":
-          message = `Upgrade of '${modelName}' initiated`;
+          logger.info(`${modelName} (${modelUUID}) upgrade initiated`);
           break;
         case "loading":
-          message = `Upgrade of '${modelName}' in progress`;
+          logger.info(`${modelName} (${modelUUID}) upgrade loading`);
           break;
         case "reconnecting":
-          message = `Attempting to reconnect to '${modelName}'`;
+          logger.info(`Attempting to reconnect to ${modelName} (${modelUUID})`);
           break;
         default:
           logger.warn("An unknown status was emitted", modelUUID, status);

--- a/src/store/middleware/process/types.ts
+++ b/src/store/middleware/process/types.ts
@@ -16,7 +16,10 @@ export type ProcessOutcome<Result> =
   | { result: Result };
 
 export type ProcessActions<Payload, Status, Result> = {
-  setStatus: (payload: Payload, status: Status) => PayloadAction<unknown>;
+  setStatus: (
+    payload: Payload,
+    status: Status,
+  ) => PayloadAction<unknown> | void;
   setRunning: (payload: Payload, running: boolean) => PayloadAction<unknown>;
   setOutcome: (
     payload: Payload,

--- a/src/store/middleware/process/types.ts
+++ b/src/store/middleware/process/types.ts
@@ -8,6 +8,7 @@ import type { Store } from "store/store";
 
 export type Hooks<P> = {
   addActionMeta?: (payload: P) => Record<string, unknown>;
+  after?: (args: P, store: Store["dispatch"]) => void;
 };
 
 export type ProcessOutcome<Result> =

--- a/src/testing/setup.ts
+++ b/src/testing/setup.ts
@@ -60,6 +60,12 @@ const Connection = vi.fn(function () {
       })),
     },
   };
+  // @ts-expect-error - Mocking a class.
+  this.transport = {
+    _ws: {
+      readyState: 0,
+    },
+  };
 });
 
 vi.mock("@canonical/jujulib", () => {
@@ -80,6 +86,14 @@ vi.mock("@canonical/jujulib", () => {
 vi.mock("@canonical/jujulib/dist/api/versions", () => ({
   jujuUpdateAvailable: vi.fn(),
 }));
+
+// Mock WebSocket associated constants, required for `connection-manager`.
+window.WebSocket = {
+  CONNECTING: 0,
+  OPEN: 1,
+  CLOSING: 2,
+  CLOSED: 3,
+} as unknown as (typeof window)["WebSocket"];
 
 afterEach(() => {
   localStorage.clear();


### PR DESCRIPTION
## Done

- Create `upgrade-to` process for use with JIMM
- Hook up process to upgrade form

## QA

- Open model upgrade panel
- Select an upgrade which requires a migration
- Click upgrade
- Look for:
  - Pending/initiated notifications
  - Periodic loading notifications
  - Notification that the model is reconnecting
  - Success notification on completion
- Model list should immediately update to reflect new versions when complete

Note: If an error occurs during the upgrade, it will not be displayed in any way, and the upgrade will continue to seem like it's loading. Additionally, if the dashboard is reloaded during an upgrade, the upgrade state will be lost.

Closes JUJU-9503