### PR TITLE
fix(e2e): pack single charm for e2e tests

### DIFF
--- a/.github/actions/setup-k8s-charm/action.yml
+++ b/.github/actions/setup-k8s-charm/action.yml
@@ -54,6 +54,7 @@ runs:
         "${{ github.workspace }}/charms/k8s-charm/build.sh" \
           "${{ env.build_type }}" \
           "${{ inputs.dashboard-resource }}" \
+          "--platform ubuntu@24.04:amd64" \
           >> "$GITHUB_OUTPUT"
     - name: Import dashboard image to microK8s
       if: ${{ env.build_type == 'source' }}

--- a/.github/actions/setup-machine-charm/action.yml
+++ b/.github/actions/setup-machine-charm/action.yml
@@ -52,7 +52,8 @@ runs:
       run: |
         "${{ github.workspace }}/charms/machine-charm/build.sh" \
           "${{ env.build_type }}" \
-          "${{ inputs.dashboard-version }}"
+          "${{ inputs.dashboard-version }}" \
+          "--platform ubuntu@24.04:amd64"
     - name: Switch to controller
       run: juju switch '${{ inputs.controller-model }}'
       shell: bash

--- a/charms/k8s-charm/build.sh
+++ b/charms/k8s-charm/build.sh
@@ -7,6 +7,7 @@ ROOT_DIR="$SCRIPT_PATH/../../"
 
 BUILD_TYPE="${1:-source}"
 DASHBOARD_RESOURCE="${2:-}"
+PACK_ARGS="${3:-}"
 
 DASHBOARD_IMAGE_ID=""
 
@@ -55,7 +56,7 @@ ATTEMPT=1
 SUCCESS=false
 
 while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
-    if (cd "$SCRIPT_PATH" && charmcraft pack); then
+    if (cd "$SCRIPT_PATH" && charmcraft pack $PACK_ARGS); then
         SUCCESS=true
         break # Success, exit retry loop
     else

--- a/charms/k8s-charm/build.sh
+++ b/charms/k8s-charm/build.sh
@@ -7,7 +7,7 @@ ROOT_DIR="$SCRIPT_PATH/../../"
 
 BUILD_TYPE="${1:-source}"
 DASHBOARD_RESOURCE="${2:-}"
-PACK_ARGS="${3:-}"
+IFS=' ' read -r -a PACK_ARGS <<< "${3:-}"
 
 DASHBOARD_IMAGE_ID=""
 
@@ -56,7 +56,7 @@ ATTEMPT=1
 SUCCESS=false
 
 while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
-    if (cd "$SCRIPT_PATH" && charmcraft pack $PACK_ARGS); then
+    if (cd "$SCRIPT_PATH" && charmcraft pack "${PACK_ARGS[@]}"); then
         SUCCESS=true
         break # Success, exit retry loop
     else

--- a/charms/machine-charm/build.sh
+++ b/charms/machine-charm/build.sh
@@ -9,6 +9,7 @@ CHARM_DIST_PATH="$SCRIPT_PATH/src/dist"
 
 BUILD_TYPE="${1:-source}"
 DASHBOARD_VERSION="${2:-}"
+PACK_ARGS="${3:-}"
 
 # 1. Build or reuse the Juju Dashboard assets
 mkdir -p "$CHARM_DIST_PATH"
@@ -68,7 +69,7 @@ ATTEMPT=1
 SUCCESS=false
 
 while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
-    if (cd "$SCRIPT_PATH" && charmcraft pack); then
+    if (cd "$SCRIPT_PATH" && charmcraft pack $PACK_ARGS); then
         SUCCESS=true
         break # Success, exit retry loop
     else

--- a/charms/machine-charm/build.sh
+++ b/charms/machine-charm/build.sh
@@ -9,7 +9,7 @@ CHARM_DIST_PATH="$SCRIPT_PATH/src/dist"
 
 BUILD_TYPE="${1:-source}"
 DASHBOARD_VERSION="${2:-}"
-PACK_ARGS="${3:-}"
+IFS=' ' read -r -a PACK_ARGS <<< "${3:-}"
 
 # 1. Build or reuse the Juju Dashboard assets
 mkdir -p "$CHARM_DIST_PATH"
@@ -69,7 +69,7 @@ ATTEMPT=1
 SUCCESS=false
 
 while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
-    if (cd "$SCRIPT_PATH" && charmcraft pack $PACK_ARGS); then
+    if (cd "$SCRIPT_PATH" && charmcraft pack "${PACK_ARGS[@]}"); then
         SUCCESS=true
         break # Success, exit retry loop
     else


### PR DESCRIPTION
## Done

- Updated `build.sh` to accept an optional third argument that is passed directly to `charmcraft pack`
- Updated the charm setup actions to pass `--platform ubuntu@24.04:amd64` to the build script, so e2e workflows only pack the single charm needed for the CI runner.

## Details
- The `charmcraft pack` produces four `.charm` files after [this](https://github.com/canonical/juju-dashboard/pull/2370) change so when the deploy step ran:

    ```
    juju deploy /path/to/juju-dashboard*.charm dashboard
    ```
  the shell expanded the glob to multiple filenames, making juju see ["dashboard"] as an unrecognised extra argument making the e2e tests fail (see [this](https://github.com/canonical/juju-dashboard/actions/runs/28207192235)).

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- All charm setup jobs in e2e workflows should pass (except the ones skipped due to failing `Start JIMM` job)

