### PR TITLE
feat: display a notification if the upgrade fails

### DIFF
--- a/src/data/sourceRaceIterator.test.ts
+++ b/src/data/sourceRaceIterator.test.ts
@@ -1,0 +1,47 @@
+import type { Source } from "data";
+
+import createSourceRaceIterator from "./sourceRaceIterator";
+
+describe("createSourceRaceIterator", () => {
+  let source1: Source<string>;
+  let source2: Source<string>;
+
+  beforeEach(() => {
+    source1 = {
+      done: vi.fn(),
+      [Symbol.asyncIterator]: async function* () {
+        await Promise.resolve();
+        yield "source1-1";
+        yield "source1-2";
+      },
+    } as unknown as Source<string>;
+    source2 = {
+      done: vi.fn(),
+      [Symbol.asyncIterator]: async function* () {
+        yield "source2-1";
+        await Promise.resolve();
+        yield "source2-2";
+      },
+    } as unknown as Source<string>;
+  });
+
+  it("returns source responses", async () => {
+    const sourceRace = createSourceRaceIterator([source1, source2]);
+    for (const value of [
+      "source2-1",
+      "source1-1",
+      "source1-2",
+      "source2-2",
+      // Done
+      true,
+      // Done
+      true,
+    ]) {
+      const isDone = value === true;
+      await expect(sourceRace.next()).resolves.toEqual({
+        done: isDone,
+        value: isDone ? undefined : value,
+      });
+    }
+  });
+});

--- a/src/data/sourceRaceIterator.ts
+++ b/src/data/sourceRaceIterator.ts
@@ -1,0 +1,43 @@
+import type { Source } from "./source";
+
+/**
+ * Monitor multiple sources for responses.
+ * Usage:
+ *   const source1 = createSource1();
+ *   const source2 = createSource1();
+ *   const sources = createSourceRaceIterator<Result1 | Result2>([source1, source2]);
+ *   for await (const response of sources) {
+ *     ...
+ *   }
+ * @param endOnFirstDone Whether the iterator should finish when the first iterator is done.
+ */
+async function* createSourceRaceIterator<T>(
+  sources: Source<T>[],
+  endOnFirstDone = false,
+): AsyncGenerator<T, void, unknown> {
+  const iterators = sources.map((source) => source[Symbol.asyncIterator]());
+  const next = iterators.map(async (iterator) => iterator.next());
+  while (iterators.length) {
+    const { value, position, done } = await Promise.race(
+      next.map(async (iteratorNext, index) =>
+        iteratorNext.then((result) => ({
+          ...result,
+          position: index,
+        })),
+      ),
+    );
+    if (done) {
+      if (endOnFirstDone) {
+        return;
+      }
+      // This iterator is done so remove it from the race.
+      iterators.splice(position, 1);
+      void next.splice(position, 1);
+      continue;
+    }
+    next[position] = iterators[position].next();
+    yield value;
+  }
+}
+
+export default createSourceRaceIterator;

--- a/src/juju/jimm/JIMMV4.test.ts
+++ b/src/juju/jimm/JIMMV4.test.ts
@@ -195,4 +195,21 @@ describe("JIMMV4", () => {
       expect.any(Function),
     );
   });
+
+  it("jobInfo", async () => {
+    const jimm = new JIMMV4(transport, connectionInfo);
+    void jimm.jobInfo("123");
+    expect(transport.write).toHaveBeenCalledWith(
+      {
+        type: "JIMM",
+        request: "JobInfo",
+        version: 4,
+        params: {
+          "job-id": "123",
+        },
+      },
+      expect.any(Function),
+      expect.any(Function),
+    );
+  });
 });

--- a/src/juju/jimm/JIMMV4.ts
+++ b/src/juju/jimm/JIMMV4.ts
@@ -83,6 +83,35 @@ export type SupportedJujuVersionsResponse = {
   versions: VersionElem[];
 };
 
