### PR TITLE
fix: serialise errors to strings before dispatching

### DIFF
--- a/src/data/source.ts
+++ b/src/data/source.ts
@@ -49,7 +49,7 @@ export type Source<T> = {
     /**
      * Underlying error object.
      */
-    source: unknown;
+    source: Error;
   } | null;
   /**
    * Callback subscription for source events.
@@ -81,7 +81,7 @@ export type Source<T> = {
  */
 export type Events<T> = {
   data: [data: T];
-  error: [message: string, source: unknown];
+  error: [message: string, source: Error];
   errorCleared: [];
   load: [result: Promise<T>];
   loadEnd: [];

--- a/src/data/sourceBase.test.ts
+++ b/src/data/sourceBase.test.ts
@@ -287,29 +287,24 @@ describe("createSource", () => {
       });
 
       describe("when `data` promise rejects", () => {
-        it.for([
-          ["an `Error`", new Error("Something happened"), "Something happened"],
-          ["a non-`Error`", 374, "An unknown error occurred"],
-        ] as const)(
-          "handles %s",
-          async ([_, error, expectedMessage], { expect }) => {
-            const dataPromise = Promise.withResolvers();
+        it("an `Error`", async () => {
+          const error = new Error("Something happened");
+          const dataPromise = Promise.withResolvers();
 
-            const source = createSource(({ load }) => {
-              load(dataPromise.promise);
-              return DUMMY_HOOKS;
-            });
+          const source = createSource(({ load }) => {
+            load(dataPromise.promise);
+            return DUMMY_HOOKS;
+          });
 
-            expect(source.loading).toEqual(true);
-            dataPromise.reject(error);
-            await tick();
+          expect(source.loading).toEqual(true);
+          dataPromise.reject(error);
+          await tick();
 
-            expect(source.loading).toEqual(false);
-            expect(source.state).toEqual(SourceState.Error);
-            expect(source.error?.source).toEqual(error);
-            expect(source.error?.message).toEqual(expectedMessage);
-          },
-        );
+          expect(source.loading).toEqual(false);
+          expect(source.state).toEqual(SourceState.Error);
+          expect(source.error?.source).toEqual(error);
+          expect(source.error?.message).toEqual("Something happened");
+        });
 
         it("clears error after next successful load", async () => {
           const dataPromises = new Array(2)

--- a/src/data/sourceBase.ts
+++ b/src/data/sourceBase.ts
@@ -215,7 +215,7 @@ export function createSource<T>(
   /**
    * Helper to correctly format an error.
    */
-  function handleError(error: unknown): NonNullable<Source<unknown>["error"]> {
+  function handleError(error: Error): NonNullable<Source<unknown>["error"]> {
     // Extract the message of the error.
     let message = "An unknown error occurred";
     if (error instanceof Error) {
@@ -274,7 +274,7 @@ export function createSource<T>(
 
           modifySource(loadId, {
             loading: false,
-            error: handleError(error),
+            error: error instanceof Error ? handleError(error) : null,
             state: SourceState.Error,
           });
 
@@ -294,7 +294,7 @@ export function createSource<T>(
   } catch (error) {
     // Handle an error that occurs during setup.
     modifySource(Infinity, {
-      error: handleError(error),
+      error: error instanceof Error ? handleError(error) : null,
       state: SourceState.Error,
       loading: false,
     });

--- a/src/store/juju/reducers.test.ts
+++ b/src/store/juju/reducers.test.ts
@@ -1766,7 +1766,7 @@ describe("reducers", () => {
             update: {
               error: {
                 message: "Something",
-                source: new Error("Something"),
+                source: "Something",
               },
             },
           }),
@@ -1775,7 +1775,7 @@ describe("reducers", () => {
           data: [],
           error: {
             message: "Something",
-            source: new Error("Something"),
+            source: "Something",
           },
           loading: false,
         });
@@ -1845,7 +1845,7 @@ describe("reducers", () => {
             update: {
               error: {
                 message: "Something",
-                source: new Error("Something"),
+                source: "Something",
               },
             },
           }),
@@ -1855,7 +1855,7 @@ describe("reducers", () => {
             data: [],
             error: {
               message: "Something",
-              source: new Error("Something"),
+              source: "Something",
             },
             loading: false,
           },
@@ -1941,7 +1941,7 @@ describe("reducers", () => {
             update: {
               error: {
                 message: "Something went wrong",
-                source: new Error("Something went wrong"),
+                source: "Something went wrong",
               },
             },
           }),
@@ -1950,7 +1950,7 @@ describe("reducers", () => {
           credentials: {},
           errors: {
             message: "Something went wrong",
-            source: new Error("Something went wrong"),
+            source: "Something went wrong",
           },
           loading: false,
         });
@@ -2044,7 +2044,7 @@ describe("reducers", () => {
             update: {
               error: {
                 message: "Something went wrong",
-                source: new Error("Something went wrong"),
+                source: "Something went wrong",
               },
             },
           }),
@@ -2053,7 +2053,7 @@ describe("reducers", () => {
           clouds: null,
           errors: {
             message: "Something went wrong",
-            source: new Error("Something went wrong"),
+            source: "Something went wrong",
           },
           loading: false,
         });

--- a/src/store/juju/types.ts
+++ b/src/store/juju/types.ts
@@ -27,7 +27,12 @@ import type { AccessLevel } from "types";
 /**
  * Data derived from a `Source`.
  */
-export type SourceData<T> = Pick<Source<T>, "data" | "error" | "loading">;
+export type SourceData<T> = {
+  error: {
+    source: null | string;
+    message: string;
+  } | null;
+} & Pick<Source<T>, "data" | "loading">;
 
 export type ControllerLocation = {
   cloud?: string;

--- a/src/store/middleware/source-middleware.ts
+++ b/src/store/middleware/source-middleware.ts
@@ -85,7 +85,7 @@ export function createSourceMiddleware<T, P>(
     setLoading: (args: P, loading: boolean) => PayloadAction<unknown>;
     setError: (
       args: P,
-      error: { message: string; source: unknown } | null,
+      error: { message: string; source: Error } | null,
     ) => PayloadAction<unknown>;
   },
   hooks?: {

--- a/src/store/middleware/source/cloud-info.ts
+++ b/src/store/middleware/source/cloud-info.ts
@@ -3,6 +3,7 @@ import type { CloudsResult } from "@canonical/jujulib/dist/api/facades/cloud/Clo
 import { createPollingSource } from "data/pollingSource";
 import type { ConnectionWithFacades } from "juju/types";
 import { actions as jujuActions } from "store/juju";
+import { toSerializableSourceError } from "store/util";
 
 import { hasConnections } from "../connection/util";
 import { createSourceMiddleware } from "../source-middleware";
@@ -46,7 +47,10 @@ export default createSourceMiddleware<
       jujuActions.updateCloudInfo({
         update: { data },
       }),
-    setError: (_, error) => jujuActions.updateCloudInfo({ update: { error } }),
+    setError: (_, error) =>
+      jujuActions.updateCloudInfo({
+        update: { error: toSerializableSourceError(error) },
+      }),
     setLoading: (_, loading) =>
       jujuActions.updateCloudInfo({
         update: { loading },

--- a/src/store/middleware/source/jimm-supported-versions.ts
+++ b/src/store/middleware/source/jimm-supported-versions.ts
@@ -6,6 +6,7 @@ import type {
 import { supportedJujuVersions } from "juju/jimm/api";
 import type { ConnectionWithFacades } from "juju/types";
 import { actions as jujuActions } from "store/juju";
+import { toSerializableSourceError } from "store/util";
 
 import { hasConnections } from "../connection/util";
 import { createSourceMiddleware } from "../source-middleware";
@@ -42,7 +43,7 @@ export default createSourceMiddleware<
     setError: ({ wsControllerURL }, error) =>
       jujuActions.updateSupportedJujuVersions({
         wsControllerURL,
-        update: { error },
+        update: { error: toSerializableSourceError(error) },
       }),
     setLoading: ({ wsControllerURL }, loading) => {
       return jujuActions.updateSupportedJujuVersions({

--- a/src/store/middleware/source/migration-targets.ts
+++ b/src/store/middleware/source/migration-targets.ts
@@ -2,6 +2,7 @@ import { createPollingSource } from "data/pollingSource";
 import { listMigrationTargets } from "juju/jimm/api";
 import type { ConnectionWithFacades } from "juju/types";
 import { actions as jujuActions } from "store/juju";
+import { toSerializableSourceError } from "store/util";
 
 import { hasConnections } from "../connection/util";
 import { createSourceMiddleware } from "../source-middleware";
@@ -43,7 +44,10 @@ export default createSourceMiddleware<
         update: { data },
       }),
     setError: ({ modelUUID }, error) =>
-      jujuActions.updateModelMigrationTargets({ modelUUID, update: { error } }),
+      jujuActions.updateModelMigrationTargets({
+        modelUUID,
+        update: { error: toSerializableSourceError(error) },
+      }),
     setLoading: ({ modelUUID }, loading) =>
       jujuActions.updateModelMigrationTargets({
         modelUUID,

--- a/src/store/middleware/source/user-credentials.ts
+++ b/src/store/middleware/source/user-credentials.ts
@@ -1,6 +1,7 @@
 import { createPollingSource } from "data/pollingSource";
 import type { ConnectionWithFacades } from "juju/types";
 import { actions as jujuActions } from "store/juju";
+import { toSerializableSourceError } from "store/util";
 
 import { hasConnections } from "../connection/util";
 import { createSourceMiddleware } from "../source-middleware";
@@ -55,7 +56,10 @@ export default createSourceMiddleware<
         update: { data: { [cloudTag]: data } },
       }),
     setError: ({ cloudTag }, error) =>
-      jujuActions.updateUserCredentials({ cloudTag, update: { error } }),
+      jujuActions.updateUserCredentials({
+        cloudTag,
+        update: { error: toSerializableSourceError(error) },
+      }),
     setLoading: ({ cloudTag }, loading) =>
       jujuActions.updateUserCredentials({
         cloudTag,

--- a/src/store/util.test.ts
+++ b/src/store/util.test.ts
@@ -1,0 +1,19 @@
+import { toSerializableSourceError } from "./util";
+
+describe("toSerializableSourceError", () => {
+  it("handles a null error", () => {
+    expect(toSerializableSourceError(null)).toBeNull();
+  });
+
+  it("handles Error", () => {
+    expect(
+      toSerializableSourceError({
+        source: new Error("Uh oh!"),
+        message: "This is an error",
+      }),
+    ).toStrictEqual({
+      source: "Uh oh!",
+      message: "This is an error",
+    });
+  });
+});

--- a/src/store/util.ts
+++ b/src/store/util.ts
@@ -1,7 +1,9 @@
 import type { PayloadAction, PayloadActionCreator } from "@reduxjs/toolkit";
 
+import type { Source } from "data";
 import type { ConnectionWithFacades } from "juju/types";
 import { isMetaAction } from "types";
+import { toErrorString } from "utils";
 
 import { hasConnections } from "./middleware/connection/util";
 
@@ -24,3 +26,18 @@ export function actionWithConnections<P, T extends string, K extends string>(
     hasConnections(action.meta, connectionKeys)
   );
 }
+
+/**
+ * Convert a source error to a serializable value.
+ */
+export const toSerializableSourceError = (
+  error: Source<unknown>["error"],
+): { message: string; source: string } | null => {
+  if (!error) {
+    return error;
+  }
+  return {
+    message: error.message,
+    source: toErrorString(error.source),
+  };
+};


### PR DESCRIPTION
## Done

- This fixes an issue where source error dispatches included `Error` objects which produced another error about not being serialisable (`A non-serializable value was detected in the state...`).

## QA

This is how I reproduced an error from the middleware:
- In config.local.js set `controllerAPIEndpoint: "wss://localhost:17070/api",`
- Create a portforward to expose your controller API on localhost e.g. `ssh -L :17070:0.0.0.0:17070 ubuntu@juju-lxd-local.local`.
- Open the dashboard, log in and go to the models list.
- Stop the portforward.
- Within 30 seconds you should have some logging errors about the websocket being closed/can't send requests but there shouldn't be any errors about non-serialisable values.

