### PR TITLE
fix: only fetch model migration data for jimm

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -48,6 +48,7 @@ contribute and what kinds of contributions are welcome.
     - [Getting models into a broken state](#getting-models-into-a-broken-state)
     - [Setting up model migrations](#setting-up-model-migrations)
     - [Add a model to a specific JAAS controller](#add-a-model-to-a-specific-jaas-controller)
+    - [Add a model with a version older than the controller](#add-a-model-with-a-version-older-than-the-controller)
 
 ## Setting up the dashboard for development
 
@@ -602,5 +603,14 @@ Assuming you have a local jimm repo and running jimm (if you haven't already bui
 
 ```bash
 cd ~/jimm
+juju switch jimm-dev
 ./jaas add-model --target-controller controller-name test-model
+```
+
+### Add a model with a version older than the controller
+
+If you need to test with a model that has a Juju version that is older than its controller's version you can do:
+
+```bash
+juju add-model test --config="agent-version=3.6.18"
 ```

--- a/HACKING.md
+++ b/HACKING.md
@@ -577,9 +577,24 @@ There are two scenarios when testing model upgrades:
 1. Upgrade a model to a patch version that is equal to or lower than the current controller's patch version (this does not require a migration to a new controller).
 2. Upgrade to a patch version that is higher than the current controller's patch version or upgrade the model's major and/or minor version (this will require a migration to a controller with the new version).
 
-- Currently Multipass does not support environment variables in cloud init scripts so on your host open `scripts/cloud-init-jimm-lxd-oidc.yaml` and change the line `su -c '/home/ubuntu/juju-dashboard/scripts/cloud-init-jimm-lxd-oidc.sh' - ubuntu` to `su -c 'export AGENT_VERSION=3.6.19 && /home/ubuntu/juju-dashboard/scripts/cloud-init-jimm-lxd-oidc.sh' - ubuntu`
-- From the root of the dashboard run `multipass launch --cpus 2 --disk 25G --memory 12G --name jimm-oidc --timeout 5000 --cloud-init ./scripts/cloud-init-jimm-lxd-oidc.yaml` and wait for the JIMM container to be ready.
-- At this point we will have a model `test` on Juju 3.6.19, now we need to upgrade the controller so its version is higher than the model's version (note: it might take a while for the controller to upgrade):
+- To begin, launch a JIMM environment: `multipass launch --cpus 2 --disk 25G --memory 12G --name jimm-oidc --timeout 5000 --cloud-init ./scripts/cloud-init-jimm-lxd-oidc.yaml` and wait for the JIMM container to be ready.
+- Now we need a controller running an older version of Juju:
+```
+cd ~/jimm
+export AGENT_VERSION=3.6.20
+export CONTROLLER_NAME=jimm2
+./local/jimm/setup-controller.sh
+./local/jimm/add-controller.sh
+```
+- Add another controller, this time running a newer version of Juju.
+```
+cd ~/jimm
+export AGENT_VERSION=3.6.21
+export CONTROLLER_NAME=jimm3
+./local/jimm/setup-controller.sh
+./local/jimm/add-controller.sh
+```
+- Now we want to add a model to the jimm2 controller but running an older version of Juju than the controller:
 ```
 multipass shell jimm-oidc
 juju switch qa-lxd
@@ -587,11 +602,7 @@ juju upgrade-controller --agent-version 3.6.20
 ```
 - We also need a controller that has a higher version that the model's current controller version, so add a second controller, this time running 3.6.21:
 ```
-cd ~/jimm
-export AGENT_VERSION=3.6.21
-export CONTROLLER_NAME=jimm2
-./local/jimm/setup-controller.sh
-./local/jimm/add-controller.sh
+~/jimm/jaas add-model --target-controller jimm2 test2 --config="agent-version=3.6.19"
 ```
 - Lastly, if you want to use a local dashboard with this JIMM env then [update the config](#configure-jimm-for-localhost) and [configure your local dashboard](#controller-configuration) to point to the new controller, just as you would normally.
 
@@ -602,9 +613,8 @@ If you're using JAAS you might want to add a model to a specific controller.
 Assuming you have a local jimm repo and running jimm (if you haven't already built the jaas command it can be done with `./local/jimm/detect-jaas.sh`)
 
 ```bash
-cd ~/jimm
 juju switch jimm-dev
-./jaas add-model --target-controller controller-name test-model
+~/jimm/jaas add-model --target-controller controller-name test-model
 ```
 
 ### Add a model with a version older than the controller

--- a/src/hooks/useModelMigrationData.test.ts
+++ b/src/hooks/useModelMigrationData.test.ts
@@ -1,3 +1,5 @@
+import jimmSupportedVersions from "store/middleware/source/jimm-supported-versions";
+import migrationTargets from "store/middleware/source/migration-targets";
 import type { RootState } from "store/store";
 import { generalStateFactory, configFactory } from "testing/factories/general";
 import {
@@ -48,13 +50,13 @@ describe("useModelMigrationData", () => {
       },
     );
     expect(
-      actions.find(
-        (dispatch) => dispatch.type === "source/jimm-supported-versions/start",
+      actions.find((dispatch) =>
+        jimmSupportedVersions.actions.start.match(dispatch),
       ),
     ).toBeUndefined();
     expect(
-      actions.find(
-        (dispatch) => dispatch.type === "source/migration-targets/start",
+      actions.find((dispatch) =>
+        migrationTargets.actions.start.match(dispatch),
       ),
     ).toBeUndefined();
   });
@@ -71,25 +73,21 @@ describe("useModelMigrationData", () => {
         store,
       },
     );
-    const supportedVersionsStart = {
-      type: "source/jimm-supported-versions/start",
-      payload: { wsControllerURL: "wss://example.com/api" },
-      meta: { withConnection: true },
-    };
+    const supportedVersionsStart = jimmSupportedVersions.actions.start({
+      wsControllerURL: "wss://example.com/api",
+    });
     expect(
-      actions.find((dispatch) => dispatch.type === supportedVersionsStart.type),
+      actions.find((dispatch) =>
+        jimmSupportedVersions.actions.start.match(dispatch),
+      ),
     ).toMatchObject(supportedVersionsStart);
-    const modelMigrationTargetsStart = {
-      type: "source/migration-targets/start",
-      payload: {
-        modelUUID: "abc123",
-        wsControllerURL: "wss://example.com/api",
-      },
-      meta: { withConnection: true },
-    };
+    const modelMigrationTargetsStart = migrationTargets.actions.start({
+      modelUUID: "abc123",
+      wsControllerURL: "wss://example.com/api",
+    });
     expect(
-      actions.find(
-        (dispatch) => dispatch.type === modelMigrationTargetsStart.type,
+      actions.find((dispatch) =>
+        migrationTargets.actions.start.match(dispatch),
       ),
     ).toMatchObject(modelMigrationTargetsStart);
   });
@@ -107,24 +105,20 @@ describe("useModelMigrationData", () => {
       },
     );
     unmount();
-    const supportedVersionsStop = {
-      type: "source/jimm-supported-versions/stop",
-      payload: { wsControllerURL: "wss://example.com/api" },
-    };
+    const supportedVersionsStop = jimmSupportedVersions.actions.stop({
+      wsControllerURL: "wss://example.com/api",
+    });
     expect(
-      actions.find((dispatch) => dispatch.type === supportedVersionsStop.type),
-    ).toMatchObject(supportedVersionsStop);
-    const modelMigrationTargetsStop = {
-      type: "source/migration-targets/stop",
-      payload: {
-        modelUUID: "abc123",
-        wsControllerURL: "wss://example.com/api",
-      },
-    };
-    expect(
-      actions.find(
-        (dispatch) => dispatch.type === modelMigrationTargetsStop.type,
+      actions.find((dispatch) =>
+        jimmSupportedVersions.actions.stop.match(dispatch),
       ),
+    ).toMatchObject(supportedVersionsStop);
+    const modelMigrationTargetsStop = migrationTargets.actions.stop({
+      modelUUID: "abc123",
+      wsControllerURL: "wss://example.com/api",
+    });
+    expect(
+      actions.find((dispatch) => migrationTargets.actions.stop.match(dispatch)),
     ).toMatchObject(modelMigrationTargetsStop);
   });
 });

--- a/src/hooks/useModelMigrationData.test.ts
+++ b/src/hooks/useModelMigrationData.test.ts
@@ -30,6 +30,35 @@ describe("useModelMigrationData", () => {
     });
   });
 
+  it("does not poll for data when using Juju", () => {
+    if (state.general.config) {
+      state.general.config.isJuju = true;
+    } else {
+      assert.fail("Config not defined");
+    }
+    const [store, actions] = createStore(state, {
+      trackActions: true,
+    });
+    renderWrappedHook(
+      () => {
+        useModelMigrationData("test1", "eggman@external");
+      },
+      {
+        store,
+      },
+    );
+    expect(
+      actions.find(
+        (dispatch) => dispatch.type === "source/jimm-supported-versions/start",
+      ),
+    ).toBeUndefined();
+    expect(
+      actions.find(
+        (dispatch) => dispatch.type === "source/migration-targets/start",
+      ),
+    ).toBeUndefined();
+  });
+
   it("starts polling for data when the hook is mounted", () => {
     const [store, actions] = createStore(state, {
       trackActions: true,

--- a/src/hooks/useModelMigrationData.ts
+++ b/src/hooks/useModelMigrationData.ts
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 
-import { getWSControllerURL } from "store/general/selectors";
+import { getIsJIMM, getWSControllerURL } from "store/general/selectors";
 import { getModelUUIDFromList } from "store/juju/selectors";
 import jimmSupportedVersions from "store/middleware/source/jimm-supported-versions";
 import modelMigrationTargets from "store/middleware/source/migration-targets";
@@ -19,9 +19,10 @@ const useModelMigrationData = (
   const modelUUID = useAppSelector((state) =>
     getModelUUIDFromList(state, modelName, qualifier),
   );
+  const isJIMM = useAppSelector(getIsJIMM);
 
   useEffect(() => {
-    if (wsControllerURL && fetchData) {
+    if (wsControllerURL && fetchData && isJIMM) {
       dispatch(jimmSupportedVersions.actions.start({ wsControllerURL }));
       if (modelUUID) {
         dispatch(
@@ -30,7 +31,7 @@ const useModelMigrationData = (
       }
     }
     return (): void => {
-      if (wsControllerURL) {
+      if (wsControllerURL && isJIMM) {
         dispatch(jimmSupportedVersions.actions.stop({ wsControllerURL }));
         if (modelUUID) {
           dispatch(
@@ -39,7 +40,7 @@ const useModelMigrationData = (
         }
       }
     };
-  }, [dispatch, fetchData, modelUUID, wsControllerURL]);
+  }, [dispatch, fetchData, isJIMM, modelUUID, wsControllerURL]);
 };
 
 export default useModelMigrationData;


### PR DESCRIPTION
## Done

- Only fetch the Juju versions and model migration targets when using JIMM.

## QA

- Connect to Juju.
- Go to the model list.
- Click the model actions menu.
- You console shouldn't have any errors about fetching jimm data.
