### PR TITLE
chore: enable owner access reduction for jimm

### DIFF
--- a/src/pages/AddModel/AccessManagement/AccessManagement.test.tsx
+++ b/src/pages/AddModel/AccessManagement/AccessManagement.test.tsx
@@ -259,7 +259,7 @@ describe("AccessManagement", () => {
     expect(adminButtons[0]).not.toHaveAttribute("aria-disabled", "true");
   });
 
-  it("does not enable the active user dropdown when another user has admin access for JIMM", async () => {
+  it("enables the active user dropdown when another user has admin access for JIMM", async () => {
     const state = rootStateFactory.build({
       general: generalStateFactory.build({
         config: configFactory.build({
@@ -283,7 +283,7 @@ describe("AccessManagement", () => {
     );
 
     const adminButtons = screen.getAllByRole("button", { name: "Admin" });
-    expect(adminButtons[0]).toHaveAttribute("aria-disabled", "true");
+    expect(adminButtons[0]).not.toHaveAttribute("aria-disabled", "true");
   });
 
   it("returns the active user's permission to 'admin' if all other admins are removed", async () => {

--- a/src/pages/AddModel/AccessManagement/types.ts
+++ b/src/pages/AddModel/AccessManagement/types.ts
@@ -22,7 +22,6 @@ export enum Label {
   HEADER_ACCESS_LEVEL = "Access Level",
   BUTTON_DELETE = "Delete",
   ONE_ADMIN_REQUIRED = "You cannot change access. At least one admin required per model.",
-  ACCESS_CANNOT_BE_CHANGED = "Model owner access cannot be changed.",
   SUPERUSER_ACCESS_CANNOT_BE_CHANGED = "Controller superusers cannot change their own model access.",
 }
 

--- a/src/pages/AddModel/AccessManagement/utils.test.ts
+++ b/src/pages/AddModel/AccessManagement/utils.test.ts
@@ -262,7 +262,7 @@ describe("AccessManagement utils", () => {
       expect(result).toBeUndefined();
     });
 
-    it("returns true for active user on JIMM, even when another admin exists", () => {
+    it("returns false for active user on JIMM when another admin exists", () => {
       const result = getAccessLevelDisabledReason(
         "user@example.com",
         {
@@ -273,7 +273,7 @@ describe("AccessManagement utils", () => {
         false,
         "user@example.com",
       );
-      expect(result).toBeDefined();
+      expect(result).toBeUndefined();
     });
 
     it("returns false when user is not active", () => {

--- a/src/pages/AddModel/AccessManagement/utils.ts
+++ b/src/pages/AddModel/AccessManagement/utils.ts
@@ -116,15 +116,8 @@ export const getAccessLevelDisabledReason = (
   );
 
   if (userValue === activeUserName) {
-    // Temporarily disable for JIMM as access reduction for active user needs correction
-    // TODO: enable the option for JIMM once the JIMM issue has been fixed:
-    // https://warthogs.atlassian.net/browse/JUJU-9822.
-    // https://github.com/canonical/jimm/issues/1978
-    if (!isJuju) {
-      return Label.ACCESS_CANNOT_BE_CHANGED;
-    }
     // Always disable for controller superusers
-    else if (activeUserControllerAccess === "superuser") {
+    if (activeUserControllerAccess === "superuser") {
       return Label.SUPERUSER_ACCESS_CANNOT_BE_CHANGED;
     }
     // Disable if active user is admin and there are no other admins to prevent locking themselves out.


### PR DESCRIPTION
## Done

- Enabled model owner access reduction flow for JIMM.
This was previously disabled due to a mismatch between how JIMM did access management vs how juju did.
- Updated tests.
- Removed unused label.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Point the dashboard to JIMM and login as a non-JIMM admin, non-superuser.
- Open the "AddModel" page and fill in the mandatory details.
- Go to the "Access Management" tab and add another user to share the model with.
- Check that the model owner's access dropdown remains disabled so far.
- Now, bump the newly added user's access to admin.
- Model owner's dropdown should now be enabled (this was not the case previously).
- Lower the model owner's permission to "read" and add the model.
- The model should be added successfully and the model should appear in the model's list with appropriate user access for both the model owner and the other user.

## Details

https://warthogs.atlassian.net/browse/JUJU-9822

## Recordings

https://github.com/user-attachments/assets/a656dd67-8328-4a37-b7bc-1e2106967349

