### PR TITLE
fix: add model footer on small screens

### DIFF
--- a/src/pages/AddModel/AddModel.tsx
+++ b/src/pages/AddModel/AddModel.tsx
@@ -156,7 +156,7 @@ const AddModel: FC = () => {
     <CheckPermissions allowed={canCreateModel} {...testId(TestId.COMPONENT)}>
       <VanillaPanel
         className="add-model"
-        contentClassName="add-model__content"
+        contentClassName="add-model__content u-no-padding"
         title={Label.TITLE}
         {...testId(TestId.COMPONENT)}
         stickyHeader
@@ -205,7 +205,7 @@ const AddModel: FC = () => {
           <Button
             onClick={handleCancel}
             appearance="base"
-            className="u-no-margin--right"
+            className="u-no-margin"
           >
             {Label.CANCEL_BUTTON}
           </Button>
@@ -216,6 +216,7 @@ const AddModel: FC = () => {
               }}
               appearance="secondary"
               disabled={isFirstStep}
+              className="u-no-margin--bottom"
             >
               {Label.BACK_BUTTON}
             </Button>
@@ -224,6 +225,7 @@ const AddModel: FC = () => {
               type="button"
               onClick={handleNextClick}
               disabled={isLastStep}
+              className="u-no-margin--bottom"
             >
               {Label.NEXT_BUTTON}
             </Button>
@@ -233,6 +235,7 @@ const AddModel: FC = () => {
             type="submit"
             form={currentStep.key}
             disabled={!isValid}
+            className="u-no-margin--bottom"
           >
             {Label.CREATE_BUTTON}
           </ActionButton>

--- a/src/pages/AddModel/_add-model.scss
+++ b/src/pages/AddModel/_add-model.scss
@@ -1,8 +1,9 @@
 .add-model {
+  bottom: 0;
   display: flex;
   flex-direction: column;
-  height: 100svh;
   position: fixed;
+  top: 0;
   width: -webkit-fill-available;
   width: stretch;
 
@@ -11,12 +12,14 @@
     flex: 1 1 auto;
     flex-direction: column;
     min-height: 0;
-    overflow-y: auto;
-    padding: 0 $sph--large;
+    overflow: hidden;
   }
 
   &__step {
-    flex: 1 0 auto;
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+    padding: 0 $sph--large;
 
     .stepper-horizontal {
       margin-bottom: $spv--large;
@@ -30,20 +33,27 @@
   }
 
   &__footer {
+    align-items: flex-end;
     background-color: white;
     border-top: 1px solid $color-mid-x-light;
-    bottom: 0;
-    padding: $spv--large $sph--small 0;
-    position: sticky;
-    text-align: right;
+    box-shadow: $box-shadow;
+    display: flex;
+    flex-shrink: 0;
+    justify-content: end;
+    padding: $spv--large;
     // To ensure the footer appears above StackList items.
     z-index: z("gamma");
 
     .navigation-buttons {
       border-left: 1px solid $color-mid-light;
       border-right: 1px solid $color-mid-light;
+      display: flex;
       margin-right: $sph--large;
-      padding: $spv--small $sph--large;
+      padding: 0 $sph--large;
+
+      @include mobile {
+        padding: 0;
+      }
     }
 
     @include mobile {


### PR DESCRIPTION
## Done

- Fixed overflowing footer on small screens
- Updated the footer styles to match figma (full width with box shadow)

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- View the add model page footer on various screen sizes
- It should always be visible

## Details

Fixes https://github.com/canonical/juju-dashboard/issues/2348
Fixes https://warthogs.atlassian.net/browse/JUJU-10009

## Screenshots

BEFORE
<img width="302" height="73" alt="Screenshot 2026-06-16 at 4 17 26 PM" src="https://github.com/user-attachments/assets/4b2ec845-f3a1-4546-ba6f-413298c7fbcb" />


AFTER
<img width="303" height="68" alt="Screenshot 2026-06-16 at 4 17 48 PM" src="https://github.com/user-attachments/assets/f769ffda-81a2-434f-b685-4e8c97d8a673" />
