### PR TITLE
fix: broken mandatory details screen

### DIFF
--- a/src/layout/MainContent/MainContent.tsx
+++ b/src/layout/MainContent/MainContent.tsx
@@ -28,28 +28,26 @@ const MainContent: FC<Props> = ({
         "l-main__content--has-secondary-nav": hasSecondaryNav,
       })}
     >
-      <>
-        {hasSecondaryNav && !loading ? (
-          <SecondaryNavigation
-            items={secondaryNav.items}
-            title={secondaryNav.title}
-          />
-        ) : null}
-        <Panel
-          className="l-main__panel"
-          {...testId(TestId.MAIN)}
-          titleClassName={titleClassName}
-          titleComponent={titleComponent}
-          stickyHeader
-          title={title}
-        >
-          <div className={classNames("l-content", contentClassName)} {...props}>
-            <FadeIn isActive={true}>
-              {loading ? <LoadingSpinner /> : children}
-            </FadeIn>
-          </div>
-        </Panel>
-      </>
+      {hasSecondaryNav && !loading ? (
+        <SecondaryNavigation
+          items={secondaryNav.items}
+          title={secondaryNav.title}
+        />
+      ) : null}
+      <Panel
+        className="l-main__panel"
+        {...testId(TestId.MAIN)}
+        titleClassName={titleClassName}
+        titleComponent={titleComponent}
+        stickyHeader
+        title={title}
+      >
+        <div className={classNames("l-content", contentClassName)} {...props}>
+          <FadeIn isActive={true}>
+            {loading ? <LoadingSpinner /> : children}
+          </FadeIn>
+        </div>
+      </Panel>
     </div>
   );
 };

--- a/src/pages/AddModel/MandatoryDetails/_mandatory-details.scss
+++ b/src/pages/AddModel/MandatoryDetails/_mandatory-details.scss
@@ -1,7 +1,8 @@
 .mandatory-details {
-  max-width: 40%;
+  display: grid;
+  grid-template-columns: 0.4fr;
 
   @include mobile {
-    max-width: 100%;
+    grid-template-columns: 1fr;
   }
 }

--- a/src/pages/AddModel/_add-model.scss
+++ b/src/pages/AddModel/_add-model.scss
@@ -3,6 +3,7 @@
   flex-direction: column;
   height: 100svh;
   position: fixed;
+  width: -webkit-fill-available;
   width: stretch;
 
   &__content {


### PR DESCRIPTION
## Done

- Fixed broken mandatory details page on safari (and probably on other browsers too)
- Improved css rules for mandatory details

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Open the AddModel page in safari browser
- The mandatory details tab should display correctly

## Details
The `position: fixed;` in `_add-model.scss` that we are using to correct dynamic heights moved the entire page out of the hierarchy forcing the page to take as much width as its children.
I originally used `width: stretch;` to make this work, however, this property doesn't work on all browsers.

## Screenshots

BEFORE
<img width="1352" height="658" alt="Screenshot 2026-06-09 at 7 32 15 PM" src="https://github.com/user-attachments/assets/aaa2e834-9644-4d0c-9fc9-1eb2fbbeb7e8" />

AFTER
<img width="1352" height="659" alt="Screenshot 2026-06-09 at 7 32 33 PM" src="https://github.com/user-attachments/assets/b0bcc4e4-b42e-4b69-911e-f02f7ec0f5c2" />
