### PR TITLE
fix: add missing window titles

### DIFF
--- a/src/pages/AddModel/AddModel.tsx
+++ b/src/pages/AddModel/AddModel.tsx
@@ -9,6 +9,7 @@ import * as Yup from "yup";
 import CheckPermissions from "components/CheckPermissions";
 import FormikFormData from "components/FormikFormData";
 import { useCanAddModel } from "hooks/useCanAddModel";
+import useWindowTitle from "hooks/useWindowTitle";
 import { getActiveUserTag, getWSControllerURL } from "store/general/selectors";
 import { actions as jujuActions } from "store/juju";
 import { getAddModelState } from "store/juju/selectors";
@@ -89,6 +90,7 @@ const AddModel: FC = () => {
   const [currentStepIndex, setCurrentStepIndex] = useState(0);
   const [isValid, setIsValid] = useState<boolean>(false);
   const [modelName, setModelName] = useState<string>("");
+  useWindowTitle(Label.TITLE);
 
   const handleCancel = (): void => {
     void navigate(urls.models.index);

--- a/src/pages/AdvancedSearch/AdvancedSearch.tsx
+++ b/src/pages/AdvancedSearch/AdvancedSearch.tsx
@@ -1,6 +1,7 @@
 import type { JSX } from "react";
 
 import CheckPermissions from "components/CheckPermissions";
+import useWindowTitle from "hooks/useWindowTitle";
 import MainContent from "layout/MainContent";
 import { isCrossModelQueriesEnabled } from "store/general/selectors";
 import { useAppSelector } from "store/store";
@@ -13,6 +14,7 @@ import { Label, TestId } from "./types";
 
 const AdvancedSearch = (): JSX.Element => {
   const crossModelQueriesEnabled = useAppSelector(isCrossModelQueriesEnabled);
+  useWindowTitle(Label.TITLE);
   return (
     <CheckPermissions
       allowed={crossModelQueriesEnabled}

--- a/src/pages/Logs/Logs.tsx
+++ b/src/pages/Logs/Logs.tsx
@@ -4,6 +4,7 @@ import ActionBar from "components/ActionBar";
 import AuditLogsTable from "components/AuditLogsTable/AuditLogsTable";
 import AuditLogsTableActions from "components/AuditLogsTable/AuditLogsTableActions";
 import CheckPermissions from "components/CheckPermissions";
+import useWindowTitle from "hooks/useWindowTitle";
 import { useAuditLogsPermitted } from "juju/api-hooks/permissions";
 import MainContent from "layout/MainContent";
 import { testId } from "testing/utils";
@@ -12,6 +13,7 @@ import { Label, TestId } from "./types";
 
 const Logs = (): JSX.Element => {
   const { loading, permitted } = useAuditLogsPermitted();
+  useWindowTitle(Label.TITLE);
   return (
     <CheckPermissions
       allowed={permitted}

--- a/src/pages/Permissions/Permissions.tsx
+++ b/src/pages/Permissions/Permissions.tsx
@@ -8,6 +8,7 @@ import { axiosInstance } from "axios-instance";
 import CheckPermissions from "components/CheckPermissions";
 import useCanAccessReBACAdmin from "hooks/useCanAccessReBACAdmin";
 import useLogout from "hooks/useLogout";
+import useWindowTitle from "hooks/useWindowTitle";
 import { useIsJIMMAdmin } from "juju/api-hooks/permissions";
 import { endpoints } from "juju/jimm/api";
 import MainContent from "layout/MainContent";
@@ -43,6 +44,7 @@ const PermissionsPage = (): JSX.Element => {
   const logout = useLogout();
   const { loading } = useIsJIMMAdmin();
   const rebacAllowed = useCanAccessReBACAdmin();
+  useWindowTitle("Manage permissions");
 
   useRef(
     axiosInstance.interceptors.response.use(


### PR DESCRIPTION
## Done

- Added window titles to pages where they were missing (e.g. the add model form).

## QA

- Go to the add model form and the window title should be "Add model"
- Refresh the page and the window title should show "Add model" again (previously refreshing it would show "404").

