### PR TITLE
fix: duplicate model destruction toasts

### DIFF
--- a/src/hooks/useModelDestructionToaster.test.tsx
+++ b/src/hooks/useModelDestructionToaster.test.tsx
@@ -4,6 +4,7 @@ import { vi, describe, it, expect, beforeEach } from "vitest";
 
 import { ToastCardTestId } from "components/ToastCard";
 import { actions as jujuActions } from "store/juju";
+import modelListSource from "store/middleware/source/model-list";
 import type { RootState } from "store/store";
 import { jujuStateFactory, rootStateFactory } from "testing/factories";
 import { configFactory, generalStateFactory } from "testing/factories/general";
@@ -75,7 +76,22 @@ describe("useModelDestructionToaster", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows a negative toast and dispatches clear action on failure", async () => {
+  it("does not show duplicate loading toasts on re-render", async () => {
+    state.juju.destroyModel.xyz456 = {
+      modelName: "enterprise",
+      errors: null,
+      loaded: false,
+      loading: true,
+    };
+    renderComponent(<TestComponent />, { state });
+
+    // There should only ever be one loading toast card for this model.
+    expect(
+      await screen.findAllByTestId(ToastCardTestId.TOAST_CARD),
+    ).toHaveLength(1);
+  });
+
+  it("shows a negative toast and dispatches clear and invalidate actions on failure", async () => {
     state.juju.destroyModel.xyz456 = {
       modelName: "enterprise",
       errors: "Permission denied",
@@ -89,6 +105,9 @@ describe("useModelDestructionToaster", () => {
       modelUUID: "xyz456",
       wsControllerURL: "wss://example.com:17070/api",
     });
+    const invalidateAction = modelListSource.actions.invalidate({
+      wsControllerURL: "wss://example.com:17070/api",
+    });
 
     const card = await screen.findByTestId(ToastCardTestId.TOAST_CARD);
     expect(card).toHaveAttribute("data-type", "negative");
@@ -100,32 +119,27 @@ describe("useModelDestructionToaster", () => {
       expect(
         actions.find((dispatch) => dispatch.type === clearAction.type),
       ).toMatchObject(clearAction);
+      expect(
+        actions.find((dispatch) => dispatch.type === invalidateAction.type),
+      ).toMatchObject(invalidateAction);
     });
   });
 
-  it("shows a positive toast and dispatches clear action on success", async () => {
-    state.juju = jujuStateFactory.build({
-      models: {
-        xyz456: modelListInfoFactory.build({
-          uuid: "xyz456",
-          name: "enterprise",
-          qualifier: "user-kirk@external",
-        }),
-      },
-      destroyModel: {
-        abc123: {
-          modelName: "enterprise",
-          errors: null,
-          loaded: true,
-          loading: false,
-        },
-      },
-    });
+  it("shows a positive toast and dispatches clear and invalidate actions on success", async () => {
+    state.juju.destroyModel.xyz456 = {
+      modelName: "enterprise",
+      errors: null,
+      loaded: true,
+      loading: false,
+    };
     const [store, actions] = createStore(state, { trackActions: true });
     renderComponent(<TestComponent />, { state, store });
 
     const clearAction = jujuActions.clearDestroyedModel({
-      modelUUID: "abc123",
+      modelUUID: "xyz456",
+      wsControllerURL: "wss://example.com:17070/api",
+    });
+    const invalidateAction = modelListSource.actions.invalidate({
       wsControllerURL: "wss://example.com:17070/api",
     });
 
@@ -141,18 +155,9 @@ describe("useModelDestructionToaster", () => {
       expect(
         actions.find((dispatch) => dispatch.type === clearAction.type),
       ).toMatchObject(clearAction);
+      expect(
+        actions.find((dispatch) => dispatch.type === invalidateAction.type),
+      ).toMatchObject(invalidateAction);
     });
-  });
-
-  it("takes no action when loaded=true but model is still present", () => {
-    state.juju.destroyModel.xyz456 = {
-      modelName: "enterprise",
-      errors: null,
-      loaded: true,
-      loading: false,
-    };
-    renderComponent(<TestComponent />, { state });
-
-    expect(screen.queryByTestId(ToastCardTestId.TOAST_CARD)).toBeNull();
   });
 });

--- a/src/hooks/useModelDestructionToaster.tsx
+++ b/src/hooks/useModelDestructionToaster.tsx
@@ -8,6 +8,7 @@ import { getDestructionState } from "store/juju/selectors";
 import modelListSource from "store/middleware/source/model-list";
 import { useAppSelector } from "store/store";
 import { externalURLs } from "urls";
+import { toErrorString } from "utils";
 import { toastNotification } from "utils/toastNotification";
 
 export default function useModelDestructionToaster(): void {
@@ -74,8 +75,8 @@ export default function useModelDestructionToaster(): void {
             toastNotification(
               <>
                 <b>Destroying model "{destructionStatus.modelName}" failed</b>
-                <div>
-                  Retry or consult{" "}
+                <div className="u-capitalise--first-letter">
+                  {toErrorString(destructionStatus.errors)}. Retry or consult{" "}
                   <Link to={externalURLs.destroyModel} target="_blank">
                     documentation
                   </Link>

--- a/src/hooks/useModelDestructionToaster.tsx
+++ b/src/hooks/useModelDestructionToaster.tsx
@@ -31,7 +31,6 @@ export default function useModelDestructionToaster(): void {
             toastNotification(
               <b>Destroying model "{destructionStatus.modelName}"...</b>,
               "information",
-              toastId,
             );
             shownToastIds.current.push(toastId);
           }
@@ -48,7 +47,6 @@ export default function useModelDestructionToaster(): void {
                 Model "{destructionStatus.modelName}" destroyed successfully
               </b>,
               "positive",
-              toastId,
             );
             shownToastIds.current.push(toastId);
           }
@@ -83,7 +81,6 @@ export default function useModelDestructionToaster(): void {
                 </div>
               </>,
               "negative",
-              toastId,
             );
             shownToastIds.current.push(toastId);
           }

--- a/src/hooks/useModelDestructionToaster.tsx
+++ b/src/hooks/useModelDestructionToaster.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useDispatch } from "react-redux";
 import { Link } from "react-router";
 
@@ -15,6 +15,9 @@ export default function useModelDestructionToaster(): void {
   const wsControllerURL = useAppSelector(getWSControllerURL);
   const dispatch = useDispatch();
 
+  // Track shown toast IDs to prevent duplicates on re-renders
+  const shownToastIds = useRef<string[]>([]);
+
   useEffect(() => {
     // Iterate over all entries in the destruction state.
     Object.entries(destructionState).forEach(
@@ -22,22 +25,32 @@ export default function useModelDestructionToaster(): void {
         // Check if the destruction is in a loading state.
         if (destructionStatus.loading) {
           // Handle an initiated destruction
-          toastNotification(
-            <b>Destroying model "{destructionStatus.modelName}"...</b>,
-            "information",
-            `destroy-loading-${modelUUID}`,
-          );
+          const toastId = `destroy-loading-${modelUUID}`;
+          if (!shownToastIds.current.includes(toastId)) {
+            toastNotification(
+              <b>Destroying model "{destructionStatus.modelName}"...</b>,
+              "information",
+              toastId,
+            );
+            shownToastIds.current.push(toastId);
+          }
         } else if (
           wsControllerURL &&
           destructionStatus.loaded &&
           destructionStatus.errors === null
         ) {
           // Handle a successful destruction (model is no longer in modelsList)
-          toastNotification(
-            <b>Model "{destructionStatus.modelName}" destroyed successfully</b>,
-            "positive",
-            `destroy-success-${modelUUID}`,
-          );
+          const toastId = `destroy-success-${modelUUID}`;
+          if (!shownToastIds.current.includes(toastId)) {
+            toastNotification(
+              <b>
+                Model "{destructionStatus.modelName}" destroyed successfully
+              </b>,
+              "positive",
+              toastId,
+            );
+            shownToastIds.current.push(toastId);
+          }
           // Invalidate the model list to ensure we have the most up-to-date information.
           dispatch(modelListSource.actions.invalidate({ wsControllerURL }));
 
@@ -47,24 +60,32 @@ export default function useModelDestructionToaster(): void {
               modelUUID,
               wsControllerURL,
             }),
+          );
+          // Remove the loading and success toasts from tracking for future cycles
+          shownToastIds.current = shownToastIds.current.filter(
+            (id) => id !== `destroy-loading-${modelUUID}` && id !== toastId,
           );
         }
 
         if (wsControllerURL && destructionStatus.errors) {
           // Handle a failed destruction
-          toastNotification(
-            <>
-              <b>Destroying model "{destructionStatus.modelName}" failed</b>
-              <div>
-                Retry or consult{" "}
-                <Link to={externalURLs.destroyModel} target="_blank">
-                  documentation
-                </Link>
-              </div>
-            </>,
-            "negative",
-            `destroy-error-${modelUUID}`,
-          );
+          const toastId = `destroy-error-${modelUUID}`;
+          if (!shownToastIds.current.includes(toastId)) {
+            toastNotification(
+              <>
+                <b>Destroying model "{destructionStatus.modelName}" failed</b>
+                <div>
+                  Retry or consult{" "}
+                  <Link to={externalURLs.destroyModel} target="_blank">
+                    documentation
+                  </Link>
+                </div>
+              </>,
+              "negative",
+              toastId,
+            );
+            shownToastIds.current.push(toastId);
+          }
           // Invalidate the model list to ensure we have the most up-to-date information.
           dispatch(modelListSource.actions.invalidate({ wsControllerURL }));
 
@@ -74,6 +95,10 @@ export default function useModelDestructionToaster(): void {
               modelUUID,
               wsControllerURL,
             }),
+          );
+          // Remove the loading and error toasts from tracking for future cycles
+          shownToastIds.current = shownToastIds.current.filter(
+            (id) => id !== `destroy-loading-${modelUUID}` && id !== toastId,
           );
         }
       },

--- a/src/hooks/useModelDestructionToaster.tsx
+++ b/src/hooks/useModelDestructionToaster.tsx
@@ -4,14 +4,14 @@ import { Link } from "react-router";
 
 import { getWSControllerURL } from "store/general/selectors";
 import { actions as jujuActions } from "store/juju";
-import { getDestructionState, getModelList } from "store/juju/selectors";
+import { getDestructionState } from "store/juju/selectors";
+import modelListSource from "store/middleware/source/model-list";
 import { useAppSelector } from "store/store";
 import { externalURLs } from "urls";
 import { toastNotification } from "utils/toastNotification";
 
 export default function useModelDestructionToaster(): void {
   const destructionState = useAppSelector(getDestructionState);
-  const modelsList = useAppSelector(getModelList);
   const wsControllerURL = useAppSelector(getWSControllerURL);
   const dispatch = useDispatch();
 
@@ -25,18 +25,21 @@ export default function useModelDestructionToaster(): void {
           toastNotification(
             <b>Destroying model "{destructionStatus.modelName}"...</b>,
             "information",
+            `destroy-loading-${modelUUID}`,
           );
         } else if (
           wsControllerURL &&
           destructionStatus.loaded &&
-          destructionStatus.errors === null &&
-          !Object.keys(modelsList).includes(modelUUID)
+          destructionStatus.errors === null
         ) {
           // Handle a successful destruction (model is no longer in modelsList)
           toastNotification(
             <b>Model "{destructionStatus.modelName}" destroyed successfully</b>,
             "positive",
+            `destroy-success-${modelUUID}`,
           );
+          // Invalidate the model list to ensure we have the most up-to-date information.
+          dispatch(modelListSource.actions.invalidate({ wsControllerURL }));
 
           // Dispatch the clear action to remove this entry from the state.
           dispatch(
@@ -60,7 +63,10 @@ export default function useModelDestructionToaster(): void {
               </div>
             </>,
             "negative",
+            `destroy-error-${modelUUID}`,
           );
+          // Invalidate the model list to ensure we have the most up-to-date information.
+          dispatch(modelListSource.actions.invalidate({ wsControllerURL }));
 
           // Dispatch the clear action to remove this entry from the state.
           dispatch(
@@ -72,5 +78,5 @@ export default function useModelDestructionToaster(): void {
         }
       },
     );
-  }, [wsControllerURL, modelsList, destructionState, dispatch]);
+  }, [wsControllerURL, destructionState, dispatch]);
 }

