### PR TITLE
chore: remove number to string cast

### DIFF
--- a/src/pages/AddModel/AddModel.test.tsx
+++ b/src/pages/AddModel/AddModel.test.tsx
@@ -383,6 +383,45 @@ describe("AddModel page", () => {
     });
   });
 
+  it("sends numeric values as numbers when model is submitted", async () => {
+    const [store, actions] = createStore(state, { trackActions: true });
+    renderComponent(<AddModel />, { store });
+
+    const addModelAction = jujuActions.addModel({
+      cloudTag: "cloud-aws",
+      credential: "cloudcred-aws_admin_aws-cred",
+      config: {
+        "net-bond-reconfigure-delay": 42,
+      },
+      modelName: "my-model",
+      userTag: "user-eggman@external",
+      disabledCommands: DisableType.NONE,
+      wsControllerURL: "wss://controller.example.com",
+    });
+
+    await userEvent.type(
+      screen.getByLabelText(new RegExp(MandatoryDetailsLabel.MODEL_NAME)),
+      "my-model",
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: Label.NEXT_BUTTON }),
+    );
+    await userEvent.clear(screen.getByLabelText("net-bond-reconfigure-delay"));
+    await userEvent.type(
+      screen.getByLabelText("net-bond-reconfigure-delay"),
+      "42",
+    );
+    await waitFor(() =>
+      fireEvent.submit(screen.getByTestId(TestId.ADD_MODEL_FORM)),
+    );
+
+    await waitFor(() => {
+      expect(
+        actions.find((dispatch) => dispatch.type === addModelAction.type),
+      ).toMatchObject(addModelAction);
+    });
+  });
+
   it("shows success toast when model creation succeeds", async () => {
     state.juju.addModelState = {
       loading: false,

--- a/src/pages/AddModel/ConfigsConstraints/CategoriesListing/CategoriesListing.test.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/CategoriesListing/CategoriesListing.test.tsx
@@ -7,6 +7,7 @@ import { externalURLs } from "urls";
 
 import { InputMode } from "../../types";
 import { CONFIG_CATEGORIES } from "../configCatalog";
+import { CONSTRAINT_CATEGORIES } from "../constraintsCatalog";
 import { FieldName, Label } from "../types";
 
 import CategoriesListing from "./CategoriesListing";
@@ -317,5 +318,89 @@ describe("CategoriesListing", () => {
     expect(
       screen.getByLabelText("container-networking-method"),
     ).toBeInTheDocument();
+  });
+
+  describe("numeric fields", () => {
+    let constraintProps: CategoriesListingProps;
+
+    beforeEach(() => {
+      constraintProps = {
+        title: Label.CONSTRAINTS_TITLE,
+        categoriesList: CONSTRAINT_CATEGORIES,
+        inputMode: FieldName.CONSTRAINT_INPUT_MODE,
+        yamlKey: FieldName.CONSTRAINT_YAML,
+        changedOnlyLabel: Label.CHANGED_CONSTRAINTS_ONLY,
+        docsLabel: Label.MODEL_CONSTRAINT_DOCS,
+        docsLink: externalURLs.constraintModel,
+        tooltipMessage: Label.NO_CHANGED_CONSTRAINTS,
+        searchPlaceholder: "Search constraints",
+        yamlPlaceholder: Label.MODEL_CONSTRAINT_PLACEHOLDER,
+        searchName: "constraintSearch",
+      };
+    });
+
+    it("renders numeric fields correctly", () => {
+      render(
+        <Formik
+          initialValues={{ [FieldName.CONSTRAINT_INPUT_MODE]: InputMode.LIST }}
+          onSubmit={vi.fn()}
+        >
+          <CategoriesListing {...constraintProps} />
+        </Formik>,
+      );
+
+      const coresInput = screen.getByLabelText("cores");
+      expect(coresInput).toHaveAttribute("type", "number");
+
+      const cpuPowerInput = screen.getByLabelText("cpu-power");
+      expect(cpuPowerInput).toHaveAttribute("type", "number");
+    });
+
+    it("treats a filled numeric field as changed and shows it in changed-only view", async () => {
+      render(
+        <Formik
+          initialValues={{
+            [FieldName.CONSTRAINT_INPUT_MODE]: InputMode.LIST,
+            cores: "4",
+          }}
+          onSubmit={vi.fn()}
+        >
+          <CategoriesListing {...constraintProps} />
+        </Formik>,
+      );
+
+      const changedOnlySwitch = screen.getByRole("switch", {
+        name: Label.CHANGED_CONSTRAINTS_ONLY,
+      });
+      await userEvent.click(changedOnlySwitch);
+
+      expect(changedOnlySwitch).toBeChecked();
+      expect(screen.getByLabelText("cores")).toBeInTheDocument();
+      // Non-numeric, unchanged field should be hidden
+      expect(screen.queryByLabelText("spaces")).not.toBeInTheDocument();
+    });
+
+    it("includes numeric field values in YAML output", async () => {
+      render(
+        <Formik
+          initialValues={{
+            [FieldName.CONSTRAINT_INPUT_MODE]: InputMode.LIST,
+            cores: "8",
+          }}
+          onSubmit={vi.fn()}
+        >
+          <CategoriesListing {...constraintProps} />
+        </Formik>,
+      );
+
+      await userEvent.click(
+        screen.getByRole("radio", { name: InputMode.YAML }),
+      );
+      const textarea = screen.getByPlaceholderText(
+        Label.MODEL_CONSTRAINT_PLACEHOLDER,
+      ) as HTMLTextAreaElement;
+
+      expect(textarea.value).toContain("cores: 8");
+    });
   });
 });

--- a/src/pages/AddModel/ConfigsConstraints/CategoriesListing/CategoriesListing.test.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/CategoriesListing/CategoriesListing.test.tsx
@@ -7,7 +7,6 @@ import { externalURLs } from "urls";
 
 import { InputMode } from "../../types";
 import { CONFIG_CATEGORIES } from "../configCatalog";
-import { CONSTRAINT_CATEGORIES } from "../constraintsCatalog";
 import { FieldName, Label } from "../types";
 
 import CategoriesListing from "./CategoriesListing";
@@ -320,87 +319,62 @@ describe("CategoriesListing", () => {
     ).toBeInTheDocument();
   });
 
