### PR TITLE
fix(models): don't clear model-index screen for error

### DIFF
--- a/src/pages/ModelsIndex/ModelsIndex.test.tsx
+++ b/src/pages/ModelsIndex/ModelsIndex.test.tsx
@@ -203,10 +203,12 @@ describe("Models Index page", () => {
     expect(router.state.location.search).toBe(`?${params.toString()}`);
   });
 
-  it("should display the error notification", async () => {
+  it("should display the error notification without clearing table", async () => {
     state.juju.modelsError = "Oops!";
     renderComponent(<ModelsIndex />, { state });
     expect(screen.getByText(/Oops!/)).toBeInTheDocument();
+    expect(screen.getByText(/3 models/)).toBeInTheDocument();
+    expect(screen.getAllByRole("grid")).toHaveLength(3);
   });
 
   it("clears spinner if initial error occurs", async () => {

--- a/src/pages/ModelsIndex/ModelsIndex.tsx
+++ b/src/pages/ModelsIndex/ModelsIndex.tsx
@@ -124,99 +124,94 @@ export default function Models(): JSX.Element {
   const modelCount = blocked + alert + running;
 
   let content: ReactNode = null;
-  if (!modelsError) {
-    if (!modelsLoaded) {
-      return <LoadingSpinner />;
-    } else if (!hasSomeModels) {
-      content = (
-        <div className="models">
-          <h3>{Label.NOT_FOUND}</h3>
-          <p>
-            Learn about <a href={externalURLs.addModel}>adding models</a> or{" "}
-            <a href={externalURLs.modelAccess}>granting access</a> to existing
-            models.
-          </p>
-        </div>
-      );
-    } else {
-      content = (
-        <>
-          <span className="models__controls" data-disabled={modelCount === 0}>
-            <SearchAndFilter
-              filterPanelData={[
-                {
-                  id: 0,
-                  heading: "Cloud",
-                  chips: generateChips("Cloud", clouds),
-                },
-                {
-                  id: 1,
-                  heading: "Region",
-                  chips: generateChips("Region", regions),
-                },
-                {
-                  id: 2,
-                  heading: "Owner",
-                  chips: generateChips("Owner", owners),
-                },
-                {
-                  id: 3,
-                  heading: "Credential",
-                  chips: generateChips("Credential", credentials),
-                },
-              ]}
-              existingSearchData={existingSearchData}
-              returnSearchData={(searchData) => {
-                // Reset active filters
-                activeFilters = {
-                  cloud: [],
-                  owner: [],
-                  region: [],
-                  credential: [],
-                  custom: [],
-                };
+  if (!modelsLoaded && !modelsError) {
+    return <LoadingSpinner />;
+  } else if (!hasSomeModels) {
+    content = (
+      <div className="models">
+        <h3>{Label.NOT_FOUND}</h3>
+        <p>
+          Learn about <a href={externalURLs.addModel}>adding models</a> or{" "}
+          <a href={externalURLs.modelAccess}>granting access</a> to existing
+          models.
+        </p>
+      </div>
+    );
+  } else {
+    content = (
+      <>
+        <span className="models__controls" data-disabled={modelCount === 0}>
+          <SearchAndFilter
+            filterPanelData={[
+              {
+                id: 0,
+                heading: "Cloud",
+                chips: generateChips("Cloud", clouds),
+              },
+              {
+                id: 1,
+                heading: "Region",
+                chips: generateChips("Region", regions),
+              },
+              {
+                id: 2,
+                heading: "Owner",
+                chips: generateChips("Owner", owners),
+              },
+              {
+                id: 3,
+                heading: "Credential",
+                chips: generateChips("Credential", credentials),
+              },
+            ]}
+            existingSearchData={existingSearchData}
+            returnSearchData={(searchData) => {
+              // Reset active filters
+              activeFilters = {
+                cloud: [],
+                owner: [],
+                region: [],
+                credential: [],
+                custom: [],
+              };
 
-                // Loop search data and pull out each filter
-                if (searchData.length) {
-                  searchData.forEach(({ lead, value }) => {
-                    const chipLead = lead ? lead.toLowerCase() : "custom";
-                    if (!(chipLead in activeFilters)) {
-                      activeFilters[chipLead] = [];
-                    }
-                    activeFilters[chipLead].push(value);
-                  });
-                }
-                if (!isObjectsEqual(activeFilters, filters)) {
-                  setQueryParams(activeFilters);
-                }
-              }}
+              // Loop search data and pull out each filter
+              if (searchData.length) {
+                searchData.forEach(({ lead, value }) => {
+                  const chipLead = lead ? lead.toLowerCase() : "custom";
+                  if (!(chipLead in activeFilters)) {
+                    activeFilters[chipLead] = [];
+                  }
+                  activeFilters[chipLead].push(value);
+                });
+              }
+              if (!isObjectsEqual(activeFilters, filters)) {
+                setQueryParams(activeFilters);
+              }
+            }}
+          />
+          <span>
+            <span className="p-text--default">Group by: </span>
+            <SegmentedControl
+              className="u-display--inline-block"
+              activeButton={queryParams.groupedby}
+              buttons={["Status", "Cloud", "Owner"].map((group) => ({
+                children: group,
+                key: group.toLowerCase(),
+                to: urls.models.group({
+                  groupedby: group.toLowerCase() as ModelsGroupedBy,
+                }),
+              }))}
+              buttonComponent={Link}
             />
-            <span>
-              <span className="p-text--default">Group by: </span>
-              <SegmentedControl
-                className="u-display--inline-block"
-                activeButton={queryParams.groupedby}
-                buttons={["Status", "Cloud", "Owner"].map((group) => ({
-                  children: group,
-                  key: group.toLowerCase(),
-                  to: urls.models.group({
-                    groupedby: group.toLowerCase() as ModelsGroupedBy,
-                  }),
-                }))}
-                buttonComponent={Link}
-              />
-            </span>
           </span>
-          <div className="models">
-            <ChipGroup chips={{ blocked, alert, running }} />
-            <ModelTableList
-              groupedBy={queryParams.groupedby}
-              filters={filters}
-            />
-          </div>
-        </>
-      );
-    }
+        </span>
+        <div className="models">
+          <ChipGroup chips={{ blocked, alert, running }} />
+          <ModelTableList groupedBy={queryParams.groupedby} filters={filters} />
+        </div>
+      </>
+    );
   }
 
   return (


### PR DESCRIPTION
## Done

- Allow rendering content in model-index even if there's an error.

## QA

- Apply diff:

```diff
diff --git a/src/store/middleware/source/model-list.ts b/src/store/middleware/source/model-list.ts
index 758def65..be6e9830 100644
--- a/src/store/middleware/source/model-list.ts
+++ b/src/store/middleware/source/model-list.ts
@@ -12,9 +12,13 @@ export const NOT_AUTHENTICATED_ERROR = "not authenticated with controller";
 export const NO_MODEL_MANAGER_FACADE =
   "ModelManager facade is not available on the connection";
 
+let count = 0;
 export async function getModelList(
   connection: ConnectionWithFacades,
 ): Promise<UserModelList> {
+  if (count++ === 1) {
+    throw new Error(ModelsError.LOAD_LATEST_MODELS);
+  }
   if (!connection.info.user?.identity) {
     throw new Error(NOT_AUTHENTICATED_ERROR);
   }
@@ -47,7 +51,7 @@ export default createSourceMiddleware<
     const connection = meta.connections.wsControllerURL;
 
     return createPollingSource(async () => getModelList(connection), {
-      interval: { seconds: 30 },
+      interval: { seconds: 5 },
     });
   },
   {
```
- Go to model index page
- Loading spinner should show, then models should populate
- After 5 seconds, an error should be shown at the top of the table
- After another 5 seconds, the error will clear


https://github.com/user-attachments/assets/8a7ae8db-ca30-4af0-8afb-6cc87625602f

