### PR TITLE
feat: implement keyboard navigation to the autocomplete input

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -110,7 +110,7 @@ yq -i ".services.jimm-base.environment.CORS_ALLOWED_ORIGINS = \"$DASHBOARD_ADDRE
 Now you can restart the Multipass container or running the following commands to reload the Docker environment
 
 ```shell
-cd /home/ubuntu/jimm && INSECURE_SECRET_STORAGE=true docker compose --profile dev up -d && docker restart jimm && juju show-controller qa-lxd | yq '.[].controller-machines.[].instance-id' | xargs lxc restart
+sudo systemctl restart jimm.service
 ```
 
 #### Dashboard setup

--- a/HACKING.md
+++ b/HACKING.md
@@ -596,12 +596,6 @@ export CONTROLLER_NAME=jimm3
 ```
 - Now we want to add a model to the jimm2 controller but running an older version of Juju than the controller:
 ```
-multipass shell jimm-oidc
-juju switch qa-lxd
-juju upgrade-controller --agent-version 3.6.20
-```
-- We also need a controller that has a higher version that the model's current controller version, so add a second controller, this time running 3.6.21:
-```
 ~/jimm/jaas add-model --target-controller jimm2 test2 --config="agent-version=3.6.19"
 ```
 - Lastly, if you want to use a local dashboard with this JIMM env then [update the config](#configure-jimm-for-localhost) and [configure your local dashboard](#controller-configuration) to point to the new controller, just as you would normally.
@@ -622,5 +616,5 @@ juju switch jimm-dev
 If you need to test with a model that has a Juju version that is older than its controller's version you can do:
 
 ```bash
