### PR TITLE
feat: upgrade model patch versions in place

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -42,6 +42,7 @@
         "jujucharms",
         "jujulib",
         "microk8s",
+        "upgrader",
         "rebac",
         "snapstore",
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     ]
   },
   "dependencies": {
-    "@canonical/jujulib": "8.1.0",
+    "@canonical/jujulib": "9.0.0",
     "@canonical/macaroon-bakery": "1.3.2",
     "@canonical/react-components": "4.5.2",
     "@canonical/rebac-admin": "0.0.1-alpha.12",

--- a/src/juju/api.ts
+++ b/src/juju/api.ts
@@ -12,6 +12,7 @@ import Cloud from "@canonical/jujulib/dist/api/facades/cloud";
 import Controller from "@canonical/jujulib/dist/api/facades/controller";
 import ModelManager from "@canonical/jujulib/dist/api/facades/model-manager";
 import type { ErrorResults } from "@canonical/jujulib/dist/api/facades/model-manager/ModelManagerV10";
+import ModelUpgrader from "@canonical/jujulib/dist/api/facades/model-upgrader";
 import Pinger from "@canonical/jujulib/dist/api/facades/pinger";
 import Secrets from "@canonical/jujulib/dist/api/facades/secrets";
 import { jujuUpdateAvailable } from "@canonical/jujulib/dist/api/versions";
@@ -78,6 +79,7 @@ export function generateConnectionOptions(
       Cloud,
       Controller,
       ModelManager,
+      ModelUpgrader,
       JIMM,
       Secrets,
     ].concat(usePinger ? Pinger : []),

--- a/src/juju/types.ts
+++ b/src/juju/types.ts
@@ -21,6 +21,7 @@ import type {
   ModelInfo as ModelManagerV11ModelInfo,
   UserModelList as ModelManagerV11UserModelList,
 } from "@canonical/jujulib/dist/api/facades/model-manager/ModelManagerV11";
+import type ModelUpgraderV1 from "@canonical/jujulib/dist/api/facades/model-upgrader/ModelUpgraderV1";
 import type PingerV1 from "@canonical/jujulib/dist/api/facades/pinger/PingerV1";
 import type SecretsV2 from "@canonical/jujulib/dist/api/facades/secrets/SecretsV2";
 
@@ -50,6 +51,7 @@ export type Facades = {
   cloud?: CloudV7;
   controller?: ControllerV12;
   modelManager?: ModelManagerV10 | ModelManagerV11;
+  modelUpgrader?: ModelUpgraderV1;
   pinger?: PingerV1;
   secrets?: SecretsV2;
   jimM?: InstanceType<typeof JIMMV4>;

--- a/src/panels/UpgradeModelPanel/UpgradeModelController/UpgradeModelController.test.tsx
+++ b/src/panels/UpgradeModelPanel/UpgradeModelController/UpgradeModelController.test.tsx
@@ -1,6 +1,7 @@
 import { act, fireEvent, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
+import { upgradeModel, upgradeTo } from "store/middleware/process";
 import type { RootState } from "store/store";
 import { rootStateFactory } from "testing/factories";
 import {
@@ -24,7 +25,7 @@ import {
   modelMigrationTargetsStateFactory,
   supportedJujuVersionsStateFactory,
 } from "testing/factories/juju/juju";
-import { renderComponent } from "testing/utils";
+import { createStore, renderComponent } from "testing/utils";
 import urls from "urls";
 
 import { Label as FieldsLabel } from "./Fields/types";
@@ -75,6 +76,7 @@ describe("UpgradeModelController", () => {
         modelData: {
           abc123: modelDataFactory.build({
             info: modelInfoFactory.build({
+              "agent-version": "1.2.1",
               uuid: "abc123",
               name: "test1",
               "controller-uuid": "controller123",
@@ -188,5 +190,82 @@ describe("UpgradeModelController", () => {
     // Vanilla doesn't display validation until the field loses focus.
     await act(() => fireEvent.blur(confirm));
     expect(submit).not.toHaveAttribute("aria-disabled");
+  });
+
+  it("starts an upgrade", async () => {
+    const [store, actions] = createStore(state, {
+      trackActions: true,
+    });
+    renderComponent(
+      <UpgradeModelController
+        back={vi.fn}
+        onRemovePanelQueryParams={vi.fn}
+        version={versionElemFactory.build({ version: "1.2.3" })}
+        modelName="test1"
+        qualifier="eggman@external"
+      />,
+      { store, url, path },
+    );
+    const confirm = screen.getByRole("checkbox", { name: FieldsLabel.CONFIRM });
+    await userEvent.click(confirm);
+    // Vanilla doesn't display validation until the field loses focus.
+    await act(() => fireEvent.blur(confirm));
+    await userEvent.click(
+      await screen.findByRole("button", {
+        name: Label.SUBMIT,
+      }),
+    );
+    const action = upgradeModel.run({
+      currentVersion: "1.2.1",
+      modelName: "test1",
+      modelURL: "wss://example.com/model/abc123/api",
+      modelUUID: "abc123",
+      targetVersion: "1.2.3",
+      wsControllerURL: "wss://example.com/api",
+    });
+    expect(
+      actions.find((dispatch) => dispatch.type === action.type),
+    ).toMatchObject(action);
+  });
+
+  it("starts a migration", async () => {
+    const [store, actions] = createStore(state, {
+      trackActions: true,
+    });
+    renderComponent(
+      <UpgradeModelController
+        back={vi.fn}
+        onRemovePanelQueryParams={vi.fn}
+        version={versionElemFactory.build({ version: "4.6.14" })}
+        modelName="test1"
+        qualifier="eggman@external"
+      />,
+      { store, url, path },
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: FieldsLabel.TARGET_CONTROLLER }),
+    );
+    await userEvent.click(screen.getByRole("option", { name: /controller2/ }));
+    const confirm = screen.getByRole("checkbox", { name: FieldsLabel.CONFIRM });
+    await userEvent.click(confirm);
+    // Vanilla doesn't display validation until the field loses focus.
+    await act(() => fireEvent.blur(confirm));
+    await userEvent.click(
+      await screen.findByRole("button", {
+        name: Label.SUBMIT,
+      }),
+    );
+    const action = upgradeTo.run({
+      currentVersion: "1.2.1",
+      modelName: "test1",
+      modelURL: "wss://example.com/model/abc123/api",
+      modelUUID: "abc123",
+      targetController: "controller2",
+      targetVersion: "4.6.14",
+      wsControllerURL: "wss://example.com/api",
+    });
+    expect(
+      actions.find((dispatch) => dispatch.type === action.type),
+    ).toMatchObject(action);
   });
 });

--- a/src/panels/UpgradeModelPanel/UpgradeModelController/UpgradeModelController.tsx
+++ b/src/panels/UpgradeModelPanel/UpgradeModelController/UpgradeModelController.tsx
@@ -15,9 +15,10 @@ import {
 } from "store/juju/selectors";
 import { getControllerVersion } from "store/juju/utils/controllers";
 import { requiresMigration } from "store/juju/utils/upgrades";
-import { upgradeTo } from "store/middleware/process";
+import { upgradeTo, upgradeModel } from "store/middleware/process";
 import { useAppDispatch, useAppSelector } from "store/store";
 import { testId } from "testing/utils";
+import getModelURL from "utils/getModelURL";
 
 import UpgradeModelPanelHeader from "../UpgradeModelPanelHeader";
 
@@ -90,9 +91,17 @@ const UpgradeModelController: FC<Props> = ({
         currentVersion,
         wsControllerURL,
         modelUUID,
-        // TODO: Use the getModelURL util here once it lands:
-        // https://github.com/canonical/juju-dashboard/pull/2285/changes#diff-b8618585b6c69654e35b6b6a0f188d72b59777badd2798cfd1d027a396ed0566R1
-        modelURL: wsControllerURL.replace("/api", `/model/${modelUUID}/api`),
+        modelURL: getModelURL(wsControllerURL, modelUUID),
+        modelName: modelName,
+      });
+      dispatch(action);
+    } else {
+      const action = upgradeModel.run({
+        targetVersion: version.version,
+        currentVersion,
+        wsControllerURL,
+        modelUUID,
+        modelURL: getModelURL(wsControllerURL, modelUUID),
         modelName: modelName,
       });
       dispatch(action);

--- a/src/store/juju/actions.test.ts
+++ b/src/store/juju/actions.test.ts
@@ -16,10 +16,6 @@ const status = fullStatusFactory.build({
   model: {
     "available-version": "",
     "cloud-tag": "",
-    "meter-status": {
-      color: "",
-      message: "",
-    },
     "model-status": {
       data: {},
       info: "",
@@ -30,7 +26,6 @@ const status = fullStatusFactory.build({
       version: "",
     },
     name: "",
-    sla: "",
     type: "",
     version: "",
   },

--- a/src/store/juju/reducers.test.ts
+++ b/src/store/juju/reducers.test.ts
@@ -38,10 +38,6 @@ const status = fullStatusFactory.build({
   model: {
     "available-version": "",
     "cloud-tag": "",
-    "meter-status": {
-      color: "",
-      message: "",
-    },
     "model-status": {
       data: {},
       info: "",
@@ -52,7 +48,6 @@ const status = fullStatusFactory.build({
       version: "",
     },
     name: "",
-    sla: "",
     type: "",
     version: "",
     region: "west",

--- a/src/store/middleware/process/index.ts
+++ b/src/store/middleware/process/index.ts
@@ -1,6 +1,6 @@
 import disableCommandProcess from "./block/disable-command";
 import createMiddleware from "./middleware";
-import { upgradeToProcess } from "./model-upgrade";
+import { upgradeModelProcess, upgradeToProcess } from "./model-upgrade";
 import type { Process } from "./types";
 
 export type { ProcessOutcome, ProcessActions, Process } from "./types";
@@ -8,9 +8,11 @@ export type { ProcessOutcome, ProcessActions, Process } from "./types";
 // Re-export actions to trigger processes.
 export const disableCommand = disableCommandProcess.actions;
 export const upgradeTo = upgradeToProcess.actions;
+export const upgradeModel = upgradeModelProcess.actions;
 
 // Construct the middleware with process handlers.
 export default createMiddleware([
   disableCommandProcess as Process<unknown>,
   upgradeToProcess as Process<unknown>,
+  upgradeModelProcess as Process<unknown>,
 ]);

--- a/src/store/middleware/process/model-upgrade/index.ts
+++ b/src/store/middleware/process/model-upgrade/index.ts
@@ -1,1 +1,2 @@
 export { default as upgradeToProcess } from "./upgrade-to";
+export { default as upgradeModelProcess } from "./upgrade-model";

--- a/src/store/middleware/process/model-upgrade/upgrade-model.test.ts
+++ b/src/store/middleware/process/model-upgrade/upgrade-model.test.ts
@@ -1,0 +1,267 @@
+import type { Mock, MockInstance } from "vitest";
+
+import type { Source } from "data";
+import type { ManagedConnection } from "store/middleware/connection/connection-manager";
+
+import * as modelConnectionRetrySourceModule from "./model-connection-retry-source";
+import type { ConnectionRetryResult } from "./model-connection-retry-source";
+import {
+  Label,
+  upgradeModel,
+  default as upgradeModelProcess,
+} from "./upgrade-model";
+
+describe("upgradeModel", () => {
+  let controllerConnection: ManagedConnection;
+  let modelConnection: ManagedConnection;
+
+  let upgradeModelMock: MockInstance;
+  let modelStatusSourceDoneMock: Mock;
+  let modelStatusSource: MockInstance;
+  let modelStatusSourceImplementation: Source<ConnectionRetryResult>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+
+    upgradeModelMock = vi.fn().mockResolvedValue({ "chosen-version": "1.2.3" });
+    controllerConnection = {
+      facades: {
+        modelUpgrader: {
+          upgradeModel: upgradeModelMock,
+        },
+      },
+    } as unknown as ManagedConnection;
+    modelConnection = {} as ManagedConnection;
+    modelStatusSourceDoneMock = vi.fn();
+    modelStatusSourceImplementation = {
+      done: modelStatusSourceDoneMock,
+      [Symbol.asyncIterator]: async function* () {
+        yield { version: "1.2.3" };
+      },
+    } as unknown as Source<ConnectionRetryResult>;
+    modelStatusSource = vi
+      .spyOn(modelConnectionRetrySourceModule, "default")
+      .mockReturnValue(modelStatusSourceImplementation);
+  });
+
+  describe("controller `upgradeModel` request", () => {
+    it("calls on controller connection with correct model tag", async ({
+      expect,
+    }) => {
+      expect.assertions(2);
+      const progress = upgradeModel(
+        "abc123",
+        "1.2.3",
+        controllerConnection,
+        modelConnection,
+      );
+
+      await expect(progress.next()).resolves.toEqual({
+        done: false,
+        value: { status: "pending" },
+      });
+      expect(upgradeModelMock).toHaveBeenCalledExactlyOnceWith({
+        "model-tag": "model-abc123",
+        "target-version": "1.2.3",
+      });
+    });
+
+    it("throws an error if request isn't successful", async ({ expect }) => {
+      expect.assertions(3);
+      upgradeModelMock.mockResolvedValue({ error: "Uh oh!" });
+      const progress = upgradeModel(
+        "abc123",
+        "1.2.3",
+        controllerConnection,
+        modelConnection,
+      );
+
+      await expect(progress.next()).resolves.toEqual({
+        done: false,
+        value: { status: "pending" },
+      });
+      expect(upgradeModelMock).toHaveBeenCalledExactlyOnceWith({
+        "model-tag": "model-abc123",
+        "target-version": "1.2.3",
+      });
+
+      await expect(progress.next()).rejects.toThrowError(
+        Label.ERROR_INIT_FAILED,
+      );
+    });
+  });
+
+  describe("model `fullStatus` polling", () => {
+    it("begins polling model after success", async ({ expect }) => {
+      expect.assertions(1);
+      const progress = upgradeModel(
+        "abc123",
+        "1.2.3",
+        controllerConnection,
+        modelConnection,
+      );
+
+      await progress.next(); // Pending
+      await progress.next(); // Initiating
+
+      void progress.next();
+      expect(modelStatusSource).toHaveBeenCalledExactlyOnceWith(
+        modelConnection,
+      );
+    });
+
+    describe("while polling", () => {
+      let modelStatusPromises: PromiseWithResolvers<ConnectionRetryResult>[];
+
+      beforeEach(() => {
+        modelStatusPromises = new Array(10)
+          .fill(null)
+          .map(() => Promise.withResolvers());
+        modelStatusSourceImplementation[Symbol.asyncIterator] =
+          async function* (): AsyncGenerator<
+            ConnectionRetryResult,
+            void,
+            void
+          > {
+            for (const { promise } of modelStatusPromises) {
+              yield await promise;
+            }
+          };
+      });
+
+      it("doesn't advance until version matches", async ({ expect }) => {
+        expect.assertions(4);
+        const progress = upgradeModel(
+          "abc123",
+          "1.2.3",
+          controllerConnection,
+          modelConnection,
+        );
+
+        await progress.next(); // Pending
+        await progress.next(); // Initiating
+
+        const statusResolvedMock = vi.fn();
+        const nextStatus = progress
+          .next()
+          .then(statusResolvedMock.mockImplementation((value) => value));
+
+        modelStatusPromises[0].resolve({ version: "0.0.0" });
+        await vi.runOnlyPendingTimersAsync();
+        expect(statusResolvedMock).not.toHaveBeenCalled();
+
+        modelStatusPromises[1].resolve({ version: "0.0.0" });
+        await vi.runOnlyPendingTimersAsync();
+        expect(statusResolvedMock).not.toHaveBeenCalled();
+
+        modelStatusPromises[2].resolve({ version: "1.2.3" });
+        await vi.runOnlyPendingTimersAsync();
+        expect(statusResolvedMock).toHaveBeenCalledOnce();
+
+        await expect(nextStatus).resolves.toEqual({ done: true });
+      });
+
+      it("calls `done` on source after completion", async ({ expect }) => {
+        expect.assertions(1);
+        const progress = upgradeModel(
+          "abc123",
+          "1.2.3",
+          controllerConnection,
+          modelConnection,
+        );
+
+        modelStatusPromises[0].resolve({ version: "1.2.3" });
+
+        await progress.next(); // Pending
+        await progress.next(); // Initiating
+        await progress.next(); // Done
+
+        expect(modelStatusSourceDoneMock).toHaveBeenCalledOnce();
+      });
+
+      it("emits status when reconnecting", async ({ expect }) => {
+        expect.assertions(3);
+        const progress = upgradeModel(
+          "abc123",
+          "1.2.3",
+          controllerConnection,
+          modelConnection,
+        );
+
+        await progress.next(); // Pending
+        await progress.next(); // Initiating
+
+        const statusResolvedMock = vi.fn();
+        const nextStatus = progress
+          .next()
+          .then(statusResolvedMock.mockImplementation((value) => value));
+
+        modelStatusPromises[0].resolve({ version: "0.0.0" });
+        await vi.runOnlyPendingTimersAsync();
+        expect(statusResolvedMock).not.toHaveBeenCalled();
+
+        modelStatusPromises[1].resolve({ reconnecting: true });
+        await vi.runOnlyPendingTimersAsync();
+        expect(statusResolvedMock).toHaveBeenCalled();
+
+        await expect(nextStatus).resolves.toEqual({
+          value: { status: "reconnecting" },
+          done: false,
+        });
+      });
+
+      it("emits loading status at an interval", async ({ expect }) => {
+        expect.assertions(2);
+        const progress = upgradeModel(
+          "abc123",
+          "1.2.3",
+          controllerConnection,
+          modelConnection,
+        );
+
+        await progress.next(); // Pending
+        await progress.next(); // Initiating
+
+        modelStatusPromises
+          .slice(0, modelStatusPromises.length - 1)
+          .map(({ resolve }) => {
+            resolve({ version: "0.0.0" });
+          });
+        modelStatusPromises[modelStatusPromises.length - 1].resolve({
+          version: "1.2.3",
+        });
+
+        await expect(progress.next()).resolves.toEqual({
+          value: { status: "loading" },
+          done: false,
+        });
+
+        await expect(progress.next()).resolves.toEqual({
+          done: true,
+        });
+      });
+    });
+  });
+});
+
+describe("action", () => {
+  it("contains meta properties", ({ expect }) => {
+    const action = upgradeModelProcess.actions.run({
+      wsControllerURL: "wss://example.com/api",
+      modelName: "some-model",
+      modelUUID: "abc123",
+      modelURL: "wss://example.com/model/abc123/api",
+      currentVersion: "0.0.0",
+      targetVersion: "1.2.3",
+    });
+
+    expect(action).toEqual(
+      expect.objectContaining({
+        meta: {
+          withConnection: true,
+          connectionList: ["wsControllerURL", "modelURL"],
+        },
+      }),
+    );
+  });
+});

--- a/src/store/middleware/process/model-upgrade/upgrade-model.test.ts
+++ b/src/store/middleware/process/model-upgrade/upgrade-model.test.ts
@@ -1,14 +1,18 @@
 import type { Mock, MockInstance } from "vitest";
 
 import type { Source } from "data";
+import { createToast } from "store/app/actions";
+import { actions as jujuActions } from "store/juju";
 import type { ManagedConnection } from "store/middleware/connection/connection-manager";
 
 import * as modelConnectionRetrySourceModule from "./model-connection-retry-source";
 import type { ConnectionRetryResult } from "./model-connection-retry-source";
 import {
   Label,
+  processActions,
   upgradeModel,
   default as upgradeModelProcess,
+  UpgradeStatus,
 } from "./upgrade-model";
 
 describe("upgradeModel", () => {
@@ -261,6 +265,118 @@ describe("action", () => {
           withConnection: true,
           connectionList: ["wsControllerURL", "modelURL"],
         },
+      }),
+    );
+  });
+});
+
+describe("process actions", () => {
+  it("creates a toast if the outcome is an error", ({ expect }) => {
+    const payload = {
+      wsControllerURL: "wss://example.com/api",
+      modelName: "some-model",
+      modelUUID: "abc123",
+      modelURL: "wss://example.com/model/abc123/api",
+      currentVersion: "0.0.0",
+      targetVersion: "1.2.3",
+    };
+    expect(
+      processActions.setOutcome(payload, {
+        error: { message: "Uh oh", source: "none" },
+      }),
+    ).toEqual(
+      createToast({
+        message:
+          'Failed to upgrade. Model "some-model" has not been migrated or upgraded. Try again or contact support.',
+        severity: "negative",
+      }),
+    );
+  });
+
+  it("creates a toast if the outcome is successful", ({ expect }) => {
+    const payload = {
+      wsControllerURL: "wss://example.com/api",
+      modelName: "some-model",
+      modelUUID: "abc123",
+      modelURL: "wss://example.com/model/abc123/api",
+      currentVersion: "0.0.0",
+      targetVersion: "1.2.3",
+    };
+    expect(
+      processActions.setOutcome(payload, {
+        result: undefined,
+      }),
+    ).toEqual(
+      createToast({
+        message: 'Model "some-model" upgraded to 1.2.3',
+        severity: "positive",
+      }),
+    );
+  });
+
+  it("creates a toast when pending", ({ expect }) => {
+    const payload = {
+      wsControllerURL: "wss://example.com/api",
+      modelName: "some-model",
+      modelUUID: "abc123",
+      modelURL: "wss://example.com/model/abc123/api",
+      currentVersion: "0.0.0",
+      targetVersion: "1.2.3",
+    };
+    expect(
+      processActions.setStatus(payload, { status: UpgradeStatus.PENDING }),
+    ).toEqual(
+      createToast({
+        message: 'Upgrading model "some-model"…',
+        severity: "information",
+      }),
+    );
+  });
+
+  it("does not create a toast for other statuses", ({ expect }) => {
+    const payload = {
+      wsControllerURL: "wss://example.com/api",
+      modelName: "some-model",
+      modelUUID: "abc123",
+      modelURL: "wss://example.com/model/abc123/api",
+      currentVersion: "0.0.0",
+      targetVersion: "1.2.3",
+    };
+    expect(
+      processActions.setStatus(payload, { status: UpgradeStatus.LOADING }),
+    ).toBeUndefined();
+  });
+
+  it("adds the upgrade when it starts running", ({ expect }) => {
+    const payload = {
+      wsControllerURL: "wss://example.com/api",
+      modelName: "some-model",
+      modelUUID: "abc123",
+      modelURL: "wss://example.com/model/abc123/api",
+      currentVersion: "0.0.0",
+      targetVersion: "1.2.3",
+    };
+    expect(processActions.setRunning(payload, true)).toEqual(
+      jujuActions.addModelUpgrade({
+        modelUUID: "abc123",
+        currentVersion: "0.0.0",
+        upgradeVersion: "1.2.3",
+      }),
+    );
+  });
+
+  it("removes the upgrade when it stops running", ({ expect }) => {
+    const payload = {
+      wsControllerURL: "wss://example.com/api",
+      modelName: "some-model",
+      modelUUID: "abc123",
+      modelURL: "wss://example.com/model/abc123/api",
+      currentVersion: "0.0.0",
+      targetVersion: "1.2.3",
+    };
+    expect(processActions.setRunning(payload, false)).toEqual(
+      jujuActions.removeModelUpgrade({
+        modelUUID: "abc123",
       }),
     );
   });

--- a/src/store/middleware/process/model-upgrade/upgrade-model.ts
+++ b/src/store/middleware/process/model-upgrade/upgrade-model.ts
@@ -1,0 +1,177 @@
+import { createToast } from "store/app/actions";
+import { actions as jujuActions } from "store/juju";
+import type { ManagedConnection } from "store/middleware/connection/connection-manager";
+import { hasConnections } from "store/middleware/connection/util";
+import modelList from "store/middleware/source/model-list";
+import { logger } from "utils/logger";
+
+import { createProcess } from "../createProcess";
+
+import createModelConnectionRetrySource from "./model-connection-retry-source";
+
+export enum Label {
+  ERROR_INVALID_VERSION = "The upgrade version is invalid",
+  ERROR_INIT_FAILED = "Upgrade failed to start",
+}
+
+enum UpgradeStatus {
+  INITIATED = "initiated",
+  LOADING = "loading",
+  PENDING = "pending",
+  RECONNECTING = "reconnecting",
+}
+
+type UpgradeState = {
+  status: UpgradeStatus;
+};
+
+const REQUIRED_CONNECTIONS = ["wsControllerURL", "modelURL"];
+/**
+ * Number of poll requests between each toast.
+ */
+const STATUS_TOAST_INTERVAL = 5;
+
+type Params = {
+  wsControllerURL: string;
+  modelName: string;
+  modelUUID: string;
+  modelURL: string;
+  currentVersion: string;
+  targetVersion: string;
+};
+
+export async function* upgradeModel(
+  modelUUID: string,
+  targetVersion: string,
+  controllerConnection: ManagedConnection,
+  modelConnection: ManagedConnection,
+): AsyncGenerator<UpgradeState, void, void> {
+  const modelTag = `model-${modelUUID}`;
+
+  const request = controllerConnection.facades.modelUpgrader?.upgradeModel({
+    "model-tag": modelTag,
+    "target-version": targetVersion,
+  });
+  yield { status: UpgradeStatus.PENDING };
+  const result = await request;
+
+  if (result?.error) {
+    throw new Error(`${Label.ERROR_INIT_FAILED}: ${result.error.message}`);
+  }
+
+  yield { status: UpgradeStatus.INITIATED };
+
+  // Poll for model version.
+  const versionSource = createModelConnectionRetrySource(modelConnection);
+  let statusCount = 0;
+  for await (const response of versionSource) {
+    if ("version" in response) {
+      if (response.version === targetVersion) {
+        // The model has reached the target version so the source can now finish.
+        break;
+      }
+      // Send a toast to to inform the user that it's in progress.
+      statusCount += 1;
+      if (statusCount % STATUS_TOAST_INTERVAL === 0) {
+        yield { status: UpgradeStatus.LOADING };
+      }
+    } else {
+      statusCount = 0;
+      yield { status: UpgradeStatus.RECONNECTING };
+    }
+  }
+  versionSource.done();
+}
+
+export default createProcess<Params, UpgradeState, void>(
+  "model-upgrade/upgrade-model",
+  async function* ({
+    modelUUID,
+    targetVersion,
+    meta,
+  }): AsyncGenerator<UpgradeState, void, void> {
+    if (!hasConnections(meta, REQUIRED_CONNECTIONS)) {
+      throw new Error("missing connections");
+    }
+
+    const controllerConnection = meta.connections.wsControllerURL;
+    const modelConnection = meta.connections.modelURL;
+
+    return yield* upgradeModel(
+      modelUUID,
+      targetVersion,
+      controllerConnection,
+      modelConnection,
+    );
+  },
+  {
+    setOutcome: ({ modelUUID, modelName, targetVersion }, outcome) => {
+      if ("error" in outcome) {
+        logger.error(
+          "An error occurred during model upgrade",
+          modelUUID,
+          outcome.error,
+        );
+        return createToast({
+          message: `Failed to upgrade. Model "${modelName}" has not been migrated or upgraded. Try again or contact support.`,
+          severity: "negative",
+        });
+      } else {
+        return createToast({
+          message: `Model "${modelName}" upgraded to ${targetVersion}`,
+          severity: "positive",
+        });
+      }
+    },
+    setStatus: ({ modelUUID, modelName }, status) => {
+      let message: null | string = null;
+      switch (status.status) {
+        case UpgradeStatus.PENDING:
+          logger.debug(`${modelName} (${modelUUID}) upgrade pending`);
+          message = `Upgrading model "${modelName}"…`;
+          break;
+        case UpgradeStatus.INITIATED:
+          logger.debug(`${modelName} (${modelUUID}) upgrade initiated`);
+          break;
+        case UpgradeStatus.LOADING:
+          logger.debug(`${modelName} (${modelUUID}) upgrade loading`);
+          break;
+        case UpgradeStatus.RECONNECTING:
+          logger.debug(
+            `Attempting to reconnect to ${modelName} (${modelUUID})`,
+          );
+          break;
+        default:
+          logger.warn("An unknown status was emitted", modelUUID, status);
+          break;
+      }
+
+      if (!message) {
+        // Don't display a toast if there is no message.
+        return;
+      }
+
+      return createToast({ message, severity: "information" });
+    },
+    setRunning: ({ modelUUID, targetVersion, currentVersion }, running) => {
+      if (running) {
+        return jujuActions.addModelUpgrade({
+          modelUUID,
+          currentVersion,
+          upgradeVersion: targetVersion,
+        });
+      } else {
+        return jujuActions.removeModelUpgrade({ modelUUID });
+      }
+    },
+  },
+  {
+    addActionMeta: () => ({
+      withConnection: true,
+      connectionList: REQUIRED_CONNECTIONS,
+    }),
+    after: ({ wsControllerURL }, dispatch) => {
+      dispatch(modelList.actions.invalidate({ wsControllerURL }));
+    },
+  },
+);

--- a/src/store/middleware/process/model-upgrade/upgrade-model.ts
+++ b/src/store/middleware/process/model-upgrade/upgrade-model.ts
@@ -6,6 +6,7 @@ import modelList from "store/middleware/source/model-list";
 import { logger } from "utils/logger";
 
 import { createProcess } from "../createProcess";
+import type { ProcessActions } from "../types";
 
 import createModelConnectionRetrySource from "./model-connection-retry-source";
 
@@ -14,7 +15,7 @@ export enum Label {
   ERROR_INIT_FAILED = "Upgrade failed to start",
 }
 
-enum UpgradeStatus {
+export enum UpgradeStatus {
   INITIATED = "initiated",
   LOADING = "loading",
   PENDING = "pending",
@@ -83,6 +84,66 @@ export async function* upgradeModel(
   versionSource.done();
 }
 
+export const processActions: ProcessActions<Params, UpgradeState, void> = {
+  setOutcome: ({ modelUUID, modelName, targetVersion }, outcome) => {
+    if ("error" in outcome) {
+      logger.error(
+        "An error occurred during model upgrade",
+        modelUUID,
+        outcome.error,
+      );
+      return createToast({
+        message: `Failed to upgrade. Model "${modelName}" has not been migrated or upgraded. Try again or contact support.`,
+        severity: "negative",
+      });
+    } else {
+      return createToast({
+        message: `Model "${modelName}" upgraded to ${targetVersion}`,
+        severity: "positive",
+      });
+    }
+  },
+  setStatus: ({ modelUUID, modelName }, status) => {
+    let message: null | string = null;
+    switch (status.status) {
+      case UpgradeStatus.PENDING:
+        logger.debug(`${modelName} (${modelUUID}) upgrade pending`);
+        message = `Upgrading model "${modelName}"…`;
+        break;
+      case UpgradeStatus.INITIATED:
+        logger.debug(`${modelName} (${modelUUID}) upgrade initiated`);
+        break;
+      case UpgradeStatus.LOADING:
+        logger.debug(`${modelName} (${modelUUID}) upgrade loading`);
+        break;
+      case UpgradeStatus.RECONNECTING:
+        logger.debug(`Attempting to reconnect to ${modelName} (${modelUUID})`);
+        break;
+      default:
+        logger.warn("An unknown status was emitted", modelUUID, status);
+        break;
+    }
+
+    if (!message) {
+      // Don't display a toast if there is no message.
+      return;
+    }
+
+    return createToast({ message, severity: "information" });
+  },
+  setRunning: ({ modelUUID, targetVersion, currentVersion }, running) => {
+    if (running) {
+      return jujuActions.addModelUpgrade({
+        modelUUID,
+        currentVersion,
+        upgradeVersion: targetVersion,
+      });
+    } else {
+      return jujuActions.removeModelUpgrade({ modelUUID });
+    }
+  },
+};
+
 export default createProcess<Params, UpgradeState, void>(
   "model-upgrade/upgrade-model",
   async function* ({
@@ -104,67 +165,7 @@ export default createProcess<Params, UpgradeState, void>(
       modelConnection,
     );
   },
-  {
-    setOutcome: ({ modelUUID, modelName, targetVersion }, outcome) => {
-      if ("error" in outcome) {
-        logger.error(
-          "An error occurred during model upgrade",
-          modelUUID,
-          outcome.error,
-        );
-        return createToast({
-          message: `Failed to upgrade. Model "${modelName}" has not been migrated or upgraded. Try again or contact support.`,
-          severity: "negative",
-        });
-      } else {
-        return createToast({
-          message: `Model "${modelName}" upgraded to ${targetVersion}`,
-          severity: "positive",
-        });
-      }
-    },
-    setStatus: ({ modelUUID, modelName }, status) => {
-      let message: null | string = null;
-      switch (status.status) {
-        case UpgradeStatus.PENDING:
-          logger.debug(`${modelName} (${modelUUID}) upgrade pending`);
-          message = `Upgrading model "${modelName}"…`;
-          break;
-        case UpgradeStatus.INITIATED:
-          logger.debug(`${modelName} (${modelUUID}) upgrade initiated`);
-          break;
-        case UpgradeStatus.LOADING:
-          logger.debug(`${modelName} (${modelUUID}) upgrade loading`);
-          break;
-        case UpgradeStatus.RECONNECTING:
-          logger.debug(
-            `Attempting to reconnect to ${modelName} (${modelUUID})`,
-          );
-          break;
-        default:
-          logger.warn("An unknown status was emitted", modelUUID, status);
-          break;
-      }
-
-      if (!message) {
-        // Don't display a toast if there is no message.
-        return;
-      }
-
-      return createToast({ message, severity: "information" });
-    },
-    setRunning: ({ modelUUID, targetVersion, currentVersion }, running) => {
-      if (running) {
-        return jujuActions.addModelUpgrade({
-          modelUUID,
-          currentVersion,
-          upgradeVersion: targetVersion,
-        });
-      } else {
-        return jujuActions.removeModelUpgrade({ modelUUID });
-      }
-    },
-  },
+  processActions,
   {
     addActionMeta: () => ({
       withConnection: true,

--- a/src/testing/factories/juju/SecretsV2.ts
+++ b/src/testing/factories/juju/SecretsV2.ts
@@ -18,6 +18,7 @@ export const secretAccessInfoFactory = Factory.define<AccessInfo>(() => ({
 export const listSecretResultFactory = Factory.define<ListSecretResult>(() => ({
   "create-time": "2024-01-05T05:10:17Z",
   "latest-revision": 1,
+  "latest-revision-checksum": "aabbccdd",
   "owner-tag": "model-ab02a18f-1ea9-49cb-898d-cad17d330b21",
   "update-time": "2024-01-05T05:10:17Z",
   revisions: [],

--- a/yarn.lock
+++ b/yarn.lock
@@ -239,15 +239,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@canonical/jujulib@npm:8.1.0":
-  version: 8.1.0
-  resolution: "@canonical/jujulib@npm:8.1.0"
+"@canonical/jujulib@npm:9.0.0":
+  version: 9.0.0
+  resolution: "@canonical/jujulib@npm:9.0.0"
   dependencies:
     "@canonical/macaroon-bakery": "npm:1.3.2"
     btoa: "npm:1.2.1"
     websocket: "npm:1.0.34"
     xhr2: "npm:0.2.1"
-  checksum: 10c0/456856fd7a8eb75c5989544ea486f998e98329f4d283b42ce550440d436d0b39399fc3944a9b7d88f6e30a770deae1390cee973d643d2b2c00cd63fffe872a56
+  checksum: 10c0/f8f93231924d136c69d018ac6b200bc9a785b22628be042c568583120a8570c187ce9893d84b49ba750dd9498078dfbab551b0ff9620d31effd008a1e140dfba
   languageName: node
   linkType: hard
 
@@ -9258,7 +9258,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "juju-dashboard@workspace:."
   dependencies:
-    "@canonical/jujulib": "npm:8.1.0"
+    "@canonical/jujulib": "npm:9.0.0"
     "@canonical/macaroon-bakery": "npm:1.3.2"
     "@canonical/react-components": "npm:4.5.2"
     "@canonical/rebac-admin": "npm:0.0.1-alpha.12"


### PR DESCRIPTION
## Done

- Add the ability to upgrade a patch version without a controller migration.

## QA

- Set up JIMM with a model that has a [lower version than the controller ](https://github.com/canonical/juju-dashboard/blob/main/HACKING.md#add-a-model-with-a-version-older-than-the-controller).
- Open the upgrade model panel and choose the manual option.
- Click inside the field and select the version that matches the version of the controller it is on.
- Go to the confirmation screen and you shouldn't see an option for selecting a controller.
- Confirm and submit. The upgrade should start and then finish very quickly and the version in the model list should update to the chosen version.

## Details

https://warthogs.atlassian.net/browse/JUJU-9735