--- a/src/pages/AddModel/AccessManagement/utils.ts
+++ b/src/pages/AddModel/AccessManagement/utils.ts
@@ -119,6 +119,7 @@ export const getAccessLevelDisabledReason = (
     // Temporarily disable for JIMM as access reduction for active user needs correction
     // TODO: enable the option for JIMM once the JIMM issue has been fixed:
     // https://warthogs.atlassian.net/browse/JUJU-9822.
+    // https://github.com/canonical/jimm/issues/1978
     if (!isJuju) {
       return Label.ACCESS_CANNOT_BE_CHANGED;
     }

--- a/src/utils/toastNotification.ts
+++ b/src/utils/toastNotification.ts
@@ -11,12 +11,13 @@ export type NotificationSeverity = NotificationProps["severity"];
 export const toastNotification = (
   message: React.ReactElement | string,
   severity: NotificationSeverity = "information",
+  id?: string,
 ): void => {
   toast(
     message,
     // React Hot Toast doesn't officially support custom toast types, but we manually
     // handle these types in our custom renderer. This might not be necessary once this
     // issue is fixed: https://github.com/timolins/react-hot-toast/issues/29.
-    { type: severity } as ToastOptions,
+    { type: severity, ...(id ? { id } : {}) } as ToastOptions,
   );
 };

--- a/src/utils/toastNotification.ts
+++ b/src/utils/toastNotification.ts
@@ -11,13 +11,12 @@ export type NotificationSeverity = NotificationProps["severity"];
 export const toastNotification = (
   message: React.ReactElement | string,
   severity: NotificationSeverity = "information",
-  id?: string,
 ): void => {
   toast(
     message,
     // React Hot Toast doesn't officially support custom toast types, but we manually
     // handle these types in our custom renderer. This might not be necessary once this
     // issue is fixed: https://github.com/timolins/react-hot-toast/issues/29.
-    { type: severity, ...(id ? { id } : {}) } as ToastOptions,
+    { type: severity } as ToastOptions,
   );
 };


### PR DESCRIPTION
## Done

- Sending an id with every toast to avoid double toasting for the same destruction state
- Removed `modelsList` dependency from the `useEffect` as that was simply put there to coordinate the models list and the toast timing. Now that we have source middleware, simply invalidating models list as soon as the destruction is complete is most optimised. This will also prevent unnecessary reruns through the hook.
- Showing the reason for destroy failure in the notification.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Add a few models
- Try deleting them from the dashboard models page one after the other
- You shouldn't see any duplicated toasts

## Details
 Fixes [JUJU-9628](https://warthogs.atlassian.net/browse/JUJU-9628) and https://github.com/canonical/juju-dashboard/issues/2284


[JUJU-9628]: https://warthogs.atlassian.net/browse/JUJU-9628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