+// As typed in JIMM:
+// https://github.com/canonical/jimm/blob/4434cb03a24b96c493e861d3dd990c1ff37fff3b/pkg/api/params/params.go#L394
+export type UpgradeToResponse = {
+  success: boolean;
+  "job-id": number;
+};
+
+// As typed in JIMM:
+// https://github.com/canonical/jimm/blob/4434cb03a24b96c493e861d3dd990c1ff37fff3b/pkg/api/params/params.go#L733
+export enum JobStatus {
+  RUNNING = "running",
+  SUCCESSFUL = "successful",
+  PENDING = "pending",
+  FAILED = "failed",
+  UNKNOWN = "unknown",
+}
+
+// As typed in JIMM:
+// https://github.com/canonical/jimm/blob/4434cb03a24b96c493e861d3dd990c1ff37fff3b/pkg/api/params/params.go#L845
+export type JobInfoResponse = {
+  id: number;
+  status: JobStatus;
+  kind: string;
+  current_attempt: number;
+  max_attempts: number;
+  finished_at?: string;
+  errors?: string;
+};
+
 class JIMMV4 extends JIMMV3 {
   static NAME: string;
   static VERSION: number;
@@ -205,7 +234,7 @@ class JIMMV4 extends JIMMV3 {
   async upgradeTo(
     modelTag: string,
     targetController: string,
-  ): Promise<boolean | undefined> {
+  ): Promise<UpgradeToResponse> {
     return new Promise((resolve, reject) => {
       const req = {
         type: "JIMM",
@@ -214,6 +243,27 @@ class JIMMV4 extends JIMMV3 {
         params: {
           "model-tag": modelTag,
           "target-controller-name": targetController,
+        },
+      };
+      this._transport.write(req, resolve, reject);
+    });
+  }
+
+  /**
+   * Get info about a job.
+   *
+   * @param jobId The id of a job.
+   *
+   * @see {@link https://github.com/canonical/jimm/blob/4434cb03a24b96c493e861d3dd990c1ff37fff3b/pkg/api/client.go#L406}
+   */
+  async jobInfo(jobId: string): Promise<JobInfoResponse> {
+    return new Promise((resolve, reject) => {
+      const req = {
+        type: "JIMM",
+        request: "JobInfo",
+        version: 4,
+        params: {
+          "job-id": jobId,
         },
       };
       this._transport.write(req, resolve, reject);

--- a/src/juju/jimm/api.test.ts
+++ b/src/juju/jimm/api.test.ts
@@ -452,7 +452,7 @@ describe("JIMM API", () => {
   });
 
   describe("upgradeTo", () => {
-    it("makes and upgrade call", async () => {
+    it("makes an upgrade call", async () => {
       const conn = {
         facades: {
           jimM: {
@@ -492,7 +492,7 @@ describe("JIMM API", () => {
   });
 
   describe("jobInfo", () => {
-    it("makes and upgrade call", async () => {
+    it("makes a job info call", async () => {
       const conn = {
         facades: {
           jimM: {

--- a/src/juju/jimm/api.test.ts
+++ b/src/juju/jimm/api.test.ts
@@ -19,6 +19,7 @@ import {
   listMigrationTargets,
   supportedJujuVersions,
   upgradeTo,
+  jobInfo,
 } from "./api";
 
 describe("JIMM API", () => {
@@ -487,6 +488,41 @@ describe("JIMM API", () => {
       await expect(
         upgradeTo(conn, "model-abc123", "controller123"),
       ).rejects.toThrow(new Error("Uh oh!"));
+    });
+  });
+
+  describe("jobInfo", () => {
+    it("makes and upgrade call", async () => {
+      const conn = {
+        facades: {
+          jimM: {
+            jobInfo: vi.fn().mockResolvedValue(true),
+          },
+        },
+      } as unknown as Connection;
+      const response = await jobInfo(conn, "123");
+      expect(conn.facades.jimM.jobInfo).toHaveBeenCalledExactlyOnceWith("123");
+      expect(response).toBe(true);
+    });
+
+    it("handles no JIMM connection", async () => {
+      const conn = {
+        facades: {},
+      } as unknown as Connection;
+      await expect(jobInfo(conn, "123")).rejects.toThrow(
+        new Error(Label.NO_JIMM),
+      );
+    });
+
+    it("should handle exceptions", async () => {
+      const conn = {
+        facades: {
+          jimM: {
+            jobInfo: vi.fn().mockRejectedValue(new Error("Uh oh!")),
+          },
+        },
+      } as unknown as Connection;
+      await expect(jobInfo(conn, "123")).rejects.toThrow(new Error("Uh oh!"));
     });
   });
 });

--- a/src/juju/jimm/api.ts
+++ b/src/juju/jimm/api.ts
@@ -7,10 +7,12 @@ import type {
   CheckRelationResponse,
   CheckRelationsResponse,
   CrossModelQueryResponse,
+  JobInfoResponse,
   ListControllersResponse,
   MigrateModelInfo,
   RelationshipTuple,
   SupportedJujuVersionsResponse,
+  UpgradeToResponse,
 } from "./JIMMV4";
 
 export enum Label {
@@ -133,9 +135,19 @@ export const upgradeTo = async (
   conn: ConnectionWithFacades,
   modelTag: string,
   targetController: string,
-): Promise<boolean> => {
+): Promise<UpgradeToResponse> => {
   return withJimmCheck(
     conn,
-    async (jimm) => (await jimm.upgradeTo(modelTag, targetController)) ?? false,
+    async (jimm) => await jimm.upgradeTo(modelTag, targetController),
   );
+};
+
+/*
+ * Get info about a job.
+ */
+export const jobInfo = async (
+  conn: ConnectionWithFacades,
+  jobId: string,
+): Promise<JobInfoResponse> => {
+  return withJimmCheck(conn, async (jimm) => await jimm.jobInfo(jobId));
 };

--- a/src/store/middleware/process/model-upgrade/job-info-source.test.ts
+++ b/src/store/middleware/process/model-upgrade/job-info-source.test.ts
@@ -1,0 +1,44 @@
+import type { Mock } from "vitest";
+
+import { Label } from "juju/jimm/api";
+import type { ManagedConnection } from "store/middleware/connection/connection-manager";
+import { jobInfoFactory } from "testing/factories/juju/jimm";
+
+import { getJobInfo } from "./job-info-source";
+
+describe("createJobInfoSource", () => {
+  let connection: ManagedConnection;
+  let jobInfoMock: Mock;
+
+  beforeEach(() => {
+    jobInfoMock = vi.fn().mockResolvedValue(jobInfoFactory.build());
+    connection = {
+      facades: {
+        jimM: {
+          jobInfo: jobInfoMock,
+        },
+      },
+    } as unknown as ManagedConnection;
+  });
+
+  it("calls `jobInfo` method on provided connection", async ({ expect }) => {
+    const tryConnection = getJobInfo(connection, "1");
+    expect(jobInfoMock).not.toHaveBeenCalled();
+
+    await expect(tryConnection()).resolves.toEqual(jobInfoFactory.build());
+    expect(jobInfoMock).toHaveBeenCalledTimes(1);
+
+    await expect(tryConnection()).resolves.toEqual(jobInfoFactory.build());
+    expect(jobInfoMock).toHaveBeenCalledTimes(2);
+
+    await expect(tryConnection()).resolves.toEqual(jobInfoFactory.build());
+    expect(jobInfoMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("throws error if `jimM` facade isn't present", async ({ expect }) => {
+    delete connection.facades.jimM;
+
+    const tryConnection = getJobInfo(connection, "1");
+    await expect(tryConnection()).rejects.toThrowError(Label.NO_JIMM);
+  });
+});

--- a/src/store/middleware/process/model-upgrade/job-info-source.ts
+++ b/src/store/middleware/process/model-upgrade/job-info-source.ts
@@ -1,0 +1,38 @@
+import type { Source } from "data";
+import { createPollingSource } from "data/pollingSource";
+import type { JobInfoResponse } from "juju/jimm/JIMMV4";
+import { jobInfo } from "juju/jimm/api";
+import type { ManagedConnection } from "store/middleware/connection/connection-manager";
+
+/**
+ * Timeout in seconds to poll the job info.
+ */
+const JOB_INFO_POLL_S = 5;
+
+/**
+ * Internal logic for `createJobInfoSource`.
+ *
+ * Saves a connection, and whenever the returned function is called, it will try to call the
+ * `fullStatus` facade method. If the call fails, it will clear the connection, and attempt to
+ * reconnect on the next call.
+ */
+export function getJobInfo(
+  controllerConnection: ManagedConnection,
+  jobId: string,
+) {
+  return async (): Promise<JobInfoResponse> =>
+    jobInfo(controllerConnection, jobId);
+}
+
+/**
+ * A source which will produce the version of a model, or an indication that it's being reconnected
+ * to.
+ */
+export default function createJobInfoSource(
+  controllerConnection: ManagedConnection,
+  jobId: string,
+): Source<JobInfoResponse> {
+  return createPollingSource(getJobInfo(controllerConnection, jobId), {
+    interval: { seconds: JOB_INFO_POLL_S },
+  });
+}

--- a/src/store/middleware/process/model-upgrade/job-info-source.ts
+++ b/src/store/middleware/process/model-upgrade/job-info-source.ts
@@ -12,9 +12,7 @@ const JOB_INFO_POLL_S = 5;
 /**
  * Internal logic for `createJobInfoSource`.
  *
- * Saves a connection, and whenever the returned function is called, it will try to call the
- * `fullStatus` facade method. If the call fails, it will clear the connection, and attempt to
- * reconnect on the next call.
+ * Fetches job info from JIMM.
  */
 export function getJobInfo(
   controllerConnection: ManagedConnection,
@@ -25,7 +23,7 @@ export function getJobInfo(
 }
 
 /**
- * A source which will produce the version of a model, or an indication that it's being reconnected
+ * A source which will produce the job info for the provided id.
  * to.
  */
 export default function createJobInfoSource(

--- a/src/store/middleware/process/model-upgrade/model-connection-retry-source.ts
+++ b/src/store/middleware/process/model-upgrade/model-connection-retry-source.ts
@@ -10,7 +10,9 @@ import { logger } from "utils/logger";
  */
 const MODEL_STATUS_POLL_S = 5;
 
-type ConnectionRetryResult = { reconnecting: true } | { version: string };
+export type ConnectionRetryResult =
+  | { reconnecting: true }
+  | { version: string };
 
 /**
  * Internal logic for `createModelConnectionRetrySource`.

--- a/src/store/middleware/process/model-upgrade/upgrade-to.test.ts
+++ b/src/store/middleware/process/model-upgrade/upgrade-to.test.ts
@@ -1,10 +1,14 @@
 import type { Mock, MockInstance } from "vitest";
 
 import type { Source } from "data";
+import { JobStatus, type JobInfoResponse } from "juju/jimm/JIMMV4";
 import * as jimmApi from "juju/jimm/api";
 import type { ManagedConnection } from "store/middleware/connection/connection-manager";
+import { jobInfoFactory } from "testing/factories/juju/jimm";
 
+import * as jobInfoSourceModule from "./job-info-source";
 import * as modelConnectionRetrySourceModule from "./model-connection-retry-source";
+import type { ConnectionRetryResult } from "./model-connection-retry-source";
 import { upgradeTo, default as upgradeToProcess } from "./upgrade-to";
 
 describe("upgradeTo", () => {
@@ -14,9 +18,10 @@ describe("upgradeTo", () => {
   let upgradeToMock: MockInstance;
   let modelStatusSourceDoneMock: Mock;
   let modelStatusSource: MockInstance;
-  let modelStatusSourceImplementation: Source<
-    { reconnecting: true } | { version: string }
-  >;
+  let modelStatusSourceImplementation: Source<ConnectionRetryResult>;
+  let jobInfoSourceDoneMock: Mock;
+  let jobInfoSource: MockInstance;
+  let jobInfoSourceImplementation: Source<JobInfoResponse>;
 
   beforeEach(() => {
     vi.useFakeTimers();
@@ -24,17 +29,29 @@ describe("upgradeTo", () => {
     controllerConnection = {} as ManagedConnection;
     modelConnection = {} as ManagedConnection;
 
-    upgradeToMock = vi.spyOn(jimmApi, "upgradeTo").mockResolvedValue(true);
+    upgradeToMock = vi
+      .spyOn(jimmApi, "upgradeTo")
+      .mockResolvedValue({ success: true, "job-id": 1 });
     modelStatusSourceDoneMock = vi.fn();
     modelStatusSourceImplementation = {
       done: modelStatusSourceDoneMock,
       [Symbol.asyncIterator]: async function* () {
         yield { version: "1.2.3" };
       },
-    } as unknown as Source<{ reconnecting: true } | { version: string }>;
+    } as unknown as Source<ConnectionRetryResult>;
     modelStatusSource = vi
       .spyOn(modelConnectionRetrySourceModule, "default")
       .mockReturnValue(modelStatusSourceImplementation);
+    jobInfoSourceDoneMock = vi.fn();
+    jobInfoSourceImplementation = {
+      done: jobInfoSourceDoneMock,
+      [Symbol.asyncIterator]: async function* () {
+        yield jobInfoFactory.build();
+      },
+    } as unknown as Source<JobInfoResponse>;
+    jobInfoSource = vi
+      .spyOn(jobInfoSourceModule, "default")
+      .mockReturnValue(jobInfoSourceImplementation);
   });
 
   describe("JIMM `upgradeTo` request", () => {
@@ -63,7 +80,7 @@ describe("upgradeTo", () => {
 
     it("throws an error if request isn't successful", async ({ expect }) => {
       expect.assertions(3);
-      upgradeToMock.mockResolvedValue(false);
+      upgradeToMock.mockResolvedValue({ success: false, "job-id": 1 });
       const progress = upgradeTo(
         "abc123",
         "some-controller",
@@ -90,7 +107,7 @@ describe("upgradeTo", () => {
 
   describe("model `fullStatus` polling", () => {
     it("begins polling model after success", async ({ expect }) => {
-      expect.assertions(1);
+      expect.assertions(2);
       const progress = upgradeTo(
         "abc123",
         "some-controller",
@@ -106,22 +123,36 @@ describe("upgradeTo", () => {
       expect(modelStatusSource).toHaveBeenCalledExactlyOnceWith(
         modelConnection,
       );
+      expect(jobInfoSource).toHaveBeenCalledExactlyOnceWith(
+        controllerConnection,
+        "1",
+      );
     });
 
     describe("while polling", () => {
-      let promises: PromiseWithResolvers<
-        { reconnecting: true } | { version: string }
-      >[];
+      let modelStatusPromises: PromiseWithResolvers<ConnectionRetryResult>[];
+      let jobInfoPromises: PromiseWithResolvers<JobInfoResponse>[];
 
       beforeEach(() => {
-        promises = new Array(10).fill(null).map(() => Promise.withResolvers());
+        modelStatusPromises = new Array(10)
+          .fill(null)
+          .map(() => Promise.withResolvers());
+        jobInfoPromises = new Array(10)
+          .fill(null)
+          .map(() => Promise.withResolvers());
         modelStatusSourceImplementation[Symbol.asyncIterator] =
           async function* (): AsyncGenerator<
-            { reconnecting: true } | { version: string },
+            ConnectionRetryResult,
             void,
             void
           > {
-            for (const { promise } of promises) {
+            for (const { promise } of modelStatusPromises) {
+              yield await promise;
+            }
+          };
+        jobInfoSourceImplementation[Symbol.asyncIterator] =
+          async function* (): AsyncGenerator<JobInfoResponse, void, void> {
+            for (const { promise } of jobInfoPromises) {
               yield await promise;
             }
           };
@@ -145,19 +176,43 @@ describe("upgradeTo", () => {
           .next()
           .then(statusResolvedMock.mockImplementation((value) => value));
 
-        promises[0].resolve({ version: "0.0.0" });
+        modelStatusPromises[0].resolve({ version: "0.0.0" });
         await vi.runOnlyPendingTimersAsync();
         expect(statusResolvedMock).not.toHaveBeenCalled();
 
-        promises[1].resolve({ version: "0.0.0" });
+        modelStatusPromises[1].resolve({ version: "0.0.0" });
         await vi.runOnlyPendingTimersAsync();
         expect(statusResolvedMock).not.toHaveBeenCalled();
 
-        promises[2].resolve({ version: "1.2.3" });
+        modelStatusPromises[2].resolve({ version: "1.2.3" });
         await vi.runOnlyPendingTimersAsync();
         expect(statusResolvedMock).toHaveBeenCalledOnce();
 
         await expect(nextStatus).resolves.toEqual({ done: true });
+      });
+
+      it("exits with an error if the job failed", async ({ expect }) => {
+        expect.assertions(1);
+        const progress = upgradeTo(
+          "abc123",
+          "some-controller",
+          "1.2.3",
+          controllerConnection,
+          modelConnection,
+        );
+
+        await progress.next(); // Pending
+        await progress.next(); // Initiating
+
+        const statusResolvedMock = vi.fn();
+        const nextStatus = progress
+          .next()
+          .then(statusResolvedMock.mockImplementation((value) => value));
+
+        jobInfoPromises[0].resolve(
+          jobInfoFactory.build({ status: JobStatus.FAILED }),
+        );
+        await expect(nextStatus).rejects.toThrow(new Error("Upgrade failed"));
       });
 
       it("calls `done` on source after completion", async ({ expect }) => {
@@ -170,7 +225,7 @@ describe("upgradeTo", () => {
           modelConnection,
         );
 
-        promises[0].resolve({ version: "1.2.3" });
+        modelStatusPromises[0].resolve({ version: "1.2.3" });
 
         await progress.next(); // Pending
         await progress.next(); // Initiating
@@ -197,11 +252,11 @@ describe("upgradeTo", () => {
           .next()
           .then(statusResolvedMock.mockImplementation((value) => value));
 
-        promises[0].resolve({ version: "0.0.0" });
+        modelStatusPromises[0].resolve({ version: "0.0.0" });
         await vi.runOnlyPendingTimersAsync();
         expect(statusResolvedMock).not.toHaveBeenCalled();
 
-        promises[1].resolve({ reconnecting: true });
+        modelStatusPromises[1].resolve({ reconnecting: true });
         await vi.runOnlyPendingTimersAsync();
         expect(statusResolvedMock).toHaveBeenCalled();
 
@@ -224,10 +279,14 @@ describe("upgradeTo", () => {
         await progress.next(); // Pending
         await progress.next(); // Initiating
 
-        promises.slice(0, promises.length - 1).map(({ resolve }) => {
-          resolve({ version: "0.0.0" });
+        modelStatusPromises
+          .slice(0, modelStatusPromises.length - 1)
+          .map(({ resolve }) => {
+            resolve({ version: "0.0.0" });
+          });
+        modelStatusPromises[modelStatusPromises.length - 1].resolve({
+          version: "1.2.3",
         });
-        promises[promises.length - 1].resolve({ version: "1.2.3" });
 
         await expect(progress.next()).resolves.toEqual({
           value: { status: "loading" },

--- a/src/store/middleware/process/model-upgrade/upgrade-to.ts
+++ b/src/store/middleware/process/model-upgrade/upgrade-to.ts
@@ -1,3 +1,5 @@
+import createSourceRaceIterator from "data/sourceRaceIterator";
+import { JobStatus, type JobInfoResponse } from "juju/jimm/JIMMV4";
 import * as jimmApi from "juju/jimm/api";
 import { createToast } from "store/app/actions";
 import { actions as jujuActions } from "store/juju";
@@ -8,6 +10,8 @@ import { logger } from "utils/logger";
 
 import { createProcess } from "../createProcess";
 
+import createJobInfoSource from "./job-info-source";
+import type { ConnectionRetryResult } from "./model-connection-retry-source";
 import createModelConnectionRetrySource from "./model-connection-retry-source";
 
 enum UpgradeStatus {
@@ -54,18 +58,32 @@ export async function* upgradeTo(
   yield { status: UpgradeStatus.PENDING };
   const result = await request;
 
-  if (!result) {
+  if (!result.success) {
     throw new Error("migration request rejected");
   }
 
   yield { status: UpgradeStatus.INITIATED };
 
   // Poll for model version.
-  const source = createModelConnectionRetrySource(modelConnection);
+  const versionSource = createModelConnectionRetrySource(modelConnection);
+  const jobInfoSource = createJobInfoSource(
+    controllerConnection,
+    result["job-id"].toString(),
+  );
   let statusCount = 0;
-  for await (const retry of source) {
-    if ("version" in retry) {
-      if (retry.version === targetVersion) {
+  const sources = createSourceRaceIterator<
+    ConnectionRetryResult | JobInfoResponse
+  >([versionSource, jobInfoSource], true);
+  for await (const response of sources) {
+    if ("status" in response) {
+      if (response.status === JobStatus.FAILED) {
+        versionSource.done();
+        jobInfoSource.done();
+        throw new Error("Upgrade failed");
+      }
+    }
+    if ("version" in response) {
+      if (response.version === targetVersion) {
         // The model has reached the target version so the source can now finish.
         break;
       }
@@ -79,7 +97,8 @@ export async function* upgradeTo(
       yield { status: UpgradeStatus.RECONNECTING };
     }
   }
-  source.done();
+  versionSource.done();
+  jobInfoSource.done();
 }
 
 export default createProcess<Params, UpgradeState, void>(
@@ -114,7 +133,7 @@ export default createProcess<Params, UpgradeState, void>(
           outcome.error,
         );
         return createToast({
-          message: `Error during upgrade of "${modelName}": ${outcome.error.message}`,
+          message: `Failed to upgrade. Model "${modelName}" has not been migrated or upgraded. Try again or contact support.`,
           severity: "negative",
         });
       } else {

--- a/src/testing/factories/juju/jimm.ts
+++ b/src/testing/factories/juju/jimm.ts
@@ -1,8 +1,12 @@
 import { Factory } from "fishery";
 
 import type { AuditEvent } from "juju/jimm/JIMMV3";
-import type { RelationshipTuple, VersionElem } from "juju/jimm/JIMMV4";
-import { JIMMRelation } from "juju/jimm/JIMMV4";
+import type {
+  JobInfoResponse,
+  RelationshipTuple,
+  VersionElem,
+} from "juju/jimm/JIMMV4";
+import { JIMMRelation, JobStatus } from "juju/jimm/JIMMV4";
 import type {
   ModelMigrationTargetsState,
   ReBACAllowed,
@@ -209,4 +213,12 @@ export const modelMigrationTargetFactory = Factory.define<
   data: null,
   error: null,
   loading: false,
+}));
+
+export const jobInfoFactory = Factory.define<JobInfoResponse>(() => ({
+  id: 1,
+  status: JobStatus.RUNNING,
+  kind: "migrate-model",
+  current_attempt: 1,
+  max_attempts: 3,
 }));


### PR DESCRIPTION
## Done

- Display a notification if the upgrade job fails.

## QA

- Set up controllers for a migration (see the HACKING doc).
- Add a model to migrate and then in your terminal get ready to delete the model immediately after you start the migration: `juju destroy-model --no-prompt --force --no-wait test-model-name` (don't press enter yet).
- In the dashboard start the migration and then immediately press enter in your terminal to delete the model (it might give an error so you might need to try and delete it a few times).
- Wait for JIMM to attempt the migration (it might take a few minutes while JIMM tries to retry the migration) and then a notification should appear with a message that the migration failed.

## Details

https://warthogs.atlassian.net/browse/JUJU-9507
