### PR TITLE
chore: update args for charmcraft create-track

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,7 +150,7 @@ jobs:
 
           if [ "$matching_track" = '' ]; then
             echo "Creating '$track' track for '$charm_name'"
-            CHARMCRAFT_AUTH='${{ secrets.CHARMHUB_TOKEN }}' charmcraft create-track "$charm_name" "$track"
+            CHARMCRAFT_AUTH='${{ secrets.CHARMHUB_TOKEN }}' charmcraft create-track --name="$charm_name" --track="$track"
           else
             echo "'$track' track for '$charm_name' already created. Continuing..."
           fi


### PR DESCRIPTION
## Done

- Updated `charmcraft create-track` to include named arguments for `--name` and `--track`
- Without this, the following error is thrown in the release job:
```
Error: the following arguments are required: --name, --track
```
Find the failing job [here](https://github.com/canonical/juju-dashboard/actions/runs/28163984459/job/83587617443) 
