### PR TITLE
chore(dev): disable ipv6 for jimm/lxd cloud init script

### DIFF
--- a/scripts/cloud-init-jimm-k8s-oidc.sh
+++ b/scripts/cloud-init-jimm-k8s-oidc.sh
@@ -57,6 +57,13 @@ python3 ./charms/k8s-charm/src/config.py
 
 # Set up k8s controller
 cd /home/ubuntu/juju-dashboard
+# Fix playwright install on 24.04+
+# https://github.com/microsoft/playwright/issues/40117#issuecomment-4346755958
+if [[ "$(arch)" -eq "aarch64" ]]; then
+   export PLAYWRIGHT_HOST_PLATFORM_OVERRIDE="ubuntu24.04-arm64"
+else
+   export PLAYWRIGHT_HOST_PLATFORM_OVERRIDE="ubuntu24.04-x64"
+fi
 yarn playwright install --with-deps --only-shell chromium
 cd /home/ubuntu/jimm
 sg snap_microk8s -c ./local/jimm/setup-microk8s-controller.sh

--- a/scripts/cloud-init-jimm-lxd-oidc.sh
+++ b/scripts/cloud-init-jimm-lxd-oidc.sh
@@ -53,6 +53,13 @@ python3 ./charms/k8s-charm/src/config.py
 sudo iptables -I FORWARD -i lxdbr0 -j ACCEPT
 sudo iptables -I FORWARD -o lxdbr0 -j ACCEPT
 cd /home/ubuntu/juju-dashboard
+# Fix playwright install on 24.04+
+# https://github.com/microsoft/playwright/issues/40117#issuecomment-4346755958
+if [[ "$(arch)" -eq "aarch64" ]]; then
+   export PLAYWRIGHT_HOST_PLATFORM_OVERRIDE="ubuntu24.04-arm64"
+else
+   export PLAYWRIGHT_HOST_PLATFORM_OVERRIDE="ubuntu24.04-x64"
+fi
 yarn playwright install --with-deps --only-shell chromium
 cd /home/ubuntu/jimm
 ./local/jimm/setup-controller.sh

--- a/scripts/cloud-init-jimm-lxd-oidc.yaml
+++ b/scripts/cloud-init-jimm-lxd-oidc.yaml
@@ -51,6 +51,13 @@ write_files:
 
 runcmd:
   - |
+    # Disable IPv6
+    echo "net.ipv6.conf.all.disable_ipv6=1" | sudo tee -a /etc/sysctl.conf
+    echo "net.ipv6.conf.default.disable_ipv6=1" | sudo tee -a /etc/sysctl.conf
+    echo "net.ipv6.conf.lo.disable_ipv6=1" | sudo tee -a /etc/sysctl.conf
+    sudo sysctl -p
+
+  - |
     # Finish Docker setup.
     sudo addgroup --system docker
     sudo adduser ubuntu docker


### PR DESCRIPTION
## Done

- Disable ipv6 when launching a jimm + LXD container
- Fix installing playwright browsers for Ubuntu 24.04
