### PR TITLE
feat: k8s charm base path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ pkg/
 public/config.local.js
 .nfs.*
 /charms/machine-charm/src/dist
+charms/k8s-charm/src/index.charm.html
 network-cache
 
 .yarn/*

--- a/charms/k8s-charm/src/charm.py
+++ b/charms/k8s-charm/src/charm.py
@@ -6,15 +6,20 @@
 
 import logging
 from pathlib import Path
+from urllib.parse import urlsplit
 
 from charms.juju_dashboard.v0.juju_dashboard import JujuDashData, JujuDashReq
 from charms.nginx_ingress_integrator.v0.nginx_route import require_nginx_route
-from charms.traefik_k8s.v2.ingress import IngressPerAppRequirer
-from config import Config, to_bool
-
+from charms.traefik_k8s.v2.ingress import (
+    IngressPerAppReadyEvent,
+    IngressPerAppRequirer,
+    IngressPerAppRevokedEvent,
+)
 from ops.charm import CharmBase, RelationEvent
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
+
+from config import Config, to_bool
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +72,8 @@ class JujuDashboardKubernetesCharm(CharmBase):
             service_port=self.config.get("port"),
         )
         self.ingress = IngressPerAppRequirer(self, port=self.config.get("port"))
+        self.framework.observe(self.ingress.on.ready, self._on_ingress_ready)
+        self.framework.observe(self.ingress.on.revoked, self._on_ingress_revoked)
 
     def _on_install(self, _):
         self.unit.status = MaintenanceStatus("Awaiting controller relation.")
@@ -88,8 +95,7 @@ class JujuDashboardKubernetesCharm(CharmBase):
 
         self._update(event, **requires.data)
 
-    def _on_config_changed(self, event):
-        self.ingress.provide_ingress_requirements(port=self.config.get("port"))
+    def _update_using_relation(self, event):
         relation = self.model.get_relation("controller")
         if not relation:
             self.unit.status = BlockedStatus("Missing controller integration")
@@ -98,9 +104,28 @@ class JujuDashboardKubernetesCharm(CharmBase):
         data = JujuDashData(relation.data[relation.app])
         self._update(event, **data)
 
+    def _on_config_changed(self, event):
+        self.ingress.provide_ingress_requirements(port=self.config.get("port"))
+        self._update_using_relation(event)
+
+    def _on_ingress_ready(self, event: IngressPerAppReadyEvent):
+        self._update_using_relation(event)
+
+    def _on_ingress_revoked(self, event: IngressPerAppRevokedEvent):
+        self._update_using_relation(event)
+
     def _update(self, event, controller_url, identity_provider_url, is_juju):
+        base_app_url: str | None = None
+        if self.ingress is not None and self.ingress.url is not None:
+            base_app_url = urlsplit(self.ingress.url).path
+        config_dir = Path(__file__).parent.resolve()
+        container = self.unit.get_container("dashboard")
+        template = container.pull("/srv/index.charm.html").read()
+        local_template = config_dir / "index.charm.html"
+        local_template.write_text(template)
         config = Config(
-            config_dir=str(Path(__file__).parent.resolve()),
+            base_app_url="" if base_app_url is None else base_app_url,
+            config_dir=str(config_dir),
             controller_url=controller_url,
             identity_provider_url=identity_provider_url,
             is_juju=to_bool(is_juju),
@@ -108,18 +133,17 @@ class JujuDashboardKubernetesCharm(CharmBase):
             dashboard_root="/srv",
             port=self.config.get("port"),
         )
-        dashboard_config, nginx_config = config.generate()
-        container = self.unit.get_container("dashboard")
+        dashboard_config, nginx_config, index_html = config.generate()
         if not container.can_connect():
             event.defer()
             self.unit.status = MaintenanceStatus("Waiting for container.")
             return
 
-        self._configure(container, dashboard_config, nginx_config)
+        self._configure(container, dashboard_config, nginx_config, index_html)
 
         self.unit.status = ActiveStatus()
 
-    def _configure(self, container, dashboard_config, nginx_config):
+    def _configure(self, container, dashboard_config, nginx_config, index_html):
         """
         Add and configure our pebble layer.
 
@@ -142,6 +166,7 @@ class JujuDashboardKubernetesCharm(CharmBase):
         container.add_layer("dashboard", pebble_layer, combine=True)
 
         container.push("/srv/config.js", dashboard_config)
+        container.push("/srv/index.html", index_html)
         container.push("/etc/nginx/sites-available/default", nginx_config)
 
         container.replan()

--- a/charms/k8s-charm/src/config.py
+++ b/charms/k8s-charm/src/config.py
@@ -1,8 +1,8 @@
 import logging
 import os
 from pathlib import Path
-from jinja2 import Environment, FileSystemLoader
 
+from jinja2 import Environment, FileSystemLoader
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +23,7 @@ class Config:
         dashboard_root: str,
         analytics_enabled: bool,
         port: int,
+        base_app_url: str | None = None,
         config_file_name: str | None = None,
         has_external_controller_url=False,
     ):
@@ -35,19 +36,20 @@ class Config:
         self._analytics_enabled = analytics_enabled
         self._port = port
         self._has_external_controller_url = has_external_controller_url
+        self._base_app_url = base_app_url
 
     def generate(self):
         env = Environment(loader=FileSystemLoader(self._config_dir))
         env.filters["bool"] = to_bool
         config_template = env.get_template("config.js.j2")
-        base_url = (
-            ""
+        controller_base_url = (
+            self._base_app_url
             if self._is_juju and not self._has_external_controller_url
             else self._controller_url
         )
         config = config_template.render(
-            base_app_url="/",
-            controller_api_endpoint=f"{base_url}/api",
+            base_app_url=self._base_app_url,
+            controller_api_endpoint=f"{controller_base_url}/api",
             identity_provider_url=self._identity_provider_url or "",
             is_juju=self._is_juju,
             analytics_enabled=self._analytics_enabled,
@@ -58,20 +60,33 @@ class Config:
         if not controller_url.startswith("https://"):
             controller_url = "https://{}".format(controller_url)
         nginx_config = nginx_template.render(
+            base_app_url=self._base_app_url,
             controller_ws_api=controller_url,
             dashboard_root=self._dashboard_root,
             port=self._port,
             is_juju=self._is_juju,
         )
-        return config, nginx_config
+        index_template = env.get_template("index.charm.html")
+        base_app_url = (
+            self._base_app_url
+            if self._base_app_url is None or self._base_app_url.endswith("/")
+            else f"{self._base_app_url}/"
+        )
+        index_html = index_template.render(
+            base_app_url=base_app_url,
+        )
+        return config, nginx_config, index_html
 
-    def write(self, write_config_js=True, write_nginx=True):
-        dashboard_config, nginx_config = self.generate()
+    def write(self, write_config_js=True, write_nginx=True, write_index=True):
+        dashboard_config, nginx_config, index_html = self.generate()
         if write_config_js:
             config_path = Path(self._dashboard_root) / (
                 self._config_file_name or "config.js"
             )
             config_path.write_text(dashboard_config)
+        if write_index:
+            config_path = Path(self._dashboard_root) / "index.html"
+            config_path.write_text(index_html)
         if write_nginx:
             nginx_path = Path("/etc/nginx/sites-available/default")
             nginx_path.write_text(nginx_config)
@@ -105,4 +120,5 @@ if __name__ == "__main__":
         config.write(
             write_config_js=to_bool(os.environ.get("WRITE_CONFIG_JS", True)),
             write_nginx=to_bool(os.environ.get("WRITE_NGINX", True)),
+            write_index=to_bool(os.environ.get("WRITE_INDEX", True)),
         )

--- a/charms/k8s-charm/src/nginx.conf.j2
+++ b/charms/k8s-charm/src/nginx.conf.j2
@@ -12,20 +12,27 @@ server {
 
     server_name _;
 
-    location / {
+{% if base_app_url != "" %}
+    location {{base_app_url}} {
+        try_files /index.html =404;
+    }
+{% endif %}
+
+    location {{base_app_url}}/ {
         try_files /index.html =404;
     }
 
-    location /config.js {
+    location {{base_app_url}}/config.js {
         try_files /config.js =404;
     }
 
-    location /assets {
-        try_files $uri =404; 
+    location ~ ^{{base_app_url|replace("/", "\/")}}(\/assets\/.+$) {
+        try_files $1 =404;
     }
 
 {% if is_juju %}
-    location ~ /api$ {
+    location ~ ^{{base_app_url|replace("/", "\/")}}((\/.+)?\/api$) {
+        rewrite ^{{base_app_url|replace("/", "\/")}}((\/.+)?\/api$) $1 break;
         proxy_pass {{controller_ws_api}};
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
@@ -33,7 +40,8 @@ server {
         proxy_set_header Host $host;
     }
 
-    location ~ /commands$ {
+    location ~ ^{{base_app_url|replace("/", "\/")}}((\/.+)?\/commands$) {
+        rewrite ^{{base_app_url|replace("/", "\/")}}((\/.+)?\/commands$) $1 break;
         proxy_pass {{controller_ws_api}};
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;

--- a/charms/k8s-charm/tests/test_charm.py
+++ b/charms/k8s-charm/tests/test_charm.py
@@ -4,7 +4,7 @@
 # Learn more about testing at: https://juju.is/docs/sdk/testing
 
 import unittest
-from unittest.mock import patch
+from unittest.mock import PropertyMock, patch
 
 from ops.model import ActiveStatus, BlockedStatus
 from ops.testing import Harness
@@ -20,6 +20,7 @@ class TestCharm(unittest.TestCase):
         self.harness.set_can_connect("dashboard", True)
         self.container = self.harness.model.unit.get_container("dashboard")
         self.container.make_dir("/srv")
+        self.container.push("/srv/index.charm.html", '<base href="{{base_app_url}}" />')
         self.container.make_dir("/etc/nginx/sites-available/", make_parents=True)
         self.rel_id = self.harness.add_relation("controller", "controller")
         self.harness.add_relation_unit(self.rel_id, "controller/0")
@@ -57,15 +58,24 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch(
+        "charms.traefik_k8s.v2.ingress.IngressPerAppRequirer.url",
+        new_callable=PropertyMock,
+    )
+    @patch(
         "charms.traefik_k8s.v2.ingress.IngressPerAppRequirer.provide_ingress_requirements"
     )
-    def test_config_changed(self, mock_provide_ingress_requirements):
+    def test_config_changed(self, mock_provide_ingress_requirements, mock_url):
+        mock_url.return_value = None
         with self.container.pull("/srv/config.js") as f:
             config = f.read()
         self.assertTrue("analyticsEnabled: true" in config)
         with self.container.pull("/etc/nginx/sites-available/default") as f:
             nginx_config = f.read()
         self.assertTrue("listen 8080" in nginx_config)
+        with self.container.pull("/srv/index.html") as f:
+            index_html = f.read()
+        self.assertTrue('<base href="/" />' in index_html)
+        mock_url.return_value = "/dashboard"
         self.harness.update_config({"analytics-enabled": False, "port": 123})
         with self.container.pull("/srv/config.js") as f:
             config = f.read()
@@ -73,6 +83,9 @@ class TestCharm(unittest.TestCase):
         with self.container.pull("/etc/nginx/sites-available/default") as f:
             nginx_config = f.read()
         self.assertTrue("listen 123" in nginx_config)
+        with self.container.pull("/srv/index.html") as f:
+            index_html = f.read()
+        self.assertTrue('<base href="/dashboard/" />' in index_html)
         mock_provide_ingress_requirements.assert_called_once_with(port=123)
 
     def test_config_changed_no_relation(self):

--- a/index.charm.html
+++ b/index.charm.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <base href="{{base_app_url}}" />
+    <meta charset="utf-8" />
+    <link rel="shortcut icon" href="favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#E9531F" />
+
+    <!--
+      manifest.json provides metadata used when your web app is installed on a
+      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
+    -->
+    <link rel="manifest" href="manifest.json" />
+    <link rel="apple-touch-icon" href="app-icon.png" />
+    <script src="config.js"></script>
+    <title>Juju Dashboard</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+    <script type="module" src="src/index.tsx"></script>
+  </body>
+</html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,7 @@ import tsconfigPaths from "vite-tsconfig-paths";
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
   return {
+    base: "./",
     build: {
       outDir: "build",
     },
@@ -37,11 +38,21 @@ export default defineConfig(({ mode }) => {
         ? null
         : // The template format is handled by the dev and jaas configs when in development.
           createHtmlPlugin({
-            inject: {
-              data: {
-                injectScript: "",
+            pages: [
+              {
+                filename: "index.html",
+                template: "index.html",
+                injectOptions: {
+                  data: {
+                    injectScript: "",
+                  },
+                },
               },
-            },
+              {
+                filename: "index.charm.html",
+                template: "index.charm.html",
+              },
+            ],
           }),
       {
         // Remove config files that are used for development.


### PR DESCRIPTION
## Done

Add support for serving the dashboard with a base path to the k8s charm

## QA

Create a multipass with microk8s and docker:
```
multipass launch --cpus 2 --disk 35G --memory 8G --name juju-k8s-local --timeout 1800 --cloud-init https://raw.githubusercontent.com/canonical/juju-dashboard/refs/heads/main/scripts/cloud-init-juju-microk8s-local.yaml
multipass shell juju-k8s-local
sudo microk8s enable ingress
sudo snap install docker
sudo addgroup --system docker
sudo adduser $USER docker
sudo snap disable docker
sudo snap enable docker
# Exit and then shell back into your container
```

Offer the dashboard relation to the controller:
```
juju switch controller
juju offer controller:dashboard
```

Create a model to host the dashboard and traefik:
```
juju add-model juju-dashboard
# if using mac:
# juju set-model-constraints arch=arm64
juju deploy traefik-k8s traefik --trust --channel=latest/beta
juju status
juju config traefik external_hostname=<ip of traefik/0>
```

Check out this branch, build the charm and deploy the dashboard:
```
cd ~/juju-dashboard/
git fetch https://github.com/huwshimi/juju-dashboard.git traefik-path:traefik-path
git checkout traefik-path
cd ~/juju-dashboard/charms/k8s-charm
# use arm64 on mac
./build.sh source '' "--platform ubuntu@24.04:amd64"
docker image save dashboard-image:local | microk8s ctr image import -
juju deploy --resource dashboard-image=dashboard-image:local ./juju-dashboard*.charm dashboard
```

Wait for the charm to be blocked on the controller relation, then:
```
juju integrate admin/controller.controller dashboard
juju integrate traefik dashboard
```

Get the ip of the multipass container and create a port forward to the ingress (using):
```
sudo microk8s.kubectl port-forward traefik-0 8080:80 --namespace=juju-dashboard --address=<multipass ip>
```

Get the path of the dashboard:
```
juju run traefik/0 show-proxied-endpoints
```

From your host you should now be able to access the dashboard using the ip of the multipass, the port from the port-forward and the dashboard's path from above e.g. http://1.2.3.4:8080/juju-dashboard-dashboard/models

## Details

https://warthogs.atlassian.net/browse/JUJU-9673
