### PR TITLE
feat: add validation for missing credentials

### DIFF
--- a/src/pages/AddModel/AddModel.test.tsx
+++ b/src/pages/AddModel/AddModel.test.tsx
@@ -10,6 +10,7 @@ import {
   jujuStateFactory,
   controllerFactory,
   cloudInfoStateFactory,
+  userCredentialsStateFactory,
 } from "testing/factories/juju/juju";
 import { rootStateFactory } from "testing/factories/root";
 import { createStore, renderComponent } from "testing/utils";
@@ -52,6 +53,11 @@ describe("AddModel page", () => {
           clouds: {
             "cloud-aws": { type: "ec2" },
             "cloud-gce": { type: "gce" },
+          },
+        }),
+        userCredentials: userCredentialsStateFactory.build({
+          credentials: {
+            "cloud-aws": ["cloudcred-aws_admin_aws-cred"],
           },
         }),
         controllers: {
@@ -169,6 +175,26 @@ describe("AddModel page", () => {
     ).toHaveAttribute("aria-disabled");
   });
 
+  it("disables Add model button on no credential", async () => {
+    state.juju.userCredentials = userCredentialsStateFactory.build({
+      credentials: {},
+    });
+    renderComponent(<AddModel />, { state });
+    await userEvent.type(
+      screen.getByLabelText(new RegExp(MandatoryDetailsLabel.MODEL_NAME)),
+      "model",
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: Label.NEXT_BUTTON }),
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: Label.NEXT_BUTTON }),
+    );
+    expect(
+      screen.getByRole("button", { name: Label.CREATE_BUTTON }),
+    ).toHaveAttribute("aria-disabled");
+  });
+
   it("enables Add model button on valid input", async () => {
     renderComponent(<AddModel />, { state });
     expect(
@@ -263,7 +289,7 @@ describe("AddModel page", () => {
 
     const addModelAction = jujuActions.addModel({
       cloudTag: "cloud-aws",
-      credential: "",
+      credential: "cloudcred-aws_admin_aws-cred",
       modelName: "my-model",
       userTag: "user-eggman@external",
       wsControllerURL: "wss://controller.example.com",
@@ -291,7 +317,7 @@ describe("AddModel page", () => {
 
     const addModelAction = jujuActions.addModel({
       cloudTag: "cloud-aws",
-      credential: "",
+      credential: "cloudcred-aws_admin_aws-cred",
       modelName: "my-model",
       userTag: "user-eggman@external",
       wsControllerURL: "wss://controller.example.com",
@@ -327,7 +353,7 @@ describe("AddModel page", () => {
 
     const addModelAction = jujuActions.addModel({
       cloudTag: "cloud-aws",
-      credential: "",
+      credential: "cloudcred-aws_admin_aws-cred",
       config: {
         "default-space": "my-space",
       },

--- a/src/pages/AddModel/AddModel.tsx
+++ b/src/pages/AddModel/AddModel.tsx
@@ -171,6 +171,8 @@ const AddModel: FC = () => {
               ...getConfigInitialValues(CONFIG_CATEGORIES),
             }}
             validationSchema={validationSchema}
+            // Mark credential as touched on mount as Vanilla doesn't display validation until the field loses focus.
+            initialTouched={{ credential: true }}
             onSubmit={handleCreateClick}
           >
             <>

--- a/src/pages/AddModel/AddModel.tsx
+++ b/src/pages/AddModel/AddModel.tsx
@@ -38,6 +38,7 @@ import {
   type AddModelFormState,
   type StepDefinition,
 } from "./types";
+import { getCredentialError } from "./utils";
 
 const MODEL_NAME_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
 
@@ -45,6 +46,16 @@ const validationSchema = Yup.object().shape({
   modelName: Yup.string()
     .matches(MODEL_NAME_PATTERN, Label.INCORRECT_MODEL_NAME_ERROR)
     .required("Required"),
+  credential: Yup.string().test({
+    test: function (value) {
+      if (value !== undefined && value !== "") {
+        return true;
+      }
+      return this.createError({
+        message: getCredentialError(this.parent.cloud),
+      });
+    },
+  }),
 });
 
 const stepDefinitions: StepDefinition[] = [

--- a/src/pages/AddModel/AddModelStepper/AddModelStepper.test.tsx
+++ b/src/pages/AddModel/AddModelStepper/AddModelStepper.test.tsx
@@ -6,6 +6,7 @@ import { InputMode } from "../ConfigsConstraints/ContentSwitcher/types";
 import { DisableType, FieldName } from "../ConfigsConstraints/types";
 import {
   type AddModelFormState,
+  Label,
   type StepDefinition,
   StepType,
 } from "../types";
@@ -15,6 +16,13 @@ import AddModelStepper from "./AddModelStepper";
 describe("AddModelStepper", () => {
   let stepDefinitions: StepDefinition[];
   let initialValues: AddModelFormState;
+
+  const getMandatoryDetailsStep = (): HTMLElement => {
+    const step = screen.getByText("Mandatory Details").closest(".step");
+    expect(step).not.toBeNull();
+    return step as HTMLElement;
+  };
+
   beforeEach(() => {
     stepDefinitions = [
       {
@@ -80,5 +88,107 @@ describe("AddModelStepper", () => {
     );
     expect(handleStepClick).toHaveBeenCalledWith(1);
     expect(handleStepClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the required model name label and an error icon when model name is empty", () => {
+    render(
+      <Formik<AddModelFormState>
+        initialValues={initialValues}
+        initialErrors={{ modelName: Label.REQUIRED_MODEL_NAME_ERROR }}
+        onSubmit={vi.fn()}
+      >
+        <AddModelStepper
+          stepDefinitions={stepDefinitions}
+          currentStepIndex={1}
+          handleStepClick={vi.fn()}
+        />
+      </Formik>,
+    );
+
+    const mandatoryDetailsStep = getMandatoryDetailsStep();
+    expect(
+      mandatoryDetailsStep.querySelector(".p-icon--error"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(Label.REQUIRED_MODEL_NAME_ERROR),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the incorrect model name label and an error icon when model name is invalid", () => {
+    render(
+      <Formik<AddModelFormState>
+        initialValues={
+          { ...initialValues, modelName: "-model" } as AddModelFormState
+        }
+        initialErrors={{ modelName: Label.INCORRECT_MODEL_NAME_ERROR }}
+        onSubmit={vi.fn()}
+      >
+        <AddModelStepper
+          stepDefinitions={stepDefinitions}
+          currentStepIndex={1}
+          handleStepClick={vi.fn()}
+        />
+      </Formik>,
+    );
+
+    const mandatoryDetailsStep = getMandatoryDetailsStep();
+    expect(
+      mandatoryDetailsStep.querySelector(".p-icon--error"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(Label.INCORRECT_MODEL_NAME_ERROR),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the credential label and an error icon when only credential has an error", () => {
+    render(
+      <Formik<AddModelFormState>
+        initialValues={initialValues}
+        initialErrors={{ credential: Label.REQUIRED_CREDENTIAL_ERROR }}
+        onSubmit={vi.fn()}
+      >
+        <AddModelStepper
+          stepDefinitions={stepDefinitions}
+          currentStepIndex={1}
+          handleStepClick={vi.fn()}
+        />
+      </Formik>,
+    );
+
+    const mandatoryDetailsStep = getMandatoryDetailsStep();
+    expect(
+      mandatoryDetailsStep.querySelector(".p-icon--error"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(Label.REQUIRED_CREDENTIAL_ERROR),
+    ).toBeInTheDocument();
+  });
+
+  it("shows a combined error label when model name and credential both have errors", () => {
+    render(
+      <Formik<AddModelFormState>
+        initialValues={initialValues}
+        initialErrors={{
+          modelName: Label.REQUIRED_MODEL_NAME_ERROR,
+          credential: Label.REQUIRED_CREDENTIAL_ERROR,
+        }}
+        onSubmit={vi.fn()}
+      >
+        <AddModelStepper
+          stepDefinitions={stepDefinitions}
+          currentStepIndex={1}
+          handleStepClick={vi.fn()}
+        />
+      </Formik>,
+    );
+
+    const mandatoryDetailsStep = getMandatoryDetailsStep();
+
+    expect(
+      mandatoryDetailsStep.querySelector(".p-icon--error"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(`${Label.REQUIRED_MODEL_NAME_ERROR} + 1 issue`),
+    ).toBeInTheDocument();
   });
 });

--- a/src/pages/AddModel/AddModelStepper/AddModelStepper.tsx
+++ b/src/pages/AddModel/AddModelStepper/AddModelStepper.tsx
@@ -22,26 +22,27 @@ const AddModelStepper = ({
       steps={stepDefinitions.map(({ key, title }, index) => {
         const isPrevious = index < currentStepIndex;
         const isCurrent = index === currentStepIndex;
-        let hasModelNameError = false;
-        let hasCredentialError = false;
         let label = undefined;
+        const labels = [];
         if (index === 0) {
           if (errors.modelName) {
-            hasModelNameError = true;
-            label =
+            labels.push(
               values.modelName !== ""
                 ? Label.INCORRECT_MODEL_NAME_ERROR
-                : Label.REQUIRED_MODEL_NAME_ERROR;
+                : Label.REQUIRED_MODEL_NAME_ERROR,
+            );
           }
           if (errors.credential) {
-            hasCredentialError = true;
-            label = hasModelNameError
-              ? `${label} + 1 issue`
-              : Label.REQUIRED_CREDENTIAL_ERROR;
+            labels.push(Label.REQUIRED_CREDENTIAL_ERROR);
+          }
+          if (labels.length > 0) {
+            [label] = labels;
+            if (labels.length > 1) {
+              label = `${label} + ${labels.length - 1} issue`;
+            }
           }
         }
-        const previousIcon =
-          hasModelNameError || hasCredentialError ? "error" : "success";
+        const previousIcon = label ? "error" : "success";
         return (
           <Step
             key={key}

--- a/src/pages/AddModel/AddModelStepper/AddModelStepper.tsx
+++ b/src/pages/AddModel/AddModelStepper/AddModelStepper.tsx
@@ -22,21 +22,31 @@ const AddModelStepper = ({
       steps={stepDefinitions.map(({ key, title }, index) => {
         const isPrevious = index < currentStepIndex;
         const isCurrent = index === currentStepIndex;
-        const hasModelNameError = (index === 0 && errors.modelName) ?? false;
+        let hasModelNameError = false;
+        let hasCredentialError = false;
         let label = undefined;
-        if (hasModelNameError && isPrevious) {
-          if (values.modelName !== "") {
-            label = Label.INCORRECT_MODEL_NAME_ERROR;
-          } else {
-            label = Label.REQUIRED_MODEL_NAME_ERROR;
+        if (index === 0) {
+          if (errors.modelName) {
+            hasModelNameError = true;
+            label =
+              values.modelName !== ""
+                ? Label.INCORRECT_MODEL_NAME_ERROR
+                : Label.REQUIRED_MODEL_NAME_ERROR;
+          }
+          if (errors.credential) {
+            hasCredentialError = true;
+            label = hasModelNameError
+              ? `${label} + 1 issue`
+              : Label.REQUIRED_CREDENTIAL_ERROR;
           }
         }
-        const previousIcon = hasModelNameError ? "error" : "success";
+        const previousIcon =
+          hasModelNameError || hasCredentialError ? "error" : "success";
         return (
           <Step
             key={key}
             title={title}
-            label={label}
+            label={isPrevious ? label : undefined}
             index={index + 1}
             enabled
             hasProgressLine={isPrevious || isCurrent}

--- a/src/pages/AddModel/types.ts
+++ b/src/pages/AddModel/types.ts
@@ -37,6 +37,7 @@ export enum Label {
   NEXT_BUTTON = "Next",
   BACK_BUTTON = "Back",
   CREATE_BUTTON = "Add model",
-  INCORRECT_MODEL_NAME_ERROR = "Incorrect model name format.",
-  REQUIRED_MODEL_NAME_ERROR = "Model name is required.",
+  INCORRECT_MODEL_NAME_ERROR = "Incorrect model name format",
+  REQUIRED_MODEL_NAME_ERROR = "Model name is required",
+  REQUIRED_CREDENTIAL_ERROR = "No cloud credentials",
 }

--- a/src/pages/AddModel/utils.test.ts
+++ b/src/pages/AddModel/utils.test.ts
@@ -1,0 +1,18 @@
+import { Label } from "./types";
+import { getCredentialError } from "./utils";
+
+describe("AddModel utils", () => {
+  describe("getCredentialError", () => {
+    it("returns a cloud-specific message when cloud is a string", () => {
+      expect(getCredentialError("cloud-aws")).toBe(
+        "No credentials available for aws. Contact admin or choose a different cloud.",
+      );
+    });
+
+    it("returns the generic credential error when cloud is not a string", () => {
+      expect(getCredentialError(undefined)).toBe(
+        Label.REQUIRED_CREDENTIAL_ERROR,
+      );
+    });
+  });
+});

--- a/src/pages/AddModel/utils.ts
+++ b/src/pages/AddModel/utils.ts
@@ -1,0 +1,10 @@
+import { extractCloudName } from "store/juju/utils/models";
+
+import { Label } from "./types";
+
+export const getCredentialError = (cloud: unknown): string => {
+  if (typeof cloud === "string") {
+    return `No credentials available for ${extractCloudName(cloud)}. Contact admin or choose a different cloud.`;
+  }
+  return Label.REQUIRED_CREDENTIAL_ERROR;
+};


### PR DESCRIPTION
## Done

- Added validation to AddModel form for when the user is missing cloud credentials
- Added appropriate error labels to the stepper for various combinations of errors

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Log into the dashboard as a new user with cloud+controller access but no credentials added
- Try navigating through the add-model flow with multiple combinations of invalid inputs
  - No model name, no credential
  - Invalid model name, no credential
  - Valid model name, no credential
  - Invalid model name, valid credential
  - All valid values to add model.
- All these scenarios should work well for both Juju and JIMM.
- The user should be able to add a model with all valid inputs

## Details

https://warthogs.atlassian.net/browse/JUJU-9892

## Screenshots


https://github.com/user-attachments/assets/a17693fc-a92f-4a6e-b749-29e0b8b3cc06


