### PR TITLE
feat: add error state to stepper, validation to access tab

### DIFF
--- a/src/pages/AddModel/AccessManagement/AccessManagement.test.tsx
+++ b/src/pages/AddModel/AccessManagement/AccessManagement.test.tsx
@@ -231,6 +231,86 @@ describe("AccessManagement", () => {
     expect(screen.getByText(FormatHint.JIMM)).toBeInTheDocument();
   });
 
+  it("shows incorrect email format only after an invalid add click for JIMM", async () => {
+    const state = rootStateFactory.build({
+      general: generalStateFactory.build({
+        config: configFactory.build({ isJuju: false }),
+      }),
+    });
+    renderComponent(
+      <Formik initialValues={{ shareModelWith: {} }} onSubmit={vi.fn()}>
+        <AccessManagement />
+      </Formik>,
+      { state },
+    );
+
+    const input = screen.getByRole("combobox", {
+      name: Label.MULTI_SELECT_LABEL,
+    });
+    await userEvent.type(input, "not-an-email");
+    expect(screen.getByText(FormatHint.JIMM)).toBeInTheDocument();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /not-an-email/i }),
+    );
+    expect(screen.getByText(Label.INCORRECT_EMAIL_FORMAT)).toBeInTheDocument();
+  });
+
+  it("restores the JIMM format hint when the user keeps typing after an invalid add click", async () => {
+    const state = rootStateFactory.build({
+      general: generalStateFactory.build({
+        config: configFactory.build({ isJuju: false }),
+      }),
+    });
+    renderComponent(
+      <Formik initialValues={{ shareModelWith: {} }} onSubmit={vi.fn()}>
+        <AccessManagement />
+      </Formik>,
+      { state },
+    );
+
+    const input = screen.getByRole("combobox", {
+      name: Label.MULTI_SELECT_LABEL,
+    });
+
+    await userEvent.type(input, "not-an-email");
+    await userEvent.click(
+      screen.getByRole("button", { name: /not-an-email/i }),
+    );
+    expect(screen.getByText(Label.INCORRECT_EMAIL_FORMAT)).toBeInTheDocument();
+
+    await userEvent.type(input, "x");
+    expect(screen.getByText(FormatHint.JIMM)).toBeInTheDocument();
+  });
+
+  it("restores the JIMM format hint when the search is cleared", async () => {
+    const state = rootStateFactory.build({
+      general: generalStateFactory.build({
+        config: configFactory.build({ isJuju: false }),
+      }),
+    });
+    renderComponent(
+      <Formik initialValues={{ shareModelWith: {} }} onSubmit={vi.fn()}>
+        <AccessManagement />
+      </Formik>,
+      { state },
+    );
+
+    const input = screen.getByRole("combobox", {
+      name: Label.MULTI_SELECT_LABEL,
+    });
+
+    await userEvent.type(input, "not-an-email");
+    await userEvent.click(
+      screen.getByRole("button", { name: /not-an-email/i }),
+    );
+    expect(screen.getByText(Label.INCORRECT_EMAIL_FORMAT)).toBeInTheDocument();
+
+    await userEvent.clear(input);
+    await userEvent.click(input);
+    expect(screen.getByText(AddUserHint.JIMM)).toBeInTheDocument();
+  });
+
   it("enables active user dropdown when another user has admin access for Juju", async () => {
     const state = rootStateFactory.build({
       general: generalStateFactory.build({

--- a/src/pages/AddModel/AccessManagement/AccessManagement.tsx
+++ b/src/pages/AddModel/AccessManagement/AccessManagement.tsx
@@ -110,6 +110,7 @@ const AccessManagement = (): JSX.Element => {
             variant="search"
             searchButtonType="button"
             inputClassName="u-no-margin--bottom u-sv1--top"
+            dropdownClassName="u-overflow--scroll"
             footerClassName="access-management__dropdown-footer u-no-padding--left u-no-padding--right"
             placeholder={Label.MULTI_SELECT_PLACEHOLDER}
             label={Label.MULTI_SELECT_LABEL}
@@ -123,11 +124,13 @@ const AccessManagement = (): JSX.Element => {
                   <Button
                     appearance="base"
                     type="button"
-                    className="u-align--left u-full-width u-no-margin--bottom u-sv-1--top"
+                    className="u-align--left u-full-width u-no-margin--bottom u-sv-1--top add-user-button"
                     onClick={handleAddUser}
                   >
-                    <Icon name="plus" className="u-sh1--right" />
-                    {trimmedSearchInput}
+                    <span className="u-truncate">
+                      <Icon name="plus" className="u-sh1--right" />
+                      {trimmedSearchInput}
+                    </span>
                     <p
                       className={classNames(
                         "u-text--muted",

--- a/src/pages/AddModel/AccessManagement/AccessManagement.tsx
+++ b/src/pages/AddModel/AccessManagement/AccessManagement.tsx
@@ -5,6 +5,7 @@ import {
   Tooltip,
   type MultiSelectItem,
 } from "@canonical/react-components";
+import classNames from "classnames";
 import { useFormikContext } from "formik";
 import type { JSX } from "react";
 import { useState } from "react";
@@ -33,6 +34,8 @@ import {
   getUserAccess,
 } from "./utils";
 
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
 const AccessManagement = (): JSX.Element => {
   const isJuju = useAppSelector(getIsJuju);
   const wsControllerURL = useAppSelector(getWSControllerURL);
@@ -44,6 +47,7 @@ const AccessManagement = (): JSX.Element => {
   );
   const { values, setFieldValue } = useFormikContext<AddModelFormState>();
   const [searchInput, setSearchInput] = useState("");
+  const [showInvalidEmailHint, setShowInvalidEmailHint] = useState(false);
 
   const activeUserName = userName ? getUserName(userName) : undefined;
   const shareModelWith = values.shareModelWith ?? {};
@@ -81,6 +85,13 @@ const AccessManagement = (): JSX.Element => {
       return;
     }
 
+    if (!isJuju && !EMAIL_PATTERN.test(trimmedSearchInput)) {
+      setShowInvalidEmailHint(true);
+      return;
+    }
+
+    setShowInvalidEmailHint(false);
+
     void setFieldValue(
       `shareModelWith["${trimmedSearchInput}"]`,
       AccessLevel.READ,
@@ -117,8 +128,20 @@ const AccessManagement = (): JSX.Element => {
                   >
                     <Icon name="plus" className="u-sh1--right" />
                     {trimmedSearchInput}
-                    <p className="u-text--muted p-text--small u-sh3 u-sv-1">
-                      {formatHint}
+                    <p
+                      className={classNames(
+                        "u-text--muted",
+                        "p-text--small",
+                        "u-sh3",
+                        "u-sv-1",
+                        {
+                          "is-negative": showInvalidEmailHint,
+                        },
+                      )}
+                    >
+                      {showInvalidEmailHint
+                        ? Label.INCORRECT_EMAIL_FORMAT
+                        : formatHint}
                     </p>
                   </Button>
                 ) : (
@@ -131,9 +154,13 @@ const AccessManagement = (): JSX.Element => {
             disabledItems={ACTIVE_USER ? [ACTIVE_USER] : []}
             items={selectedItems}
             selectedItems={selectedItems}
-            onSearchChange={setSearchInput}
+            onSearchChange={(value) => {
+              setSearchInput(value);
+              setShowInvalidEmailHint(false);
+            }}
             onClose={() => {
               setSearchInput("");
+              setShowInvalidEmailHint(false);
             }}
             onItemsUpdate={handleItemsUpdate}
           />

--- a/src/pages/AddModel/AccessManagement/_access-management.scss
+++ b/src/pages/AddModel/AccessManagement/_access-management.scss
@@ -1,6 +1,10 @@
 .access-management {
   &__dropdown-footer {
     border: none;
+
+    .is-negative {
+      color: $color-negative;
+    }
   }
 
   &__access-col {

--- a/src/pages/AddModel/AccessManagement/_access-management.scss
+++ b/src/pages/AddModel/AccessManagement/_access-management.scss
@@ -2,6 +2,10 @@
   &__dropdown-footer {
     border: none;
 
+    .add-user-button {
+      display: grid;
+    }
+
     .is-negative {
       color: $color-negative;
     }

--- a/src/pages/AddModel/AccessManagement/types.ts
+++ b/src/pages/AddModel/AccessManagement/types.ts
@@ -18,6 +18,7 @@ export enum Label {
   MULTI_SELECT_LABEL = "Add users",
   MULTI_SELECT_PLACEHOLDER = "Search and add users",
   MULTI_SELECT_NO_USERS = "No users found",
+  INCORRECT_EMAIL_FORMAT = "Incorrect email format",
   HEADER_USER_NAME = "User Name",
   HEADER_ACCESS_LEVEL = "Access Level",
   BUTTON_DELETE = "Delete",

--- a/src/pages/AddModel/AddModel.test.tsx
+++ b/src/pages/AddModel/AddModel.test.tsx
@@ -183,6 +183,25 @@ describe("AddModel page", () => {
     ).not.toHaveAttribute("aria-disabled");
   });
 
+  it("renders an error icon on the stepper after leaving it with invalid input", async () => {
+    renderComponent(<AddModel />, { state });
+    await userEvent.type(
+      screen.getByLabelText(new RegExp(MandatoryDetailsLabel.MODEL_NAME)),
+      "-model",
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: Label.NEXT_BUTTON }),
+    );
+
+    const mandatoryDetailsStep = screen
+      .getByText("Mandatory Details")
+      .closest(".step");
+    expect(mandatoryDetailsStep).not.toBeNull();
+    expect(
+      (mandatoryDetailsStep as HTMLElement).querySelector(".p-icon--error"),
+    ).toBeInTheDocument();
+  });
+
   it("navigates to steps when clicking step titles", async () => {
     renderComponent(<AddModel />, { state });
     await userEvent.click(

--- a/src/pages/AddModel/AddModel.tsx
+++ b/src/pages/AddModel/AddModel.tsx
@@ -49,16 +49,21 @@ const stepDefinitions: Array<{
   key: StepType;
   title: string;
   content: JSX.Element;
+  validatedFields?: string[];
+  errorLabel?: string;
 }> = [
   {
     key: StepType.MANDATORY_DETAILS,
     title: "Mandatory Details",
     content: <MandatoryDetails />,
+    validatedFields: ["modelName"],
+    errorLabel: Label.INCORRECT_MODEL_NAME_ERROR,
   },
   {
     key: StepType.CONFIGURATION_CONSTRAINTS,
     title: "Configuration & Constraints (optional)",
     content: <ConfigsConstraints />,
+    errorLabel: Label.INCORRECT_CONFIG_ERROR,
   },
   {
     key: StepType.ACCESS_MANAGEMENT,
@@ -149,26 +154,6 @@ const AddModel: FC = () => {
         {...testId(TestId.COMPONENT)}
         stickyHeader
       >
-        <Stepper
-          variant="horizontal"
-          steps={stepDefinitions.map(({ key, title }, index) => {
-            const isPrevious = index < currentStepIndex;
-            const isCurrent = index === currentStepIndex;
-            return (
-              <Step
-                key={key}
-                title={title}
-                index={index + 1}
-                enabled
-                hasProgressLine={isPrevious || isCurrent}
-                iconName={isPrevious ? "success" : "number"}
-                handleClick={() => {
-                  setCurrentStepIndex(index);
-                }}
-              />
-            );
-          })}
-        />
         <div className="add-model__step" {...testId(TestId.ADD_MODEL_CONTENT)}>
           <Formik<AddModelFormState>
             initialValues={{
@@ -184,15 +169,54 @@ const AddModel: FC = () => {
             validationSchema={validationSchema}
             onSubmit={handleCreateClick}
           >
-            <FormikFormData
-              onValidate={setIsValid}
-              id={currentStep.key}
-              {...testId(TestId.ADD_MODEL_FORM)}
-              className={currentStep.key}
-              stacked={currentStep.key === StepType.CONFIGURATION_CONSTRAINTS}
-            >
-              {currentStep.content}
-            </FormikFormData>
+            {({ errors }) => (
+              <>
+                <Stepper
+                  variant="horizontal"
+                  steps={stepDefinitions.map(
+                    ({ key, title, validatedFields, errorLabel }, index) => {
+                      const isPrevious = index < currentStepIndex;
+                      const isCurrent = index === currentStepIndex;
+                      const hasValidatedFieldError =
+                        validatedFields?.some((field) => !!errors[field]) ??
+                        false;
+                      const previousIcon = hasValidatedFieldError
+                        ? "error"
+                        : "success";
+                      return (
+                        <Step
+                          key={key}
+                          title={title}
+                          label={
+                            hasValidatedFieldError && isPrevious
+                              ? errorLabel
+                              : undefined
+                          }
+                          index={index + 1}
+                          enabled
+                          hasProgressLine={isPrevious || isCurrent}
+                          iconName={isPrevious ? previousIcon : "number"}
+                          handleClick={() => {
+                            setCurrentStepIndex(index);
+                          }}
+                        />
+                      );
+                    },
+                  )}
+                />
+                <FormikFormData
+                  onValidate={setIsValid}
+                  id={currentStep.key}
+                  {...testId(TestId.ADD_MODEL_FORM)}
+                  className={currentStep.key}
+                  stacked={
+                    currentStep.key === StepType.CONFIGURATION_CONSTRAINTS
+                  }
+                >
+                  {currentStep.content}
+                </FormikFormData>
+              </>
+            )}
           </Formik>
         </div>
         <div className="add-model__footer">

--- a/src/pages/AddModel/AddModel.tsx
+++ b/src/pages/AddModel/AddModel.tsx
@@ -49,21 +49,16 @@ const stepDefinitions: Array<{
   key: StepType;
   title: string;
   content: JSX.Element;
-  validatedFields?: string[];
-  errorLabel?: string;
 }> = [
   {
     key: StepType.MANDATORY_DETAILS,
     title: "Mandatory Details",
     content: <MandatoryDetails />,
-    validatedFields: ["modelName"],
-    errorLabel: Label.INCORRECT_MODEL_NAME_ERROR,
   },
   {
     key: StepType.CONFIGURATION_CONSTRAINTS,
     title: "Configuration & Constraints (optional)",
     content: <ConfigsConstraints />,
-    errorLabel: Label.INCORRECT_CONFIG_ERROR,
   },
   {
     key: StepType.ACCESS_MANAGEMENT,
@@ -173,36 +168,33 @@ const AddModel: FC = () => {
               <>
                 <Stepper
                   variant="horizontal"
-                  steps={stepDefinitions.map(
-                    ({ key, title, validatedFields, errorLabel }, index) => {
-                      const isPrevious = index < currentStepIndex;
-                      const isCurrent = index === currentStepIndex;
-                      const hasValidatedFieldError =
-                        validatedFields?.some((field) => !!errors[field]) ??
-                        false;
-                      const previousIcon = hasValidatedFieldError
-                        ? "error"
-                        : "success";
-                      return (
-                        <Step
-                          key={key}
-                          title={title}
-                          label={
-                            hasValidatedFieldError && isPrevious
-                              ? errorLabel
-                              : undefined
-                          }
-                          index={index + 1}
-                          enabled
-                          hasProgressLine={isPrevious || isCurrent}
-                          iconName={isPrevious ? previousIcon : "number"}
-                          handleClick={() => {
-                            setCurrentStepIndex(index);
-                          }}
-                        />
-                      );
-                    },
-                  )}
+                  steps={stepDefinitions.map(({ key, title }, index) => {
+                    const isPrevious = index < currentStepIndex;
+                    const isCurrent = index === currentStepIndex;
+                    const hasModelNameError =
+                      (index === 0 && errors.modelName) ?? false;
+                    const previousIcon = hasModelNameError
+                      ? "error"
+                      : "success";
+                    return (
+                      <Step
+                        key={key}
+                        title={title}
+                        label={
+                          hasModelNameError && isPrevious
+                            ? Label.INCORRECT_MODEL_NAME_ERROR
+                            : undefined
+                        }
+                        index={index + 1}
+                        enabled
+                        hasProgressLine={isPrevious || isCurrent}
+                        iconName={isPrevious ? previousIcon : "number"}
+                        handleClick={() => {
+                          setCurrentStepIndex(index);
+                        }}
+                      />
+                    );
+                  })}
                 />
                 <FormikFormData
                   onValidate={setIsValid}

--- a/src/pages/AddModel/AddModel.tsx
+++ b/src/pages/AddModel/AddModel.tsx
@@ -1,9 +1,4 @@
-import {
-  ActionButton,
-  Button,
-  Step,
-  Stepper,
-} from "@canonical/react-components";
+import { ActionButton, Button } from "@canonical/react-components";
 import VanillaPanel from "@canonical/react-components/dist/components/Panel";
 import { Formik } from "formik";
 import type { FC, JSX } from "react";
@@ -25,6 +20,7 @@ import { toErrorString } from "utils";
 import { toastNotification } from "utils/toastNotification";
 
 import AccessManagement from "./AccessManagement";
+import AddModelStepper from "./AddModelStepper";
 import ConfigsConstraints from "./ConfigsConstraints";
 import { InputMode } from "./ConfigsConstraints/ContentSwitcher/types";
 import { CONFIG_CATEGORIES } from "./ConfigsConstraints/configCatalog";
@@ -164,51 +160,22 @@ const AddModel: FC = () => {
             validationSchema={validationSchema}
             onSubmit={handleCreateClick}
           >
-            {({ errors }) => (
-              <>
-                <Stepper
-                  variant="horizontal"
-                  steps={stepDefinitions.map(({ key, title }, index) => {
-                    const isPrevious = index < currentStepIndex;
-                    const isCurrent = index === currentStepIndex;
-                    const hasModelNameError =
-                      (index === 0 && errors.modelName) ?? false;
-                    const previousIcon = hasModelNameError
-                      ? "error"
-                      : "success";
-                    return (
-                      <Step
-                        key={key}
-                        title={title}
-                        label={
-                          hasModelNameError && isPrevious
-                            ? Label.INCORRECT_MODEL_NAME_ERROR
-                            : undefined
-                        }
-                        index={index + 1}
-                        enabled
-                        hasProgressLine={isPrevious || isCurrent}
-                        iconName={isPrevious ? previousIcon : "number"}
-                        handleClick={() => {
-                          setCurrentStepIndex(index);
-                        }}
-                      />
-                    );
-                  })}
-                />
-                <FormikFormData
-                  onValidate={setIsValid}
-                  id={currentStep.key}
-                  {...testId(TestId.ADD_MODEL_FORM)}
-                  className={currentStep.key}
-                  stacked={
-                    currentStep.key === StepType.CONFIGURATION_CONSTRAINTS
-                  }
-                >
-                  {currentStep.content}
-                </FormikFormData>
-              </>
-            )}
+            <>
+              <AddModelStepper
+                stepDefinitions={stepDefinitions}
+                currentStepIndex={currentStepIndex}
+                handleStepClick={setCurrentStepIndex}
+              />
+              <FormikFormData
+                onValidate={setIsValid}
+                id={currentStep.key}
+                {...testId(TestId.ADD_MODEL_FORM)}
+                className={currentStep.key}
+                stacked={currentStep.key === StepType.CONFIGURATION_CONSTRAINTS}
+              >
+                {currentStep.content}
+              </FormikFormData>
+            </>
           </Formik>
         </div>
         <div className="add-model__footer">

--- a/src/pages/AddModel/AddModel.tsx
+++ b/src/pages/AddModel/AddModel.tsx
@@ -1,7 +1,7 @@
 import { ActionButton, Button } from "@canonical/react-components";
 import VanillaPanel from "@canonical/react-components/dist/components/Panel";
 import { Formik } from "formik";
-import type { FC, JSX } from "react";
+import type { FC } from "react";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router";
 import * as Yup from "yup";
@@ -31,7 +31,13 @@ import {
   getConfigInitialValues,
 } from "./ConfigsConstraints/utils";
 import MandatoryDetails from "./MandatoryDetails";
-import { TestId, StepType, Label, type AddModelFormState } from "./types";
+import {
+  TestId,
+  StepType,
+  Label,
+  type AddModelFormState,
+  type StepDefinition,
+} from "./types";
 
 const MODEL_NAME_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
 
@@ -41,11 +47,7 @@ const validationSchema = Yup.object().shape({
     .required("Required"),
 });
 
-const stepDefinitions: Array<{
-  key: StepType;
-  title: string;
-  content: JSX.Element;
-}> = [
+const stepDefinitions: StepDefinition[] = [
   {
     key: StepType.MANDATORY_DETAILS,
     title: "Mandatory Details",

--- a/src/pages/AddModel/AddModelStepper/AddModelStepper.test.tsx
+++ b/src/pages/AddModel/AddModelStepper/AddModelStepper.test.tsx
@@ -4,34 +4,42 @@ import { Formik } from "formik";
 
 import { InputMode } from "../ConfigsConstraints/ContentSwitcher/types";
 import { DisableType, FieldName } from "../ConfigsConstraints/types";
-import { type AddModelFormState, StepType } from "../types";
+import {
+  type AddModelFormState,
+  type StepDefinition,
+  StepType,
+} from "../types";
 
 import AddModelStepper from "./AddModelStepper";
 
-const stepDefinitions = [
-  {
-    key: StepType.MANDATORY_DETAILS,
-    title: "Mandatory Details",
-    content: <div />,
-  },
-  {
-    key: StepType.CONFIGURATION_CONSTRAINTS,
-    title: "Configuration & Constraints (optional)",
-    content: <div />,
-  },
-];
-
-const initialValues: AddModelFormState = {
-  modelName: "",
-  cloud: "",
-  region: "",
-  credential: "",
-  [FieldName.CONFIG_INPUT_MODE]: InputMode.LIST,
-  [FieldName.CONFIG_YAML]: "",
-  [FieldName.DISABLED_COMMANDS]: DisableType.NONE,
-};
-
 describe("AddModelStepper", () => {
+  let stepDefinitions: StepDefinition[];
+  let initialValues: AddModelFormState;
+  beforeEach(() => {
+    stepDefinitions = [
+      {
+        key: StepType.MANDATORY_DETAILS,
+        title: "Mandatory Details",
+        content: <div />,
+      },
+      {
+        key: StepType.CONFIGURATION_CONSTRAINTS,
+        title: "Configuration & Constraints (optional)",
+        content: <div />,
+      },
+    ];
+
+    initialValues = {
+      modelName: "",
+      cloud: "",
+      region: "",
+      credential: "",
+      [FieldName.CONFIG_INPUT_MODE]: InputMode.LIST,
+      [FieldName.CONFIG_YAML]: "",
+      [FieldName.DISABLED_COMMANDS]: DisableType.NONE,
+    };
+  });
+
   it("renders properly", () => {
     render(
       <Formik<AddModelFormState>

--- a/src/pages/AddModel/AddModelStepper/AddModelStepper.test.tsx
+++ b/src/pages/AddModel/AddModelStepper/AddModelStepper.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Formik } from "formik";
+
+import { InputMode } from "../ConfigsConstraints/ContentSwitcher/types";
+import { DisableType, FieldName } from "../ConfigsConstraints/types";
+import { type AddModelFormState, StepType } from "../types";
+
+import AddModelStepper from "./AddModelStepper";
+
+const stepDefinitions = [
+  {
+    key: StepType.MANDATORY_DETAILS,
+    title: "Mandatory Details",
+    content: <div />,
+  },
+  {
+    key: StepType.CONFIGURATION_CONSTRAINTS,
+    title: "Configuration & Constraints (optional)",
+    content: <div />,
+  },
+];
+
+const initialValues: AddModelFormState = {
+  modelName: "",
+  cloud: "",
+  region: "",
+  credential: "",
+  [FieldName.CONFIG_INPUT_MODE]: InputMode.LIST,
+  [FieldName.CONFIG_YAML]: "",
+  [FieldName.DISABLED_COMMANDS]: DisableType.NONE,
+};
+
+describe("AddModelStepper", () => {
+  it("renders properly", () => {
+    render(
+      <Formik<AddModelFormState>
+        initialValues={initialValues}
+        onSubmit={vi.fn()}
+      >
+        <AddModelStepper
+          stepDefinitions={stepDefinitions}
+          currentStepIndex={0}
+          handleStepClick={vi.fn()}
+        />
+      </Formik>,
+    );
+
+    expect(screen.getByText("Mandatory Details")).toBeInTheDocument();
+    expect(
+      screen.getByText("Configuration & Constraints (optional)"),
+    ).toBeInTheDocument();
+  });
+
+  it("calls handleStepClick with the step index", async () => {
+    const handleStepClick = vi.fn();
+    render(
+      <Formik<AddModelFormState>
+        initialValues={initialValues}
+        onSubmit={vi.fn()}
+      >
+        <AddModelStepper
+          stepDefinitions={stepDefinitions}
+          currentStepIndex={0}
+          handleStepClick={handleStepClick}
+        />
+      </Formik>,
+    );
+
+    await userEvent.click(
+      screen.getByText("Configuration & Constraints (optional)"),
+    );
+    expect(handleStepClick).toHaveBeenCalledWith(1);
+    expect(handleStepClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/pages/AddModel/AddModelStepper/AddModelStepper.tsx
+++ b/src/pages/AddModel/AddModelStepper/AddModelStepper.tsx
@@ -1,0 +1,58 @@
+import { Stepper, Step } from "@canonical/react-components";
+import { useFormikContext } from "formik";
+import type { JSX } from "react";
+
+import { type AddModelFormState, Label, type StepType } from "../types";
+
+type Props = {
+  stepDefinitions: Array<{
+    key: StepType;
+    title: string;
+    content: JSX.Element;
+  }>;
+  currentStepIndex: number;
+  handleStepClick: (index: number) => void;
+};
+
+const AddModelStepper = ({
+  stepDefinitions,
+  currentStepIndex,
+  handleStepClick,
+}: Props): JSX.Element => {
+  const { errors, values } = useFormikContext<AddModelFormState>();
+  return (
+    <Stepper
+      variant="horizontal"
+      steps={stepDefinitions.map(({ key, title }, index) => {
+        const isPrevious = index < currentStepIndex;
+        const isCurrent = index === currentStepIndex;
+        const hasModelNameError = (index === 0 && errors.modelName) ?? false;
+        let label = undefined;
+        if (hasModelNameError && isPrevious) {
+          if (values.modelName !== "") {
+            label = Label.INCORRECT_MODEL_NAME_ERROR;
+          } else {
+            label = Label.REQUIRED_MODEL_NAME_ERROR;
+          }
+        }
+        const previousIcon = hasModelNameError ? "error" : "success";
+        return (
+          <Step
+            key={key}
+            title={title}
+            label={label}
+            index={index + 1}
+            enabled
+            hasProgressLine={isPrevious || isCurrent}
+            iconName={isPrevious ? previousIcon : "number"}
+            handleClick={() => {
+              handleStepClick(index);
+            }}
+          />
+        );
+      })}
+    />
+  );
+};
+
+export default AddModelStepper;

--- a/src/pages/AddModel/AddModelStepper/AddModelStepper.tsx
+++ b/src/pages/AddModel/AddModelStepper/AddModelStepper.tsx
@@ -2,14 +2,10 @@ import { Stepper, Step } from "@canonical/react-components";
 import { useFormikContext } from "formik";
 import type { JSX } from "react";
 
-import { type AddModelFormState, Label, type StepType } from "../types";
+import { type AddModelFormState, Label, type StepDefinition } from "../types";
 
 type Props = {
-  stepDefinitions: Array<{
-    key: StepType;
-    title: string;
-    content: JSX.Element;
-  }>;
+  stepDefinitions: StepDefinition[];
   currentStepIndex: number;
   handleStepClick: (index: number) => void;
 };

--- a/src/pages/AddModel/AddModelStepper/index.ts
+++ b/src/pages/AddModel/AddModelStepper/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AddModelStepper";

--- a/src/pages/AddModel/ConfigsConstraints/StackList/StackList.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/StackList/StackList.tsx
@@ -26,7 +26,10 @@ const StackList = ({ visibleConfigs }: Props): JSX.Element => {
             <FormikField
               {...(config.input?.type === "select"
                 ? { component: Select }
-                : { type: "text", placeholder: config.defaultValue })}
+                : {
+                    type: config.isNumeric ? "number" : "text",
+                    placeholder: config.defaultValue,
+                  })}
               label={
                 <>
                   {changed ? (

--- a/src/pages/AddModel/ConfigsConstraints/configCatalog.ts
+++ b/src/pages/AddModel/ConfigsConstraints/configCatalog.ts
@@ -9,6 +9,7 @@ export type CategoryDefinition = {
     description: string;
     defaultValue?: string;
     input?: { type: "select" } & SelectProps;
+    isNumeric?: boolean;
   }[];
 };
 
@@ -118,6 +119,7 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         description:
           "The amount of time in seconds to sleep between ifdown and ifup when bridging",
         defaultValue: "17",
+        isNumeric: true,
       },
       {
         label: "saas-ingress-allow",
@@ -336,11 +338,13 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         description:
           "The number of container provisioning workers to use per machine",
         defaultValue: "4",
+        isNumeric: true,
       },
       {
         label: "num-provision-workers",
         description: "The number of provisioning workers to use per model",
         defaultValue: "16",
+        isNumeric: true,
       },
       {
         label: "project",

--- a/src/pages/AddModel/ConfigsConstraints/configCatalog.ts
+++ b/src/pages/AddModel/ConfigsConstraints/configCatalog.ts
@@ -19,6 +19,40 @@ const BOOLEAN_OPTIONS = [
 
 export const CONFIG_CATEGORIES: CategoryDefinition[] = [
   {
+    category: "Cloud-specific configurations",
+    fields: [
+      {
+        label: "base-image-path",
+        description: "Base path to look for machine disk images",
+      },
+      {
+        label: "vpc-id",
+        description: "Use a specific VPC network",
+        defaultValue: "false",
+        input: {
+          type: "select",
+          options: [
+            { label: "True", value: "true" },
+            { label: "False", value: "false" },
+          ],
+        },
+      },
+      {
+        label: "vpc-id-force",
+        description:
+          "Force Juju to use the GCE VPC ID specified with vpc-id, when it fails the minimum validation criteria",
+        defaultValue: "false",
+        input: {
+          type: "select",
+          options: [
+            { label: "True", value: "true" },
+            { label: "False", value: "false" },
+          ],
+        },
+      },
+    ],
+  },
+  {
     category: "Networking & Firewall",
     fields: [
       {
@@ -490,40 +524,6 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         input: {
           type: "select",
           options: BOOLEAN_OPTIONS,
-        },
-      },
-    ],
-  },
-  {
-    category: "Cloud-specific configurations",
-    fields: [
-      {
-        label: "base-image-path",
-        description: "Base path to look for machine disk images",
-      },
-      {
-        label: "vpc-id",
-        description: "Use a specific VPC network",
-        defaultValue: "false",
-        input: {
-          type: "select",
-          options: [
-            { label: "True", value: "true" },
-            { label: "False", value: "false" },
-          ],
-        },
-      },
-      {
-        label: "vpc-id-force",
-        description:
-          "Force Juju to use the GCE VPC ID specified with vpc-id, when it fails the minimum validation criteria",
-        defaultValue: "false",
-        input: {
-          type: "select",
-          options: [
-            { label: "True", value: "true" },
-            { label: "False", value: "false" },
-          ],
         },
       },
     ],

--- a/src/pages/AddModel/_add-model.scss
+++ b/src/pages/AddModel/_add-model.scss
@@ -14,6 +14,16 @@
 
   &__step {
     flex: 1 0 auto;
+
+    .stepper-horizontal {
+      margin-bottom: $spv--large;
+
+      .step-optional-content {
+        color: $color-negative;
+        font-size: #{map-get($font-sizes, small)}rem;
+        max-width: fit-content;
+      }
+    }
   }
 
   &__footer {

--- a/src/pages/AddModel/types.ts
+++ b/src/pages/AddModel/types.ts
@@ -30,4 +30,5 @@ export enum Label {
   BACK_BUTTON = "Back",
   CREATE_BUTTON = "Add model",
   INCORRECT_MODEL_NAME_ERROR = "Incorrect model name format.",
+  INCORRECT_CONFIG_ERROR = "Incorrect configuration input(s).",
 }

--- a/src/pages/AddModel/types.ts
+++ b/src/pages/AddModel/types.ts
@@ -1,3 +1,5 @@
+import type { JSX } from "react";
+
 import type { AccessLevel } from "types";
 
 import type { FormFields } from "./ConfigsConstraints/types";
@@ -22,6 +24,12 @@ export type AddModelFormState = {
   shareModelWith?: Record<string, AccessLevel>;
 } & FormFields &
   Record<string, string>;
+
+export type StepDefinition = {
+  key: StepType;
+  title: string;
+  content: JSX.Element;
+};
 
 export enum Label {
   TITLE = "Add model",

--- a/src/pages/AddModel/types.ts
+++ b/src/pages/AddModel/types.ts
@@ -30,5 +30,4 @@ export enum Label {
   BACK_BUTTON = "Back",
   CREATE_BUTTON = "Add model",
   INCORRECT_MODEL_NAME_ERROR = "Incorrect model name format.",
-  INCORRECT_CONFIG_ERROR = "Incorrect configuration input(s).",
 }

--- a/src/pages/AddModel/types.ts
+++ b/src/pages/AddModel/types.ts
@@ -30,4 +30,5 @@ export enum Label {
   BACK_BUTTON = "Back",
   CREATE_BUTTON = "Add model",
   INCORRECT_MODEL_NAME_ERROR = "Incorrect model name format.",
+  REQUIRED_MODEL_NAME_ERROR = "Model name is required.",
 }

--- a/src/pages/ModelsIndex/ModelsIndex.tsx
+++ b/src/pages/ModelsIndex/ModelsIndex.tsx
@@ -193,7 +193,6 @@ export default function Models(): JSX.Element {
           <span>
             <span className="p-text--default">Group by: </span>
             <SegmentedControl
-              className="u-display--inline-block"
               activeButton={queryParams.groupedby}
               buttons={["Status", "Cloud", "Owner"].map((group) => ({
                 children: group,


### PR DESCRIPTION
## Done

- Moved the stepper component within AddModel form and into its own component to allow it access to error states in form tabs
- Added error state to steps that appears when the user navigates away from current tab
- Added error label to step that appears whenever there is an error state on a stepper tab
- Added `isNumeric` key to the configCatalog which is then used to render the input as `type=number`
- Introduced email validation logic to JIMM add-model flow
- The validation is run when a user tries to add an email of invalid format to share their model with
- Added truncation and overflow to username/emails

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Point the dashboard to JIMM to test all validation in one setup
- Go to the AddModel page
- Trying navigating away from the first tab with no model name set and with an invalid name set (e.g., `-model`)
- The stepper icon should change to error and an error label must be visible under tab title
- On the configs+constraints tab, look for `net-bond-reconfigure-delay` and try entering a non-numerical value, it should only allow number input
- On the access management tab, try adding an invalid email to the list
- An error label, `Incorrect email format` should appear on clicking the add button
- This should go away when continuing to type further and reappear on add click if the input is still invalid

## Details

https://warthogs.atlassian.net/browse/JUJU-9830

## Screenshots


https://github.com/user-attachments/assets/19dfecda-90a7-4f1e-a78c-dbfcc3d84568