-  describe("numeric fields", () => {
-    let constraintProps: CategoriesListingProps;
+  it("renders numeric fields correctly", () => {
+    render(
+      <Formik
+        initialValues={{ [FieldName.CONFIG_INPUT_MODE]: InputMode.LIST }}
+        onSubmit={vi.fn()}
+      >
+        <CategoriesListing {...defaultProps} />
+      </Formik>,
+    );
 
-    beforeEach(() => {
-      constraintProps = {
-        title: Label.CONSTRAINTS_TITLE,
-        categoriesList: CONSTRAINT_CATEGORIES,
-        inputMode: FieldName.CONSTRAINT_INPUT_MODE,
-        yamlKey: FieldName.CONSTRAINT_YAML,
-        changedOnlyLabel: Label.CHANGED_CONSTRAINTS_ONLY,
-        docsLabel: Label.MODEL_CONSTRAINT_DOCS,
-        docsLink: externalURLs.constraintModel,
-        tooltipMessage: Label.NO_CHANGED_CONSTRAINTS,
-        searchPlaceholder: "Search constraints",
-        yamlPlaceholder: Label.MODEL_CONSTRAINT_PLACEHOLDER,
-        searchName: "constraintSearch",
-      };
+    const coresInput = screen.getByLabelText("net-bond-reconfigure-delay");
+    expect(coresInput).toHaveAttribute("type", "number");
+  });
+
+  it("treats a filled numeric field as changed and shows it in changed-only view", async () => {
+    render(
+      <Formik
+        initialValues={{
+          [FieldName.CONFIG_INPUT_MODE]: InputMode.LIST,
+          "net-bond-reconfigure-delay": 15,
+        }}
+        onSubmit={vi.fn()}
+      >
+        <CategoriesListing {...defaultProps} />
+      </Formik>,
+    );
+
+    const changedOnlySwitch = screen.getByRole("switch", {
+      name: Label.CHANGED_CONFIGS_ONLY,
     });
+    await userEvent.click(changedOnlySwitch);
 
-    it("renders numeric fields correctly", () => {
-      render(
-        <Formik
-          initialValues={{ [FieldName.CONSTRAINT_INPUT_MODE]: InputMode.LIST }}
-          onSubmit={vi.fn()}
-        >
-          <CategoriesListing {...constraintProps} />
-        </Formik>,
-      );
+    expect(changedOnlySwitch).toBeChecked();
+    expect(
+      screen.getByLabelText("net-bond-reconfigure-delay"),
+    ).toBeInTheDocument();
+  });
 
-      const coresInput = screen.getByLabelText("cores");
-      expect(coresInput).toHaveAttribute("type", "number");
+  it("includes numeric field values in YAML output", async () => {
+    render(
+      <Formik
+        initialValues={{
+          [FieldName.CONFIG_INPUT_MODE]: InputMode.LIST,
+          "net-bond-reconfigure-delay": 15,
+        }}
+        onSubmit={vi.fn()}
+      >
+        <CategoriesListing {...defaultProps} />
+      </Formik>,
+    );
 
-      const cpuPowerInput = screen.getByLabelText("cpu-power");
-      expect(cpuPowerInput).toHaveAttribute("type", "number");
-    });
+    await userEvent.click(screen.getByRole("radio", { name: InputMode.YAML }));
+    const textarea = screen.getByPlaceholderText(
+      Label.MODEL_CONFIG_PLACEHOLDER,
+    ) as HTMLTextAreaElement;
 
-    it("treats a filled numeric field as changed and shows it in changed-only view", async () => {
-      render(
-        <Formik
-          initialValues={{
-            [FieldName.CONSTRAINT_INPUT_MODE]: InputMode.LIST,
-            cores: "4",
-          }}
-          onSubmit={vi.fn()}
-        >
-          <CategoriesListing {...constraintProps} />
-        </Formik>,
-      );
-
-      const changedOnlySwitch = screen.getByRole("switch", {
-        name: Label.CHANGED_CONSTRAINTS_ONLY,
-      });
-      await userEvent.click(changedOnlySwitch);
-
-      expect(changedOnlySwitch).toBeChecked();
-      expect(screen.getByLabelText("cores")).toBeInTheDocument();
-      // Non-numeric, unchanged field should be hidden
-      expect(screen.queryByLabelText("spaces")).not.toBeInTheDocument();
-    });
-
-    it("includes numeric field values in YAML output", async () => {
-      render(
-        <Formik
-          initialValues={{
-            [FieldName.CONSTRAINT_INPUT_MODE]: InputMode.LIST,
-            cores: "8",
-          }}
-          onSubmit={vi.fn()}
-        >
-          <CategoriesListing {...constraintProps} />
-        </Formik>,
-      );
-
-      await userEvent.click(
-        screen.getByRole("radio", { name: InputMode.YAML }),
-      );
-      const textarea = screen.getByPlaceholderText(
-        Label.MODEL_CONSTRAINT_PLACEHOLDER,
-      ) as HTMLTextAreaElement;
-
-      expect(textarea.value).toContain("cores: 8");
-    });
+    expect(textarea.value).toContain("net-bond-reconfigure-delay: 15");
   });
 });

--- a/src/pages/AddModel/ConfigsConstraints/CategoriesListing/CategoriesListing.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/CategoriesListing/CategoriesListing.tsx
@@ -40,7 +40,7 @@ const CategoriesListing = ({
 }: Props): JSX.Element => {
   const id = useId();
   const { values, setFieldValue } = useFormikContext<
-    FormFields & Record<string, string>
+    FormFields & Record<string, number | string>
   >();
   const [searchQuery, setSearchQuery] = useDebounce("", 250);
   const [changedOnly, setChangedOnly] = useState(false);

--- a/src/pages/AddModel/ConfigsConstraints/StackList/StackList.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/StackList/StackList.tsx
@@ -10,7 +10,9 @@ type Props = {
 };
 
 const StackList = ({ visibleFields }: Props): JSX.Element => {
-  const { values } = useFormikContext<FormFields & Record<string, string>>();
+  const { values } = useFormikContext<
+    FormFields & Record<string, number | string>
+  >();
 
   return (
     <>

--- a/src/pages/AddModel/ConfigsConstraints/StackList/StackList.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/StackList/StackList.tsx
@@ -2,7 +2,11 @@ import { FormikField, Icon, Select } from "@canonical/react-components";
 import { useFormikContext } from "formik";
 import { Fragment, type JSX } from "react";
 
-import type { CategoryDefinition, FormFields } from "../types";
+import type {
+  CategoryDefinition,
+  ConfigFieldValue,
+  FormFields,
+} from "../types";
 import { isConfigChanged } from "../utils";
 
 type Props = {
@@ -11,7 +15,7 @@ type Props = {
 
 const StackList = ({ visibleFields }: Props): JSX.Element => {
   const { values } = useFormikContext<
-    FormFields & Record<string, number | string>
+    FormFields & Record<string, ConfigFieldValue>
   >();
 
   return (

--- a/src/pages/AddModel/ConfigsConstraints/types.ts
+++ b/src/pages/AddModel/ConfigsConstraints/types.ts
@@ -50,12 +50,14 @@ export enum DisableType {
   ALL = "BlockChange",
 }
 
+export type ConfigFieldValue = number | string | undefined;
+
 export type CategoryDefinition = {
   category: string;
   fields: {
     label: string;
     description: string;
-    defaultValue?: number | string;
+    defaultValue?: ConfigFieldValue;
     input?: { type: "select" } & SelectProps;
     isNumeric?: boolean;
   }[];

--- a/src/pages/AddModel/ConfigsConstraints/utils.test.ts
+++ b/src/pages/AddModel/ConfigsConstraints/utils.test.ts
@@ -45,7 +45,6 @@ describe("utils", () => {
   describe("isConfigChanged", () => {
     it("returns false when value is undefined", () => {
       const result = isConfigChanged("some-label", {}, "default-value");
-
       expect(result).toBe(false);
     });
 
@@ -55,7 +54,6 @@ describe("utils", () => {
         { "some-label": "default-value" },
         "default-value",
       );
-
       expect(result).toBe(false);
     });
 
@@ -65,7 +63,6 @@ describe("utils", () => {
         { "some-label": "different-value" },
         "default-value",
       );
-
       expect(result).toBe(true);
     });
 
@@ -75,7 +72,6 @@ describe("utils", () => {
         { "some-label": "some-value" },
         undefined,
       );
-
       expect(result).toBe(true);
     });
 
@@ -85,13 +81,11 @@ describe("utils", () => {
         { "some-label": 0 },
         undefined,
       );
-
       expect(result).toBe(true);
     });
 
     it("returns false when a numeric value matches a numeric default", () => {
-      const result = isConfigChanged("some-label", { "some-label": "0" }, 0);
-
+      const result = isConfigChanged("some-label", { "some-label": 0 }, 0);
       expect(result).toBe(false);
     });
   });
@@ -124,7 +118,6 @@ describe("utils", () => {
         "container-networking-method": "provider",
         "logging-config": "",
       });
-
       expect(result).toEqual([]);
     });
 
@@ -134,7 +127,6 @@ describe("utils", () => {
         "container-networking-method": "provider",
         "logging-config": "debug",
       });
-
       expect(result).toHaveLength(2);
       expect(result.map((field) => field.label)).toEqual([
         "default-space",
@@ -146,7 +138,6 @@ describe("utils", () => {
   describe("buildYAML", () => {
     it("returns empty string when no fields have changed", () => {
       const result = buildYAML(categories, {});
-
       expect(result).toBe("");
     });
 
@@ -194,7 +185,6 @@ describe("utils", () => {
         "logging-config": "<root>=INFO",
         arch: "",
       });
-
       expect(result).toEqual({});
     });
 
@@ -217,7 +207,6 @@ describe("utils", () => {
   describe("getCategoriesWithVisibleFields", () => {
     it("returns empty array when no fields have changed", () => {
       const result = getCategoriesWithVisibleFields(categories, {});
-
       expect(result).toHaveLength(0);
     });
 
@@ -236,7 +225,6 @@ describe("utils", () => {
   describe("getConfigInitialValues", () => {
     it("returns object with all fields and their default values", () => {
       const result = getConfigInitialValues(categories);
-
       expect(result).toEqual({
         "default-space": "alpha",
         "container-networking-method": "provider",
@@ -259,13 +247,30 @@ describe("utils", () => {
       ];
 
       const result = getConfigInitialValues(categoriesWithUndefinedDefaults);
-
       expect(result["test-field"]).toBe("");
+    });
+
+    it("preserves numeric default values without converting to strings", () => {
+      const categoriesWithNumericDefaults: CategoryDefinition[] = [
+        {
+          category: "Test",
+          fields: [
+            {
+              label: "numeric-field",
+              defaultValue: 17,
+              description: "A numeric field",
+              isNumeric: true,
+            },
+          ],
+        },
+      ];
+
+      const result = getConfigInitialValues(categoriesWithNumericDefaults);
+      expect(result["numeric-field"]).toBe(17);
     });
 
     it("returns empty object when categories are empty", () => {
       const result = getConfigInitialValues([]);
-
       expect(result).toEqual({});
     });
   });
@@ -273,7 +278,6 @@ describe("utils", () => {
   describe("filterCategoriesBySearch", () => {
     it("returns all categories when query is empty", () => {
       const result = filterCategoriesBySearch("", categories);
-
       expect(result.length).toBeGreaterThan(0);
     });
 
@@ -306,7 +310,6 @@ describe("utils", () => {
         "non-existent-query123456",
         categories,
       );
-
       expect(result).toEqual([]);
     });
 

--- a/src/pages/AddModel/ConfigsConstraints/utils.ts
+++ b/src/pages/AddModel/ConfigsConstraints/utils.ts
@@ -7,8 +7,7 @@ export const isConfigChanged = (
   values: Record<string, number | string>,
   defaultValue: number | string | undefined,
 ): boolean => {
-  // Casting numeric fields for standardized comparison, as form values are strings.
-  const currentValue = values[label]?.toString();
+  const currentValue = values[label];
 
   // If value is undefined, it hasn't been set - not changed
   if (currentValue === undefined) {
@@ -18,16 +17,16 @@ export const isConfigChanged = (
   // If there's a default value, check if current differs from it
   // This includes catching empty string ("") vs default
   if (defaultValue !== undefined) {
-    return currentValue !== defaultValue.toString();
+    return currentValue !== defaultValue;
   }
 
   // No default value: only changed if non-empty
-  return currentValue.length > 0;
+  return currentValue !== "";
 };
 
 export const getChangedFields = (
   category: CategoryDefinition,
-  values: Record<string, string>,
+  values: Record<string, number | string>,
 ): CategoryDefinition["fields"] =>
   category.fields.filter((field) =>
     isConfigChanged(field.label, values, field.defaultValue),
@@ -35,7 +34,7 @@ export const getChangedFields = (
 
 export const getCategoriesWithVisibleFields = (
   categories: CategoryDefinition[],
-  values: Record<string, string>,
+  values: Record<string, number | string>,
 ): Array<{ category: string; fields: CategoryDefinition["fields"] }> =>
   categories
     .map((cat) => ({
@@ -46,7 +45,7 @@ export const getCategoriesWithVisibleFields = (
 
 export const buildYAML = (
   categories: CategoryDefinition[],
-  values: Record<string, string>,
+  values: Record<string, number | string>,
 ): string => {
   const yamlSections = categories
     .map((category) => {
@@ -68,10 +67,10 @@ export const buildYAML = (
 };
 
 export const buildConfigsConstraintsPayload = (
-  values: Record<string, string>,
-): Record<string, string> =>
+  values: Record<string, number | string>,
+): Record<string, number | string> =>
   [...CONFIG_CATEGORIES, ...CONSTRAINT_CATEGORIES].reduce<
-    Record<string, string>
+    Record<string, number | string>
   >((config, category) => {
     getChangedFields(category, values).forEach((field) => {
       config[field.label] = values[field.label];
@@ -81,10 +80,10 @@ export const buildConfigsConstraintsPayload = (
 
 export const getConfigInitialValues = (
   categories: CategoryDefinition[],
-): Record<string, string> =>
-  categories.reduce<Record<string, string>>((values, category) => {
+): Record<string, number | string> =>
+  categories.reduce<Record<string, number | string>>((values, category) => {
     category.fields.forEach((field) => {
-      values[field.label] = field.defaultValue?.toString() ?? "";
+      values[field.label] = field.defaultValue ?? "";
     });
     return values;
   }, {});

--- a/src/pages/AddModel/ConfigsConstraints/utils.ts
+++ b/src/pages/AddModel/ConfigsConstraints/utils.ts
@@ -1,11 +1,11 @@
 import { CONFIG_CATEGORIES } from "./configCatalog";
 import { CONSTRAINT_CATEGORIES } from "./constraintsCatalog";
-import type { CategoryDefinition } from "./types";
+import type { CategoryDefinition, ConfigFieldValue } from "./types";
 
 export const isConfigChanged = (
   label: string,
-  values: Record<string, number | string>,
-  defaultValue: number | string | undefined,
+  values: Record<string, ConfigFieldValue>,
+  defaultValue?: ConfigFieldValue,
 ): boolean => {
   const currentValue = values[label];
 
@@ -26,7 +26,7 @@ export const isConfigChanged = (
 
 export const getChangedFields = (
   category: CategoryDefinition,
-  values: Record<string, number | string>,
+  values: Record<string, ConfigFieldValue>,
 ): CategoryDefinition["fields"] =>
   category.fields.filter((field) =>
     isConfigChanged(field.label, values, field.defaultValue),
@@ -34,7 +34,7 @@ export const getChangedFields = (
 
 export const getCategoriesWithVisibleFields = (
   categories: CategoryDefinition[],
-  values: Record<string, number | string>,
+  values: Record<string, ConfigFieldValue>,
 ): Array<{ category: string; fields: CategoryDefinition["fields"] }> =>
   categories
     .map((cat) => ({
@@ -45,7 +45,7 @@ export const getCategoriesWithVisibleFields = (
 
 export const buildYAML = (
   categories: CategoryDefinition[],
-  values: Record<string, number | string>,
+  values: Record<string, ConfigFieldValue>,
 ): string => {
   const yamlSections = categories
     .map((category) => {
@@ -67,22 +67,26 @@ export const buildYAML = (
 };
 
 export const buildConfigsConstraintsPayload = (
-  values: Record<string, number | string>,
+  values: Record<string, ConfigFieldValue>,
 ): Record<string, number | string> =>
   [...CONFIG_CATEGORIES, ...CONSTRAINT_CATEGORIES].reduce<
     Record<string, number | string>
   >((config, category) => {
     getChangedFields(category, values).forEach((field) => {
-      config[field.label] = values[field.label];
+      const value = values[field.label];
+      if (value !== undefined) {
+        config[field.label] = value;
+      }
     });
     return config;
   }, {});
 
 export const getConfigInitialValues = (
   categories: CategoryDefinition[],
-): Record<string, number | string> =>
-  categories.reduce<Record<string, number | string>>((values, category) => {
+): Record<string, ConfigFieldValue> =>
+  categories.reduce<Record<string, ConfigFieldValue>>((values, category) => {
     category.fields.forEach((field) => {
+      // Coerce undefined to '' so the <input> is always controlled.
       values[field.label] = field.defaultValue ?? "";
     });
     return values;

--- a/src/pages/AddModel/types.ts
+++ b/src/pages/AddModel/types.ts
@@ -23,7 +23,7 @@ export type AddModelFormState = {
   credential: string;
   shareModelWith?: Record<string, AccessLevel>;
 } & FormFields &
-  Record<string, string>;
+  Record<string, number | string>;
 
 export type StepDefinition = {
   key: StepType;

--- a/src/store/juju/types.ts
+++ b/src/store/juju/types.ts
@@ -161,7 +161,7 @@ export type AddModel = {
   shareModelWith?: Record<string, AccessLevel>;
   disabledCommands: DisableType;
   region?: string;
-  config?: Record<string, string>;
+  config?: Record<string, number | string>;
 };
 
 export type AddModelState = {


### PR DESCRIPTION
## Done

- Removed `number` to `string` casting and coercion in the add model flow
- Handle `undefined` defaults gracefully without `""` fallbacks in data model

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Try fiddling with the numeric fields on the ConfigsConstraints tab on AddModel page
- All should work fine

