### PR TITLE
fix: only fetch migration targets as admin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ pkg/
 public/config.local.js
 .nfs.*
 /charms/machine-charm/src/dist
+network-cache
 
 .yarn/*
 !.yarn/patches

--- a/HACKING.md
+++ b/HACKING.md
@@ -381,7 +381,7 @@ To be able to add models, first as the admin user give them permission to add mo
 
 Next you will need to log out of the admin account and log in as the user you just created.
 
-NOTE: when logging in as the new user you may need to use another browser or private window if you've previously logged in as jimm-test otherwise you'll get logged in as the admin.
+NOTE: when logging in as the new user you may need to clear your cookies or use another browser or private window if you've previously logged in as jimm-test otherwise you'll get logged in as the admin.
 
 ```shell
 juju unregister jimm-dev

--- a/HACKING.md
+++ b/HACKING.md
@@ -39,6 +39,7 @@ contribute and what kinds of contributions are welcome.
       - [Vanilla React Components](#vanilla-react-components)
   - [Deployed JIMM controller](#deployed-jimm-controller)
     - [Adding users](#adding-users)
+      - [Add model permissions](#add-model-permissions)
     - [Self signed certificates](#self-signed-certificates)
     - [Juju on M1 Macs](#juju-on-m1-macs)
   - [Building the Docker image](#building-the-docker-image)
@@ -369,9 +370,31 @@ form.
 
 On the user details page click on the 'Credentials' tab and set a password.
 
-You can now give the user access in all the normal ways such as `juju
-grant-cloud [user@email] add-model localhost` and you can log in as the user with `juju
-login` and enter the details you set above.
+#### Add model permissions
+
+To be able to add models, first as the admin user give them permission to add models on the cloud and controller, substituting the user's email address and controller name (for the microk8s setup it would be controller-qa-microk8s).
+
+```shell
+~/jimm/jaas add-permission user-test@example.com can_addmodel cloud-localhost
+~/jimm/jaas add-permission user-test@example.com can_addmodel controller-qa-lxd
+```
+
+Next you will need to log out of the admin account and log in as the user you just created.
+
+NOTE: when logging in as the new user you may need to use another browser or private window if you've previously logged in as jimm-test otherwise you'll get logged in as the admin.
+
+```shell
+juju unregister jimm-dev
+juju login jimm.localhost -c jimm-dev
+```
+
+Confirm that you've logged in as the new user with `juju whoami`.
+
+Finally, update your credentials. This will use the credentials that have been stored in your local credentials.yaml
+
+```shell
+juju update-credentials localhost --controller jimm-dev
+```
 
 ### Self signed certificates
 

--- a/src/components/ModelActions/ModelActions.test.tsx
+++ b/src/components/ModelActions/ModelActions.test.tsx
@@ -547,7 +547,7 @@ describe("ModelActions", () => {
       ).not.toBeInTheDocument();
     });
 
-    it("disables the option if the user is not a JIMM admin", async () => {
+    it("does not display the option if the user is not a JIMM admin", async () => {
       state.juju.rebac.allowed = [];
       renderComponent(
         <ModelActions
@@ -561,8 +561,8 @@ describe("ModelActions", () => {
       );
       await userEvent.click(screen.getByRole("button", { name: Label.TOGGLE }));
       expect(
-        screen.getByRole("menuitem", { name: Label.UPGRADE }),
-      ).toHaveAttribute("aria-disabled");
+        screen.queryByRole("menuitem", { name: Label.UPGRADE }),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/src/components/ModelActions/ModelActions.tsx
+++ b/src/components/ModelActions/ModelActions.tsx
@@ -56,28 +56,29 @@ const generateLinks = (
   nextVersion: string | undefined,
   handleClose: NonNullable<ContextualMenuDropdownProps["handleClose"]>,
 ): React.JSX.Element => {
-  const upgradeButton: ReactNode = isJuju ? null : (
-    <Button
-      className="p-contextual-menu__link"
-      disabled={!isJIMMControllerAdmin || !hasUpgrades}
-      role="menuitem"
-      onClick={(event) => {
-        event.stopPropagation();
-        handleClose(event);
-        setPanelQs(
-          {
-            modelName,
-            panel: "upgrade-model",
-            qualifier,
-          },
-          { replace: true },
-        );
-      }}
-    >
-      {Label.UPGRADE}
-      {upgradeDataLoaded ? null : <Spinner className="u-sh1" />}
-    </Button>
-  );
+  const upgradeButton: ReactNode =
+    isJuju || !isJIMMControllerAdmin ? null : (
+      <Button
+        className="p-contextual-menu__link"
+        disabled={!isJIMMControllerAdmin || !hasUpgrades}
+        role="menuitem"
+        onClick={(event) => {
+          event.stopPropagation();
+          handleClose(event);
+          setPanelQs(
+            {
+              modelName,
+              panel: "upgrade-model",
+              qualifier,
+            },
+            { replace: true },
+          );
+        }}
+      >
+        {Label.UPGRADE}
+        {upgradeDataLoaded ? null : <Spinner className="u-sh1" />}
+      </Button>
+    );
   let upgradeTooltip: null | string = null;
   if (upgradeDataLoaded && !hasUpgrades) {
     if (isLatest) {

--- a/src/components/ModelActions/ModelActions.tsx
+++ b/src/components/ModelActions/ModelActions.tsx
@@ -60,7 +60,7 @@ const generateLinks = (
     isJuju || !isJIMMControllerAdmin ? null : (
       <Button
         className="p-contextual-menu__link"
-        disabled={!isJIMMControllerAdmin || !hasUpgrades}
+        disabled={!hasUpgrades}
         role="menuitem"
         onClick={(event) => {
           event.stopPropagation();

--- a/src/hooks/useModelMigrationData.test.ts
+++ b/src/hooks/useModelMigrationData.test.ts
@@ -1,7 +1,16 @@
+import { JIMMRelation, JIMMTarget } from "juju/jimm/JIMMV4";
 import jimmSupportedVersions from "store/middleware/source/jimm-supported-versions";
 import migrationTargets from "store/middleware/source/migration-targets";
 import type { RootState } from "store/store";
-import { generalStateFactory, configFactory } from "testing/factories/general";
+import {
+  generalStateFactory,
+  configFactory,
+  authUserInfoFactory,
+} from "testing/factories/general";
+import {
+  rebacAllowedFactory,
+  relationshipTupleFactory,
+} from "testing/factories/juju/jimm";
 import {
   jujuStateFactory,
   modelListInfoFactory,
@@ -20,6 +29,13 @@ describe("useModelMigrationData", () => {
         config: configFactory.build({
           controllerAPIEndpoint: "wss://example.com/api",
         }),
+        controllerConnections: {
+          "wss://example.com/api": {
+            user: authUserInfoFactory.build({
+              identity: "user-eggman@external",
+            }),
+          },
+        },
       }),
       juju: jujuStateFactory.build({
         models: {
@@ -27,6 +43,18 @@ describe("useModelMigrationData", () => {
             uuid: "abc123",
             name: "test1",
           }),
+        },
+        rebac: {
+          allowed: [
+            rebacAllowedFactory.build({
+              tuple: relationshipTupleFactory.build({
+                object: "user-eggman@external",
+                relation: JIMMRelation.ADMINISTRATOR,
+                target_object: JIMMTarget.JIMM_CONTROLLER,
+              }),
+              allowed: true,
+            }),
+          ],
         },
       }),
     });
@@ -38,6 +66,31 @@ describe("useModelMigrationData", () => {
     } else {
       assert.fail("Config not defined");
     }
+    const [store, actions] = createStore(state, {
+      trackActions: true,
+    });
+    renderWrappedHook(
+      () => {
+        useModelMigrationData("test1", "eggman@external");
+      },
+      {
+        store,
+      },
+    );
+    expect(
+      actions.find((dispatch) =>
+        jimmSupportedVersions.actions.start.match(dispatch),
+      ),
+    ).toBeUndefined();
+    expect(
+      actions.find((dispatch) =>
+        migrationTargets.actions.start.match(dispatch),
+      ),
+    ).toBeUndefined();
+  });
+
+  it("does not poll for data if the user is not a JIMM admin", () => {
+    state.juju.rebac.allowed = [];
     const [store, actions] = createStore(state, {
       trackActions: true,
     });

--- a/src/hooks/useModelMigrationData.ts
+++ b/src/hooks/useModelMigrationData.ts
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 
+import { useIsJIMMAdmin } from "juju/api-hooks/permissions";
 import { getIsJIMM, getWSControllerURL } from "store/general/selectors";
 import { getModelUUIDFromList } from "store/juju/selectors";
 import jimmSupportedVersions from "store/middleware/source/jimm-supported-versions";
@@ -20,9 +21,10 @@ const useModelMigrationData = (
     getModelUUIDFromList(state, modelName, qualifier),
   );
   const isJIMM = useAppSelector(getIsJIMM);
+  const { permitted: isJIMMControllerAdmin } = useIsJIMMAdmin();
 
   useEffect(() => {
-    if (wsControllerURL && fetchData && isJIMM) {
+    if (wsControllerURL && fetchData && isJIMM && isJIMMControllerAdmin) {
       dispatch(jimmSupportedVersions.actions.start({ wsControllerURL }));
       if (modelUUID) {
         dispatch(
@@ -31,7 +33,7 @@ const useModelMigrationData = (
       }
     }
     return (): void => {
-      if (wsControllerURL && isJIMM) {
+      if (wsControllerURL && isJIMM && isJIMMControllerAdmin) {
         dispatch(jimmSupportedVersions.actions.stop({ wsControllerURL }));
         if (modelUUID) {
           dispatch(
@@ -40,7 +42,14 @@ const useModelMigrationData = (
         }
       }
     };
-  }, [dispatch, fetchData, isJIMM, modelUUID, wsControllerURL]);
+  }, [
+    dispatch,
+    fetchData,
+    isJIMM,
+    isJIMMControllerAdmin,
+    modelUUID,
+    wsControllerURL,
+  ]);
 };
 
 export default useModelMigrationData;


### PR DESCRIPTION
## Done

- Fixed model upgrades so that migration targets are only fetched if the user is a JIMM admin.

## QA

- Add a model that can be upgraded.
- Log in to the dashboard as a JIMM admin.
- Open the model actions menu and the upgrade item should be enabled.
- Add a non JIMM admin user (see the new instructions in the hacking doc if needed).
- Log in to the dashboard as the non-admin user.
- Open the model actions menu and the upgrade item should not be visible and there shouldn't be any errors in the console.