-juju add-model test --config="agent-version=3.6.18"
+juju add-model test --config="agent-version=3.6.19"
 ```

--- a/src/components/AutocompleteField/AutocompleteField.test.tsx
+++ b/src/components/AutocompleteField/AutocompleteField.test.tsx
@@ -20,10 +20,8 @@ describe("AutocompleteField", () => {
     const input = screen.getByRole("textbox", { name: "auto complete" });
     expect(input).toBeInTheDocument();
     await userEvent.click(input);
-    expect(screen.getByRole("option", { name: "Option One" })).toHaveAttribute(
-      "data-value",
-      "option1",
-    );
+    await userEvent.click(screen.getByRole("option", { name: "Option One" }));
+    expect(input).toHaveValue("option1");
   });
 
   it("should update value in formik", async () => {

--- a/src/components/AutocompleteField/AutocompleteField.tsx
+++ b/src/components/AutocompleteField/AutocompleteField.tsx
@@ -7,7 +7,7 @@ import AutocompleteInput from "components/AutocompleteInput";
 
 export type AutocompleteInputItem = {
   label: string;
-  value: number | string;
+  value: string;
 };
 
 const AutocompleteField: FC<FormikFieldProps<typeof AutocompleteInput>> = ({

--- a/src/components/AutocompleteInput/AutocompleteInput.test.tsx
+++ b/src/components/AutocompleteInput/AutocompleteInput.test.tsx
@@ -178,6 +178,7 @@ describe("AutocompleteInput", () => {
             options={[
               { label: "Option One", value: "option1" },
               { label: "Option Two", value: "option2" },
+              { label: "Option Three", value: "option3" },
             ]}
             onValueChanged={vi.fn()}
           />
@@ -224,48 +225,42 @@ describe("AutocompleteInput", () => {
     it("selects the previous item if the up arrow is pressed", async () => {
       const input = screen.getByRole("textbox", { name: "auto complete" });
       expect(
-        screen.getByRole("option", { name: "Option Two" }),
+        screen.getByRole("option", { name: "Option Three" }),
       ).toHaveAttribute("aria-selected", "false");
+      await userEvent.type(input, "{arrowup}", { skipClick: true });
+      expect(
+        screen.getByRole("option", { name: "Option Three" }),
+      ).toHaveAttribute("aria-selected", "true");
       await userEvent.type(input, "{arrowup}", { skipClick: true });
       expect(
         screen.getByRole("option", { name: "Option Two" }),
       ).toHaveAttribute("aria-selected", "true");
+    });
+
+    it("selects the first item if the down arrow is pressed on the last item", async () => {
+      const input = screen.getByRole("textbox", { name: "auto complete" });
+      // Move to the last item.
       await userEvent.type(input, "{arrowup}", { skipClick: true });
       expect(
-        screen.getByRole("option", { name: "Option Two" }),
-      ).toHaveAttribute("aria-selected", "false");
-    });
-
-    it("selects the next item if tab is pressed", async () => {
-      const input = screen.getByRole("textbox", { name: "auto complete" });
-      expect(
-        screen.getByRole("option", { name: "Option One" }),
-      ).toHaveAttribute("aria-selected", "false");
-      await userEvent.type(input, "{tab}", { skipClick: true });
+        screen.getByRole("option", { name: "Option Three" }),
+      ).toHaveAttribute("aria-selected", "true");
+      await userEvent.type(input, "{arrowdown}", { skipClick: true });
       expect(
         screen.getByRole("option", { name: "Option One" }),
       ).toHaveAttribute("aria-selected", "true");
-      await userEvent.type(input, "{tab}", { skipClick: true });
-      expect(
-        screen.getByRole("option", { name: "Option Two" }),
-      ).toHaveAttribute("aria-selected", "true");
-      // It shouldn't remove focus from the input.
-      expect(input).toHaveFocus();
     });
 
-    it("selects the previous item if shift+tab is pressed", async () => {
+    it("selects the last item if the up arrow is pressed on the first item", async () => {
       const input = screen.getByRole("textbox", { name: "auto complete" });
+      // Move to the first item
+      await userEvent.type(input, "{arrowdown}", { skipClick: true });
       expect(
-        screen.getByRole("option", { name: "Option Two" }),
-      ).toHaveAttribute("aria-selected", "false");
-      await userEvent.type(input, "{shift>}{tab}", { skipClick: true });
-      expect(
-        screen.getByRole("option", { name: "Option Two" }),
+        screen.getByRole("option", { name: "Option One" }),
       ).toHaveAttribute("aria-selected", "true");
-      await userEvent.type(input, "{shift>}{tab}", { skipClick: true });
+      await userEvent.type(input, "{arrowup}", { skipClick: true });
       expect(
-        screen.getByRole("option", { name: "Option Two" }),
-      ).toHaveAttribute("aria-selected", "false");
+        screen.getByRole("option", { name: "Option Three" }),
+      ).toHaveAttribute("aria-selected", "true");
     });
 
     it("selects an item if the enter key is pressed", async () => {
@@ -278,6 +273,13 @@ describe("AutocompleteInput", () => {
       expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
       // It shouldn't submit the form.
       expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it("closes the menu if tab is pressed", async () => {
+      const input = screen.getByRole("textbox", { name: "auto complete" });
+      // Close the menu
+      await userEvent.type(input, "{tab}", { skipClick: true });
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
     });
 
     it("closes the menu if escape is pressed", async () => {

--- a/src/components/AutocompleteInput/AutocompleteInput.test.tsx
+++ b/src/components/AutocompleteInput/AutocompleteInput.test.tsx
@@ -1,5 +1,6 @@
-import { screen } from "@testing-library/react";
+import { act, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { Mock } from "vitest";
 
 import { renderComponent } from "testing/utils";
 
@@ -161,5 +162,157 @@ describe("AutocompleteInput", () => {
     );
     await userEvent.click(screen.getByRole("option", { name: "Option One" }));
     expect(onValueChanged).toHaveBeenCalledWith("option1");
+  });
+
+  describe("navigation", () => {
+    let onSubmit: Mock;
+    let onFormKeyDown: Mock;
+    beforeEach(() => {
+      onSubmit = vi.fn();
+      onFormKeyDown = vi.fn();
+      renderComponent(
+        <form onSubmit={onSubmit} onKeyDown={onFormKeyDown}>
+          <AutocompleteInput
+            name="auto-complete"
+            label="auto complete"
+            options={[
+              { label: "Option One", value: "option1" },
+              { label: "Option Two", value: "option2" },
+            ]}
+            onValueChanged={vi.fn()}
+          />
+        </form>,
+      );
+      act(() => {
+        screen.getByRole("textbox", { name: "auto complete" }).focus();
+      });
+    });
+
+    it("opens the menu if the up key is pressed", async () => {
+      const input = screen.getByRole("textbox", { name: "auto complete" });
+      // Close the menu
+      await userEvent.type(input, "{escape}", { skipClick: true });
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+      await userEvent.type(input, "{arrowup}", { skipClick: true });
+      expect(await screen.findByRole("listbox")).toBeInTheDocument();
+    });
+
+    it("opens the menu if the down key is pressed", async () => {
+      const input = screen.getByRole("textbox", { name: "auto complete" });
+      // Close the menu
+      await userEvent.type(input, "{escape}", { skipClick: true });
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+      await userEvent.type(input, "{arrowdown}");
+      expect(screen.queryByRole("listbox")).toBeInTheDocument();
+    });
+
+    it("selects the next item if the down arrow is pressed", async () => {
+      const input = screen.getByRole("textbox", { name: "auto complete" });
+      expect(
+        screen.getByRole("option", { name: "Option One" }),
+      ).toHaveAttribute("aria-selected", "false");
+      await userEvent.type(input, "{arrowdown}", { skipClick: true });
+      expect(
+        screen.getByRole("option", { name: "Option One" }),
+      ).toHaveAttribute("aria-selected", "true");
+      await userEvent.type(input, "{arrowdown}", { skipClick: true });
+      expect(
+        screen.getByRole("option", { name: "Option Two" }),
+      ).toHaveAttribute("aria-selected", "true");
+    });
+
+    it("selects the previous item if the up arrow is pressed", async () => {
+      const input = screen.getByRole("textbox", { name: "auto complete" });
+      expect(
+        screen.getByRole("option", { name: "Option Two" }),
+      ).toHaveAttribute("aria-selected", "false");
+      await userEvent.type(input, "{arrowup}", { skipClick: true });
+      expect(
+        screen.getByRole("option", { name: "Option Two" }),
+      ).toHaveAttribute("aria-selected", "true");
+      await userEvent.type(input, "{arrowup}", { skipClick: true });
+      expect(
+        screen.getByRole("option", { name: "Option Two" }),
+      ).toHaveAttribute("aria-selected", "false");
+    });
+
+    it("selects the next item if tab is pressed", async () => {
+      const input = screen.getByRole("textbox", { name: "auto complete" });
+      expect(
+        screen.getByRole("option", { name: "Option One" }),
+      ).toHaveAttribute("aria-selected", "false");
+      await userEvent.type(input, "{tab}", { skipClick: true });
+      expect(
+        screen.getByRole("option", { name: "Option One" }),
+      ).toHaveAttribute("aria-selected", "true");
+      await userEvent.type(input, "{tab}", { skipClick: true });
+      expect(
+        screen.getByRole("option", { name: "Option Two" }),
+      ).toHaveAttribute("aria-selected", "true");
+      // It shouldn't remove focus from the input.
+      expect(input).toHaveFocus();
+    });
+
+    it("selects the previous item if shift+tab is pressed", async () => {
+      const input = screen.getByRole("textbox", { name: "auto complete" });
+      expect(
+        screen.getByRole("option", { name: "Option Two" }),
+      ).toHaveAttribute("aria-selected", "false");
+      await userEvent.type(input, "{shift>}{tab}", { skipClick: true });
+      expect(
+        screen.getByRole("option", { name: "Option Two" }),
+      ).toHaveAttribute("aria-selected", "true");
+      await userEvent.type(input, "{shift>}{tab}", { skipClick: true });
+      expect(
+        screen.getByRole("option", { name: "Option Two" }),
+      ).toHaveAttribute("aria-selected", "false");
+    });
+
+    it("selects an item if the enter key is pressed", async () => {
+      const input = screen.getByRole("textbox", { name: "auto complete" });
+      expect(
+        screen.getByRole("option", { name: "Option One" }),
+      ).toHaveAttribute("aria-selected", "false");
+      await userEvent.type(input, "{arrowdown}{enter}", { skipClick: true });
+      expect(input).toHaveValue("option1");
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+      // It shouldn't submit the form.
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it("closes the menu if escape is pressed", async () => {
+      const input = screen.getByRole("textbox", { name: "auto complete" });
+      // Close the menu
+      await userEvent.type(input, "{escape}", { skipClick: true });
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    });
+
+    it("allows enter to work normally if the menu is closed", async () => {
+      const input = screen.getByRole("textbox", { name: "auto complete" });
+      // Close the menu
+      await userEvent.type(input, "{escape}", { skipClick: true });
+      await userEvent.type(input, "{enter}", { skipClick: true });
+      expect(onSubmit).toHaveBeenCalled();
+    });
+
+    it("allows tab to work normally if the menu is closed", async () => {
+      const input = screen.getByRole("textbox", { name: "auto complete" });
+      // Close the menu
+      await userEvent.type(input, "{escape}", { skipClick: true });
+      expect(input).toHaveFocus();
+      await userEvent.type(input, "{tab}", { skipClick: true });
+      expect(input).not.toHaveFocus();
+    });
+
+    it("allows escape to work normally if the menu is closed", async () => {
+      const input = screen.getByRole("textbox", { name: "auto complete" });
+      // Close the menu
+      await userEvent.type(input, "{escape}", { skipClick: true });
+      expect(onFormKeyDown).not.toHaveBeenCalled();
+      await userEvent.type(input, "{escape}", { skipClick: true });
+      expect(onFormKeyDown).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({ key: "Escape" }),
+      );
+    });
   });
 });

--- a/src/components/AutocompleteInput/AutocompleteInput.test.tsx
+++ b/src/components/AutocompleteInput/AutocompleteInput.test.tsx
@@ -275,7 +275,7 @@ describe("AutocompleteInput", () => {
       expect(onSubmit).not.toHaveBeenCalled();
     });
 
-    it("closes the menu if tab is pressed", async () => {
+    it("closes the menu if the input loses focus", async () => {
       const input = screen.getByRole("textbox", { name: "auto complete" });
       // Close the menu
       await userEvent.type(input, "{tab}", { skipClick: true });

--- a/src/components/AutocompleteInput/AutocompleteInput.tsx
+++ b/src/components/AutocompleteInput/AutocompleteInput.tsx
@@ -64,7 +64,6 @@ const handleKeyDown = (
   onSelectItem: (item: string) => void,
   event: React.KeyboardEvent<HTMLInputElement>,
 ): void => {
-  const isTab = event.key === "Tab";
   const isUp = event.key === "ArrowUp";
   const isDown = event.key === "ArrowDown";
   const isUpDown = isUp || isDown;
@@ -87,15 +86,6 @@ const handleKeyDown = (
     // When the menu is open then pressing enter should not do the default action (e.g. submitting a form).
     event.preventDefault();
   }
-  if (isTab && isDropdownOpen) {
-    // Moving focus away from the field should close the dropdown.
-    updateDropdown(
-      setIsDropdownOpen,
-      filteredOptions,
-      setHighlightedOptionIndex,
-      false,
-    );
-  }
   if (
     isEnter &&
     highlightedOptionIndex !== null &&
@@ -104,7 +94,7 @@ const handleKeyDown = (
     // Select the highlighted item in the menu.
     onSelectItem(filteredOptions[highlightedOptionIndex].value);
   }
-  // Pressing up/down or tab/shift+tab should move the selected item up/down.
+  // Pressing up/down should move the selected item up/down.
   if (isUpDown) {
     setHighlightedOptionIndex((prevIndex) => {
       return getNextOptionIndex(filteredOptions, isUp, prevIndex);
@@ -224,6 +214,16 @@ const AutocompleteInput: FC<Props> = ({
             );
             // Call any parent onFocus handlers.
             props.onFocus?.(event);
+          }}
+          onBlur={(event) => {
+            updateDropdown(
+              setIsDropdownOpen,
+              filteredOptions,
+              setHighlightedOptionIndex,
+              false,
+            );
+            // Call any parent onBlur handlers.
+            props.onBlur?.(event);
           }}
           onKeyDown={(event) => {
             handleKeyDown(

--- a/src/components/AutocompleteInput/AutocompleteInput.tsx
+++ b/src/components/AutocompleteInput/AutocompleteInput.tsx
@@ -1,13 +1,13 @@
 import type { InputProps, PropsWithSpread } from "@canonical/react-components";
 import { ContextualMenu, Input } from "@canonical/react-components";
 import type { FC, HTMLProps } from "react";
-import { useId, useMemo, useState } from "react";
+import { useCallback, useId, useMemo, useState } from "react";
 
 import AutocompleteInputDropdown from "./AutocompleteInputDropdown";
 
 type AutocompleteInputItem = {
   label: string;
-  value: number | string;
+  value: string;
 };
 
 type Props = PropsWithSpread<
@@ -19,12 +19,110 @@ type Props = PropsWithSpread<
   InputProps
 >;
 
+const getNextOptionIndex = (
+  options: Props["options"],
+  goingUp: boolean,
+  prevIndex: null | number,
+): number => {
+  if (prevIndex === null) {
+    return goingUp ? options.length - 1 : 0;
+  }
+  const increment = goingUp ? -1 : 1;
+  const nextIndex = prevIndex + increment;
+
+  if (increment > 0) {
+    return nextIndex < options.length ? nextIndex : prevIndex;
+  }
+
+  return nextIndex >= 0 ? nextIndex : prevIndex;
+};
+
+const updateDropdown = (
+  setIsDropdownOpen: (isDropdownOpen: boolean) => void,
+  filteredOptions: Props["options"],
+  setHighlightedOptionIndex: React.Dispatch<
+    React.SetStateAction<null | number>
+  >,
+  visible: boolean,
+): void => {
+  // Only show the dropdown if there are options.
+  setIsDropdownOpen(visible && !!filteredOptions.length);
+  // Clear the selected item when it closes.
+  if (!visible) {
+    setHighlightedOptionIndex(null);
+  }
+};
+
+const handleKeyDown = (
+  isDropdownOpen: boolean,
+  setIsDropdownOpen: (isDropdownOpen: boolean) => void,
+  filteredOptions: Props["options"],
+  setHighlightedOptionIndex: React.Dispatch<
+    React.SetStateAction<null | number>
+  >,
+  highlightedOptionIndex: null | number,
+  onSelectItem: (item: string) => void,
+  event: React.KeyboardEvent<HTMLInputElement>,
+): void => {
+  const isTab = event.key === "Tab";
+  const isUp = event.key === "ArrowUp";
+  const isDown = event.key === "ArrowDown";
+  const isUpDown = isUp || isDown;
+  const isEnter = event.key === "Enter";
+  if (isUpDown) {
+    // Don't move the cursor in the input.
+    event.preventDefault();
+
+    // Pressing an up/down key should open the menu.
+    if (!isDropdownOpen) {
+      updateDropdown(
+        setIsDropdownOpen,
+        filteredOptions,
+        setHighlightedOptionIndex,
+        true,
+      );
+    }
+  }
+  if ((isEnter || isTab) && isDropdownOpen) {
+    // When the menu is open then pressing enter or tab should not do the default actions (submitting a form, moving focus etc.)
+    event.preventDefault();
+  }
+  if (
+    isEnter &&
+    highlightedOptionIndex !== null &&
+    filteredOptions[highlightedOptionIndex]
+  ) {
+    // Select the highlighted item in the menu.
+    onSelectItem(filteredOptions[highlightedOptionIndex].value);
+  }
+  // Pressing up/down or tab/shift+tab should move the selected item up/down.
+  if (isUpDown || isTab) {
+    setHighlightedOptionIndex((prevIndex) => {
+      const goingUp = isUp || (isTab && event.shiftKey);
+      return getNextOptionIndex(filteredOptions, goingUp, prevIndex);
+    });
+  }
+  // If escape is pressed and the dropdown is open then close it, otherwise let the key behave as normal.
+  if (isDropdownOpen && event.key === "Escape") {
+    event.stopPropagation();
+    updateDropdown(
+      setIsDropdownOpen,
+      filteredOptions,
+      setHighlightedOptionIndex,
+      false,
+    );
+  }
+};
+
 const AutocompleteInput: FC<Props> = ({
   autocompleteStyle,
   options,
   onValueChanged,
   ...props
 }) => {
+  const [highlightedOptionIndex, setHighlightedOptionIndex] = useState<
+    null | number
+  >(null);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [inputValue, setInputValue] = useState<string>(
     props.value?.toString() ?? "",
@@ -43,15 +141,29 @@ const AutocompleteInput: FC<Props> = ({
     });
     // If there are no options to display then close the dropdown.
     if (!filtered.length) {
-      setIsDropdownOpen(false);
+      updateDropdown(
+        setIsDropdownOpen,
+        filtered,
+        setHighlightedOptionIndex,
+        false,
+      );
     }
     return filtered;
   }, [inputValue, options]);
 
-  const updateDropdown = (visible: boolean): void => {
-    // Only show the dropdown if there are options.
-    setIsDropdownOpen(visible && !!filteredOptions.length);
-  };
+  const onSelectItem = useCallback(
+    (value: string) => {
+      onValueChanged?.(value);
+      setInputValue(value);
+      updateDropdown(
+        setIsDropdownOpen,
+        filteredOptions,
+        setHighlightedOptionIndex,
+        false,
+      );
+    },
+    [filteredOptions, onValueChanged],
+  );
 
   return (
     <ContextualMenu
@@ -61,12 +173,18 @@ const AutocompleteInput: FC<Props> = ({
         // Handle syncing the state when toggling the menu from within the
         // contextual menu component e.g. when clicking outside.
         if (isOpen !== isDropdownOpen) {
-          updateDropdown(isOpen);
+          updateDropdown(
+            setIsDropdownOpen,
+            filteredOptions,
+            setHighlightedOptionIndex,
+            isOpen,
+          );
         }
       }}
       position="left"
       positionNode={document.getElementById(inputId)}
       constrainPanelWidth
+      scrollOverflow
       toggle={
         <Input
           {...props}
@@ -79,15 +197,36 @@ const AutocompleteInput: FC<Props> = ({
             const { value } = event.target;
             setInputValue(value);
             // Reopen if dropdown has been closed via ESC.
-            updateDropdown(true);
+            updateDropdown(
+              setIsDropdownOpen,
+              filteredOptions,
+              setHighlightedOptionIndex,
+              true,
+            );
             onValueChanged?.(value);
             // Call any parent onChange handlers.
             props.onChange?.(event);
           }}
           onFocus={(event) => {
-            updateDropdown(true);
+            updateDropdown(
+              setIsDropdownOpen,
+              filteredOptions,
+              setHighlightedOptionIndex,
+              true,
+            );
             // Call any parent onFocus handlers.
             props.onFocus?.(event);
+          }}
+          onKeyDown={(event) => {
+            handleKeyDown(
+              isDropdownOpen,
+              setIsDropdownOpen,
+              filteredOptions,
+              setHighlightedOptionIndex,
+              highlightedOptionIndex,
+              onSelectItem,
+              event,
+            );
           }}
           type="text"
           value={inputValue}
@@ -96,14 +235,12 @@ const AutocompleteInput: FC<Props> = ({
       visible={isDropdownOpen}
     >
       <AutocompleteInputDropdown
+        highlightedOptionIndex={highlightedOptionIndex}
         id={dropdownId}
         isOpen={isDropdownOpen}
         options={filteredOptions}
-        onSelectItem={(value) => {
-          onValueChanged?.(value);
-          setInputValue(value);
-          setIsDropdownOpen(false);
-        }}
+        onSelectItem={onSelectItem}
+        setHighlightedOptionIndex={setHighlightedOptionIndex}
       />
     </ContextualMenu>
   );

--- a/src/components/AutocompleteInput/AutocompleteInput.tsx
+++ b/src/components/AutocompleteInput/AutocompleteInput.tsx
@@ -31,10 +31,10 @@ const getNextOptionIndex = (
   const nextIndex = prevIndex + increment;
 
   if (increment > 0) {
-    return nextIndex < options.length ? nextIndex : prevIndex;
+    return nextIndex < options.length ? nextIndex : 0;
   }
 
-  return nextIndex >= 0 ? nextIndex : prevIndex;
+  return nextIndex >= 0 ? nextIndex : options.length - 1;
 };
 
 const updateDropdown = (
@@ -83,9 +83,18 @@ const handleKeyDown = (
       );
     }
   }
-  if ((isEnter || isTab) && isDropdownOpen) {
-    // When the menu is open then pressing enter or tab should not do the default actions (submitting a form, moving focus etc.)
+  if (isEnter && isDropdownOpen) {
+    // When the menu is open then pressing enter should not do the default action (e.g. submitting a form).
     event.preventDefault();
+  }
+  if (isTab && isDropdownOpen) {
+    // Moving focus away from the field should close the dropdown.
+    updateDropdown(
+      setIsDropdownOpen,
+      filteredOptions,
+      setHighlightedOptionIndex,
+      false,
+    );
   }
   if (
     isEnter &&
@@ -96,10 +105,9 @@ const handleKeyDown = (
     onSelectItem(filteredOptions[highlightedOptionIndex].value);
   }
   // Pressing up/down or tab/shift+tab should move the selected item up/down.
-  if (isUpDown || isTab) {
+  if (isUpDown) {
     setHighlightedOptionIndex((prevIndex) => {
-      const goingUp = isUp || (isTab && event.shiftKey);
-      return getNextOptionIndex(filteredOptions, goingUp, prevIndex);
+      return getNextOptionIndex(filteredOptions, isUp, prevIndex);
     });
   }
   // If escape is pressed and the dropdown is open then close it, otherwise let the key behave as normal.

--- a/src/components/AutocompleteInput/AutocompleteInputDropdown/AutocompleteInputDropdown.test.tsx
+++ b/src/components/AutocompleteInput/AutocompleteInputDropdown/AutocompleteInputDropdown.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { renderComponent } from "testing/utils";
@@ -9,6 +9,9 @@ describe("AutocompleteInputDropdown", () => {
   it("displays options", () => {
     renderComponent(
       <AutocompleteInputDropdown
+        highlightedOptionIndex={0}
+        id="abc"
+        setHighlightedOptionIndex={vi.fn()}
         options={[
           { label: "Option One", value: "option1" },
           { label: "Option Two", value: "option2" },
@@ -17,20 +20,21 @@ describe("AutocompleteInputDropdown", () => {
         isOpen
       />,
     );
-    expect(screen.getByRole("option", { name: "Option One" })).toHaveAttribute(
-      "data-value",
-      "option1",
-    );
-    expect(screen.getByRole("option", { name: "Option Two" })).toHaveAttribute(
-      "data-value",
-      "option2",
-    );
+    expect(
+      screen.getByRole("option", { name: "Option One" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: "Option Two" }),
+    ).toBeInTheDocument();
   });
 
   it("calls the callback when an option is clicked", async () => {
     const onSelectItem = vi.fn();
     renderComponent(
       <AutocompleteInputDropdown
+        highlightedOptionIndex={0}
+        id="abc"
+        setHighlightedOptionIndex={vi.fn()}
         options={[
           { label: "Option One", value: "option1" },
           { label: "Option Two", value: "option2" },
@@ -41,5 +45,71 @@ describe("AutocompleteInputDropdown", () => {
     );
     await userEvent.click(screen.getByRole("option", { name: "Option One" }));
     expect(onSelectItem).toHaveBeenCalledWith("option1");
+  });
+
+  it("displays an item as highlighted", async () => {
+    const onSelectItem = vi.fn();
+    renderComponent(
+      <AutocompleteInputDropdown
+        highlightedOptionIndex={1}
+        id="abc"
+        setHighlightedOptionIndex={vi.fn()}
+        options={[
+          { label: "Option One", value: "option1" },
+          { label: "Option Two", value: "option2" },
+        ]}
+        onSelectItem={onSelectItem}
+        isOpen
+      />,
+    );
+    const option = screen.getByRole("option", { name: "Option Two" });
+    expect(option).toHaveClass("highlight");
+    expect(option).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("listbox")).toHaveAttribute(
+      "aria-activedescendant",
+      "abc-option-1",
+    );
+  });
+
+  it("sets the highlighted index when hovered", async () => {
+    const setHighlightedOptionIndex = vi.fn();
+    renderComponent(
+      <AutocompleteInputDropdown
+        highlightedOptionIndex={0}
+        id="abc"
+        setHighlightedOptionIndex={setHighlightedOptionIndex}
+        options={[
+          { label: "Option One", value: "option1" },
+          { label: "Option Two", value: "option2" },
+        ]}
+        onSelectItem={vi.fn()}
+        isOpen
+      />,
+    );
+    await userEvent.hover(screen.getByRole("option", { name: "Option Two" }));
+    expect(setHighlightedOptionIndex).toHaveBeenCalledWith(1);
+  });
+
+  it("scrolls to items that are off the screen", async () => {
+    const scrollSpy = vi.spyOn(window.HTMLElement.prototype, "scrollIntoView");
+    renderComponent(
+      <div style={{ height: "20px", overflow: "scroll" }}>
+        <AutocompleteInputDropdown
+          highlightedOptionIndex={1}
+          id="abc"
+          setHighlightedOptionIndex={vi.fn()}
+          options={[
+            { label: "Option One", value: "option1" },
+            { label: "Option Two", value: "option2" },
+          ]}
+          onSelectItem={vi.fn()}
+          isOpen
+        />
+        ,
+      </div>,
+    );
+    await waitFor(() => {
+      expect(scrollSpy).toHaveBeenCalledOnce();
+    });
   });
 });

--- a/src/components/AutocompleteInput/AutocompleteInputDropdown/AutocompleteInputDropdown.tsx
+++ b/src/components/AutocompleteInput/AutocompleteInputDropdown/AutocompleteInputDropdown.tsx
@@ -1,7 +1,7 @@
 import { FadeInDown } from "@canonical/react-components/dist/components/MultiSelect/FadeInDown";
 import classNames from "classnames";
 import type { FC } from "react";
-import React, { useLayoutEffect } from "react";
+import React, { useLayoutEffect, useRef } from "react";
 
 type AutocompleteInputItem = {
   label: string;
@@ -25,17 +25,6 @@ type Props = {
 const getOptionId = (optionsId: string, index: number): string =>
   `${optionsId}-option-${index}`;
 
-/**
- * Scroll to the option if there are more items than fit on the screen.
- */
-const scrollToOption = (id: string, highlightedOptionIndex: number): void => {
-  document
-    .getElementById(getOptionId(id, highlightedOptionIndex))
-    ?.scrollIntoView({
-      block: "nearest",
-    });
-};
-
 const AutocompleteInputDropdown: FC<Props> = ({
   options,
   onSelectItem,
@@ -45,13 +34,16 @@ const AutocompleteInputDropdown: FC<Props> = ({
   setHighlightedOptionIndex,
   ...props
 }) => {
+  const optionsRefs = useRef<HTMLLIElement[]>([]);
   // Wait for any rerenders and then scroll to items that are outside the visible scroll area.
   useLayoutEffect(() => {
     if (highlightedOptionIndex !== null) {
       // The event needs to happen after repaint in case the DOM changed.
-      window.requestAnimationFrame(
-        scrollToOption.bind(this, id, highlightedOptionIndex),
-      );
+      window.requestAnimationFrame(() => {
+        optionsRefs.current[highlightedOptionIndex]?.scrollIntoView({
+          block: "nearest",
+        });
+      });
     }
   }, [highlightedOptionIndex, id]);
 
@@ -73,6 +65,12 @@ const AutocompleteInputDropdown: FC<Props> = ({
               <li
                 key={item.value}
                 id={getOptionId(id, index)}
+                ref={(node) => {
+                  if (!node) {
+                    return;
+                  }
+                  optionsRefs.current[index] = node;
+                }}
                 aria-selected={selected}
                 className={classNames(
                   "autocomplete-input__dropdown-item p-contextual-menu__link",
@@ -80,7 +78,7 @@ const AutocompleteInputDropdown: FC<Props> = ({
                     highlight: selected,
                   },
                 )}
-                onMouseMove={() => {
+                onMouseEnter={() => {
                   // Select the item that is being hovered so that the mouse and keyboard events are in sync.
                   setHighlightedOptionIndex(index);
                 }}

--- a/src/components/AutocompleteInput/AutocompleteInputDropdown/AutocompleteInputDropdown.tsx
+++ b/src/components/AutocompleteInput/AutocompleteInputDropdown/AutocompleteInputDropdown.tsx
@@ -82,6 +82,10 @@ const AutocompleteInputDropdown: FC<Props> = ({
                   // Select the item that is being hovered so that the mouse and keyboard events are in sync.
                   setHighlightedOptionIndex(index);
                 }}
+                onMouseDown={(event) => {
+                  // Prevent clicks in the menu from removing focus from the input.
+                  event.preventDefault();
+                }}
                 onMouseUp={(event) => {
                   // Prevent clicks from propagating so that if the autocomplete is inside a panel or modal it's
                   // not registered as a cloud outside (as the dropdown is inside a portal).

--- a/src/components/AutocompleteInput/AutocompleteInputDropdown/AutocompleteInputDropdown.tsx
+++ b/src/components/AutocompleteInput/AutocompleteInputDropdown/AutocompleteInputDropdown.tsx
@@ -1,49 +1,101 @@
 import { FadeInDown } from "@canonical/react-components/dist/components/MultiSelect/FadeInDown";
+import classNames from "classnames";
 import type { FC } from "react";
-import React from "react";
+import React, { useLayoutEffect } from "react";
 
 type AutocompleteInputItem = {
   label: string;
-  value: number | string;
+  value: string;
 };
 
 type Props = {
+  highlightedOptionIndex: null | number;
   isOpen: boolean;
-  options: AutocompleteInputItem[];
   onSelectItem: (item: string) => void;
+  options: AutocompleteInputItem[];
+  id: string;
+  setHighlightedOptionIndex: React.Dispatch<
+    React.SetStateAction<null | number>
+  >;
 } & React.HTMLAttributes<HTMLDivElement>;
+
+/**
+ * Get a unique id for the option at a specific position.
+ */
+const getOptionId = (optionsId: string, index: number): string =>
+  `${optionsId}-option-${index}`;
+
+/**
+ * Scroll to the option if there are more items than fit on the screen.
+ */
+const scrollToOption = (id: string, highlightedOptionIndex: number): void => {
+  document
+    .getElementById(getOptionId(id, highlightedOptionIndex))
+    ?.scrollIntoView({
+      block: "nearest",
+    });
+};
 
 const AutocompleteInputDropdown: FC<Props> = ({
   options,
   onSelectItem,
+  id,
+  highlightedOptionIndex,
   isOpen,
+  setHighlightedOptionIndex,
   ...props
 }) => {
-  const onMouseUp = (event: React.MouseEvent<HTMLLIElement>): void => {
-    // Prevent clicks from propagating so that if the autocomplete is inside a panel or modal it's
-    // not registered as a cloud outside (as the dropdown is inside a portal).
-    event.stopPropagation();
-    const value = (event.target as HTMLLIElement)?.dataset.value;
-    if (value) {
-      onSelectItem(value);
+  // Wait for any rerenders and then scroll to items that are outside the visible scroll area.
+  useLayoutEffect(() => {
+    if (highlightedOptionIndex !== null) {
+      // The event needs to happen after repaint in case the DOM changed.
+      window.requestAnimationFrame(
+        scrollToOption.bind(this, id, highlightedOptionIndex),
+      );
     }
-  };
+  }, [highlightedOptionIndex, id]);
 
   return (
     <FadeInDown isVisible={isOpen}>
-      <div role="listbox" {...props}>
+      <div
+        {...props}
+        role="listbox"
+        aria-activedescendant={
+          highlightedOptionIndex !== null
+            ? getOptionId(id, highlightedOptionIndex)
+            : undefined
+        }
+      >
         <ul className="autocomplete-input__dropdown-list">
-          {options.map((item) => (
-            <li
-              key={item.value}
-              className="autocomplete-input__dropdown-item p-contextual-menu__link"
-              data-value={item.value}
-              onMouseUp={onMouseUp}
-              role="option"
-            >
-              {item.label}
-            </li>
-          ))}
+          {options.map((item, index) => {
+            const selected = index === highlightedOptionIndex;
+            return (
+              <li
+                key={item.value}
+                id={getOptionId(id, index)}
+                aria-selected={selected}
+                className={classNames(
+                  "autocomplete-input__dropdown-item p-contextual-menu__link",
+                  {
+                    highlight: selected,
+                  },
+                )}
+                onMouseMove={() => {
+                  // Select the item that is being hovered so that the mouse and keyboard events are in sync.
+                  setHighlightedOptionIndex(index);
+                }}
+                onMouseUp={(event) => {
+                  // Prevent clicks from propagating so that if the autocomplete is inside a panel or modal it's
+                  // not registered as a cloud outside (as the dropdown is inside a portal).
+                  event.stopPropagation();
+                  onSelectItem(item.value);
+                }}
+                role="option"
+              >
+                {item.label}
+              </li>
+            );
+          })}
         </ul>
       </div>
     </FadeInDown>

--- a/src/components/AutocompleteInput/_autocomplete-input.scss
+++ b/src/components/AutocompleteInput/_autocomplete-input.scss
@@ -9,5 +9,9 @@
 
   &__dropdown-item {
     cursor: pointer;
+
+    &.highlight {
+      background-color: $colors--theme--background-active;
+    }
   }
 }


### PR DESCRIPTION
## Done

- Add keyboard navigation to the autocomplete input.

## QA

- You can either test this feature in the model upgrades form or via Logs -> Filter.
- Check that you can navigate up and down the options with arrow keys and select an option with enter.
- With the menu closed enter should submit the form.
- With the menu open escape should close the menu, pressing it again should close the panel.

## Details

https://warthogs.atlassian.net/browse/JUJU-9498
