### PR TITLE
feat: show toast when admin's access is reset

### DIFF
--- a/src/hooks/useModelDestructionToaster.test.tsx
+++ b/src/hooks/useModelDestructionToaster.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor, within } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import type { JSX } from "react";
 import { vi, describe, it, expect, beforeEach } from "vitest";
 
@@ -9,6 +9,7 @@ import type { RootState } from "store/store";
 import { jujuStateFactory, rootStateFactory } from "testing/factories";
 import { configFactory, generalStateFactory } from "testing/factories/general";
 import { modelListInfoFactory } from "testing/factories/juju/juju";
+import { findNotificationByText } from "testing/queries/notifications";
 import { createStore, renderComponent } from "testing/utils";
 
 import useModelDestructionToaster from "./useModelDestructionToaster";
@@ -70,9 +71,11 @@ describe("useModelDestructionToaster", () => {
     renderComponent(<TestComponent />, { state });
 
     const card = await screen.findByTestId(ToastCardTestId.TOAST_CARD);
-    expect(card).toHaveAttribute("data-type", "information");
     expect(
-      await within(card).findByText('Destroying model "enterprise"...'),
+      await findNotificationByText(card, 'Destroying model "enterprise"...', {
+        appearance: "toast",
+        severity: "information",
+      }),
     ).toBeInTheDocument();
   });
 
@@ -110,9 +113,15 @@ describe("useModelDestructionToaster", () => {
     });
 
     const card = await screen.findByTestId(ToastCardTestId.TOAST_CARD);
-    expect(card).toHaveAttribute("data-type", "negative");
     expect(
-      await within(card).findByText('Destroying model "enterprise" failed'),
+      await findNotificationByText(
+        card,
+        'Destroying model "enterprise" failed',
+        {
+          appearance: "toast",
+          severity: "negative",
+        },
+      ),
     ).toBeInTheDocument();
 
     await waitFor(() => {
@@ -144,10 +153,14 @@ describe("useModelDestructionToaster", () => {
     });
 
     const card = await screen.findByTestId(ToastCardTestId.TOAST_CARD);
-    expect(card).toHaveAttribute("data-type", "positive");
     expect(
-      await within(card).findByText(
+      await findNotificationByText(
+        card,
         'Model "enterprise" destroyed successfully',
+        {
+          appearance: "toast",
+          severity: "positive",
+        },
       ),
     ).toBeInTheDocument();
 

--- a/src/pages/AddModel/AccessManagement/AccessManagement.test.tsx
+++ b/src/pages/AddModel/AccessManagement/AccessManagement.test.tsx
@@ -9,6 +9,7 @@ import {
   generalStateFactory,
 } from "testing/factories/general";
 import { rootStateFactory } from "testing/factories/root";
+import { findNotificationByText } from "testing/queries/notifications";
 import { customWithin } from "testing/queries/within";
 import { renderComponent } from "testing/utils";
 
@@ -458,9 +459,15 @@ describe("AccessManagement", () => {
     expect(updatedActiveUserButton).toHaveTextContent("Admin");
 
     const card = await screen.findByTestId(ToastCardTestId.TOAST_CARD);
-    expect(card).toHaveAttribute("data-type", "caution");
     expect(
-      await within(card).findByText("Admin access set for eggman@external"),
+      await findNotificationByText(
+        card,
+        "Admin access set for eggman@external",
+        {
+          appearance: "toast",
+          severity: "caution",
+        },
+      ),
     ).toBeInTheDocument();
   });
 

--- a/src/pages/AddModel/AccessManagement/AccessManagement.test.tsx
+++ b/src/pages/AddModel/AccessManagement/AccessManagement.test.tsx
@@ -95,6 +95,51 @@ describe("AccessManagement", () => {
     expect(readButtons.length).toBeGreaterThan(0);
   });
 
+  it("updates the list when a user item is deselected from the multiselect dropdown", async () => {
+    const state = rootStateFactory.build({
+      general: generalStateFactory.withConfig().build({
+        controllerConnections: {
+          "wss://controller.example.com": {
+            user: authUserInfoFactory.build({
+              identity: "user-eggman@external",
+            }),
+          },
+        },
+      }),
+    });
+
+    renderComponent(
+      <Formik
+        initialValues={{
+          shareModelWith: {
+            "eggman@external": "admin",
+            "reader@example.com": "read",
+          },
+        }}
+        onSubmit={vi.fn()}
+      >
+        <AccessManagement />
+      </Formik>,
+      { state },
+    );
+
+    await userEvent.click(
+      screen.getByRole("combobox", {
+        name: Label.MULTI_SELECT_LABEL,
+      }),
+    );
+    await userEvent.click(
+      screen.getByRole("checkbox", {
+        name: "reader@example.com",
+      }),
+    );
+
+    expect(screen.queryByText("reader@example.com")).not.toBeInTheDocument();
+    expect(screen.getByRole("table")).toHaveTextContent(
+      "eggman@external (you)",
+    );
+  });
+
   it("updates access level when changed from custom select", async () => {
     renderComponent(
       <Formik initialValues={{ shareModelWith: {} }} onSubmit={vi.fn()}>

--- a/src/pages/AddModel/AccessManagement/AccessManagement.test.tsx
+++ b/src/pages/AddModel/AccessManagement/AccessManagement.test.tsx
@@ -2,6 +2,7 @@ import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 
+import { ToastCardTestId } from "components/ToastCard";
 import {
   authUserInfoFactory,
   configFactory,
@@ -410,6 +411,12 @@ describe("AccessManagement", () => {
 
     expect(updatedActiveUserButton).toHaveAttribute("aria-disabled", "true");
     expect(updatedActiveUserButton).toHaveTextContent("Admin");
+
+    const card = await screen.findByTestId(ToastCardTestId.TOAST_CARD);
+    expect(card).toHaveAttribute("data-type", "caution");
+    expect(
+      await within(card).findByText("Admin access set for eggman@external"),
+    ).toBeInTheDocument();
   });
 
   it("restores active user to admin when the only admin is removed and readers remain", async () => {

--- a/src/pages/AddModel/AccessManagement/AccessManagement.tsx
+++ b/src/pages/AddModel/AccessManagement/AccessManagement.tsx
@@ -20,6 +20,7 @@ import { useAppSelector } from "store/store";
 import { testId } from "testing/utils";
 import { AccessLevel } from "types";
 import { getUserName } from "utils";
+import { toastNotification } from "utils/toastNotification";
 
 import type { AddModelFormState } from "../types";
 
@@ -239,10 +240,24 @@ const AccessManagement = (): JSX.Element => {
                     className="u-no-margin--bottom u-no-padding--top u-no-padding--bottom"
                     disabled={userValue === activeUserName}
                     onClick={() => {
-                      void setFieldValue(
-                        "shareModelWith",
-                        removeUser(userValue, shareModelWith, activeUserName),
-                      );
+                      const { nextShareModelWith, showAccessRevertToast } =
+                        removeUser(userValue, shareModelWith, activeUserName);
+                      void setFieldValue("shareModelWith", nextShareModelWith);
+
+                      // Show a toast for when the active user's access is reverted
+                      if (showAccessRevertToast) {
+                        toastNotification(
+                          <>
+                            <b>Admin access set for {activeUserName}</b>
+                            <div>
+                              There needs to be at least 1 admin per model. Your
+                              role was reset to admin. To change your role add
+                              another admin user.
+                            </div>
+                          </>,
+                          "caution",
+                        );
+                      }
                     }}
                     aria-label={Label.BUTTON_DELETE}
                   >

--- a/src/pages/AddModel/AccessManagement/utils.test.ts
+++ b/src/pages/AddModel/AccessManagement/utils.test.ts
@@ -153,8 +153,11 @@ describe("AccessManagement utils", () => {
         "user@example.com",
       );
       expect(result).toEqual({
-        "user@example.com": AccessLevel.ADMIN,
-        "user2@example.com": AccessLevel.READ,
+        nextShareModelWith: {
+          "user@example.com": AccessLevel.ADMIN,
+          "user2@example.com": AccessLevel.READ,
+        },
+        showAccessRevertToast: false,
       });
     });
 
@@ -168,7 +171,10 @@ describe("AccessManagement utils", () => {
         "user1@example.com",
       );
       expect(result).toEqual({
-        "user1@example.com": AccessLevel.ADMIN,
+        nextShareModelWith: {
+          "user1@example.com": AccessLevel.ADMIN,
+        },
+        showAccessRevertToast: false,
       });
     });
 
@@ -183,7 +189,26 @@ describe("AccessManagement utils", () => {
         "user2@example.com",
       );
       expect(result).toEqual({
-        "user2@example.com": AccessLevel.ADMIN,
+        nextShareModelWith: {
+          "user2@example.com": AccessLevel.ADMIN,
+        },
+        showAccessRevertToast: true,
+      });
+    });
+
+    it("treats the active user as implicit admin when the key is missing", () => {
+      const shareModelWith = {
+        "other-admin@example.com": AccessLevel.ADMIN,
+      };
+      const result = removeUser(
+        "other-admin@example.com",
+        shareModelWith,
+        "owner@example.com",
+      );
+
+      expect(result).toEqual({
+        nextShareModelWith: {},
+        showAccessRevertToast: false,
       });
     });
 
@@ -199,8 +224,11 @@ describe("AccessManagement utils", () => {
         "owner@example.com",
       );
       expect(result).toEqual({
-        "owner@example.com": AccessLevel.ADMIN,
-        "reader@example.com": AccessLevel.READ,
+        nextShareModelWith: {
+          "owner@example.com": AccessLevel.ADMIN,
+          "reader@example.com": AccessLevel.READ,
+        },
+        showAccessRevertToast: true,
       });
     });
   });

--- a/src/pages/AddModel/AccessManagement/utils.ts
+++ b/src/pages/AddModel/AccessManagement/utils.ts
@@ -74,25 +74,32 @@ export const removeUser = (
   userValue: number | string,
   shareModelWith: Record<string, string>,
   activeUserName?: string,
-): Record<string, string> => {
+): {
+  nextShareModelWith: Record<string, string>;
+  showAccessRevertToast: boolean;
+} => {
   const { [userValue]: _removedUser, ...nextShareModelWith } = shareModelWith;
+  let showAccessRevertToast = false;
 
   if (activeUserName) {
-    const activeUserIsAdmin =
-      nextShareModelWith[activeUserName] === AccessLevel.ADMIN;
     const hasOtherAdmins = hasOtherAdmin(
       nextShareModelWith,
       activeUserName,
       activeUserName,
     );
 
+    // Missing key means the active user is implicit admin.
+    const activeUserIsAdmin =
+      (nextShareModelWith[activeUserName] ?? AccessLevel.ADMIN) ===
+      AccessLevel.ADMIN;
     // Ensure at least one admin remains after a removal.
     if (!activeUserIsAdmin && !hasOtherAdmins) {
       nextShareModelWith[activeUserName] = AccessLevel.ADMIN;
+      showAccessRevertToast = true;
     }
   }
 
-  return nextShareModelWith;
+  return { nextShareModelWith, showAccessRevertToast };
 };
 
 /**

--- a/src/pages/AddModel/AddModel.test.tsx
+++ b/src/pages/AddModel/AddModel.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor, within } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { ToastCardTestId } from "components/ToastCard";
@@ -13,6 +13,7 @@ import {
   userCredentialsStateFactory,
 } from "testing/factories/juju/juju";
 import { rootStateFactory } from "testing/factories/root";
+import { findNotificationByText } from "testing/queries/notifications";
 import { createStore, renderComponent } from "testing/utils";
 import urls from "urls";
 
@@ -392,9 +393,11 @@ describe("AddModel page", () => {
     renderComponent(<AddModel />, { state });
 
     const card = await screen.findByTestId(ToastCardTestId.TOAST_CARD);
-    expect(card).toHaveAttribute("data-type", "positive");
     expect(
-      await within(card).findByText('Model "" added successfully'),
+      await findNotificationByText(card, 'Model "" added successfully', {
+        appearance: "toast",
+        severity: "positive",
+      }),
     ).toBeInTheDocument();
   });
 
@@ -408,9 +411,11 @@ describe("AddModel page", () => {
     renderComponent(<AddModel />, { state });
 
     const card = await screen.findByTestId(ToastCardTestId.TOAST_CARD);
-    expect(card).toHaveAttribute("data-type", "negative");
     expect(
-      await within(card).findByText('Adding model "" failed'),
+      await findNotificationByText(card, 'Adding model "" failed', {
+        appearance: "toast",
+        severity: "negative",
+      }),
     ).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Done

- Added a warning toast for when the active user's access is reverted to admin
- Added a unit test for an uncovered callback.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Login with a non-superuser and go to AddModel page
- Navigate to AccessManagement tab and add a second user
- Modify the second user's access to admin, the active user's dropdown should now enable
- Reduce the active user's access to read/write
- Delete the second user's row
- Active user's access should revert to admin and a warning toast should be displayed

## Details

https://warthogs.atlassian.net/browse/JUJU-9837

## Screenshots


https://github.com/user-attachments/assets/3a376220-5de6-43b9-8fd3-4c1a37e71e0c


