### PR TITLE
chore: handle boolean fields

### DIFF
--- a/src/pages/AddModel/AddModel.tsx
+++ b/src/pages/AddModel/AddModel.tsx
@@ -40,7 +40,7 @@ import {
   type AddModelFormState,
   type StepDefinition,
 } from "./types";
-import { getCredentialError } from "./utils";
+import { getBooleanSchema, getCredentialError } from "./utils";
 
 const MODEL_NAME_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
 
@@ -58,6 +58,7 @@ const validationSchema = Yup.object().shape({
       });
     },
   }),
+  ...getBooleanSchema(),
 });
 
 const stepDefinitions: StepDefinition[] = [

--- a/src/pages/AddModel/ConfigsConstraints/CategoriesListing/CategoriesListing.test.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/CategoriesListing/CategoriesListing.test.tsx
@@ -104,6 +104,8 @@ describe("CategoriesListing", () => {
         initialValues={{
           [FieldName.CONFIG_INPUT_MODE]: InputMode.LIST,
           "default-space": "my-space",
+          "net-bond-reconfigure-delay": 15,
+          "disable-network-management": "true",
         }}
         onSubmit={vi.fn()}
       >
@@ -117,6 +119,8 @@ describe("CategoriesListing", () => {
     ) as HTMLTextAreaElement;
 
     expect(textarea.value).toContain("default-space: my-space");
+    expect(textarea.value).toContain("net-bond-reconfigure-delay: 15");
+    expect(textarea.value).toContain("disable-network-management: true");
   });
 
   it("switches back to list mode from yaml mode", async () => {
@@ -333,7 +337,7 @@ describe("CategoriesListing", () => {
     expect(coresInput).toHaveAttribute("type", "number");
   });
 
-  it("treats a filled numeric field as changed and shows it in changed-only view", async () => {
+  it("handles changed numeric fields", async () => {
     render(
       <Formik
         initialValues={{
@@ -357,12 +361,12 @@ describe("CategoriesListing", () => {
     ).toBeInTheDocument();
   });
 
-  it("includes numeric field values in YAML output", async () => {
+  it("handles changed boolean fields", async () => {
     render(
       <Formik
         initialValues={{
           [FieldName.CONFIG_INPUT_MODE]: InputMode.LIST,
-          "net-bond-reconfigure-delay": 15,
+          "disable-network-management": "true",
         }}
         onSubmit={vi.fn()}
       >
@@ -370,11 +374,14 @@ describe("CategoriesListing", () => {
       </Formik>,
     );
 
-    await userEvent.click(screen.getByRole("radio", { name: InputMode.YAML }));
-    const textarea = screen.getByPlaceholderText(
-      Label.MODEL_CONFIG_PLACEHOLDER,
-    ) as HTMLTextAreaElement;
+    const changedOnlySwitch = screen.getByRole("switch", {
+      name: Label.CHANGED_CONFIGS_ONLY,
+    });
+    await userEvent.click(changedOnlySwitch);
 
-    expect(textarea.value).toContain("net-bond-reconfigure-delay: 15");
+    expect(changedOnlySwitch).toBeChecked();
+    expect(
+      document.querySelector('select[name="disable-network-management"]'),
+    ).toBeInTheDocument();
   });
 });

--- a/src/pages/AddModel/ConfigsConstraints/CategoriesListing/CategoriesListing.test.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/CategoriesListing/CategoriesListing.test.tsx
@@ -105,7 +105,7 @@ describe("CategoriesListing", () => {
           [FieldName.CONFIG_INPUT_MODE]: InputMode.LIST,
           "default-space": "my-space",
           "net-bond-reconfigure-delay": 15,
-          "disable-network-management": "true",
+          "disable-network-management": true,
         }}
         onSubmit={vi.fn()}
       >
@@ -366,7 +366,7 @@ describe("CategoriesListing", () => {
       <Formik
         initialValues={{
           [FieldName.CONFIG_INPUT_MODE]: InputMode.LIST,
-          "disable-network-management": "true",
+          "disable-network-management": true,
         }}
         onSubmit={vi.fn()}
       >

--- a/src/pages/AddModel/ConfigsConstraints/CategoriesListing/CategoriesListing.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/CategoriesListing/CategoriesListing.tsx
@@ -16,7 +16,7 @@ import useDebounce from "hooks/useDebounce";
 
 import { InputMode } from "../../types";
 import StackList from "../StackList";
-import type { FormFields } from "../types";
+import type { ConfigFieldValue, FormFields } from "../types";
 import {
   buildYAML,
   filterCategoriesBySearch,
@@ -40,7 +40,7 @@ const CategoriesListing = ({
 }: Props): JSX.Element => {
   const id = useId();
   const { values, setFieldValue } = useFormikContext<
-    FormFields & Record<string, number | string>
+    FormFields & Record<string, ConfigFieldValue>
   >();
   const [searchQuery, setSearchQuery] = useDebounce("", 250);
   const [changedOnly, setChangedOnly] = useState(false);

--- a/src/pages/AddModel/ConfigsConstraints/StackList/StackList.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/StackList/StackList.tsx
@@ -32,7 +32,7 @@ const StackList = ({ visibleFields }: Props): JSX.Element => {
               {...(field.input?.type === "select"
                 ? { component: Select }
                 : {
-                    type: field.isNumeric ? "number" : "text",
+                    type: field.valueType === "number" ? "number" : "text",
                     placeholder: field.defaultValue,
                   })}
               label={

--- a/src/pages/AddModel/ConfigsConstraints/configCatalog.ts
+++ b/src/pages/AddModel/ConfigsConstraints/configCatalog.ts
@@ -14,28 +14,16 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
       {
         label: "vpc-id",
         description: "Use a specific VPC network",
-        defaultValue: "false",
-        valueType: "boolean",
-        input: {
-          type: "select",
-          options: [
-            { label: "True", value: "true" },
-            { label: "False", value: "false" },
-          ],
-        },
       },
       {
         label: "vpc-id-force",
         description:
           "Force Juju to use the GCE VPC ID specified with vpc-id, when it fails the minimum validation criteria",
-        defaultValue: "false",
+        defaultValue: false,
         valueType: "boolean",
         input: {
           type: "select",
-          options: [
-            { label: "True", value: "true" },
-            { label: "False", value: "false" },
-          ],
+          options: BOOLEAN_OPTIONS,
         },
       },
     ],
@@ -63,7 +51,7 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
       {
         label: "disable-network-management",
         description: "Determines whether the provider should control networks",
-        defaultValue: "false",
+        defaultValue: false,
         valueType: "boolean",
         input: {
           type: "select",
@@ -96,7 +84,7 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         label: "ignore-machine-addresses",
         description:
           "Determines whether the machine worker should discover machine addresses on startup",
-        defaultValue: "false",
+        defaultValue: false,
         valueType: "boolean",
         input: {
           type: "select",
@@ -125,7 +113,7 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
       {
         label: "ssl-hostname-verification",
         description: "Determines whether SSL hostname verification is enabled",
-        defaultValue: "true",
+        defaultValue: true,
         valueType: "boolean",
         input: {
           type: "select",
@@ -204,7 +192,7 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         label: "proxy-ssh",
         description:
           "Determines whether SSH commands should be proxied through the API server",
-        defaultValue: "false",
+        defaultValue: false,
         valueType: "boolean",
         input: {
           type: "select",
@@ -245,7 +233,7 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         label: "container-image-metadata-defaults-disabled",
         description:
           "Determines whether default simplestreams sources are used for image metadata with containers",
-        defaultValue: "false",
+        defaultValue: false,
         valueType: "boolean",
         input: {
           type: "select",
@@ -282,7 +270,7 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         label: "enable-os-refresh-update",
         description:
           "Determines whether newly provisioned instances should run their respective OS's update capability",
-        defaultValue: "true",
+        defaultValue: true,
         valueType: "boolean",
         input: {
           type: "select",
@@ -293,7 +281,7 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         label: "enable-os-upgrade",
         description:
           "Determines whether newly provisioned instances should run their respective OS's upgrade capability",
-        defaultValue: "true",
+        defaultValue: true,
         valueType: "boolean",
         input: {
           type: "select",
@@ -304,7 +292,7 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         label: "image-metadata-defaults-disabled",
         description:
           "Determines whether default simplestreams sources are used for image metadata",
-        defaultValue: "false",
+        defaultValue: false,
         valueType: "boolean",
         input: {
           type: "select",
@@ -376,7 +364,7 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
       {
         label: "logforward-enabled",
         description: "Determines whether syslog forwarding is enabled",
-        defaultValue: "false",
+        defaultValue: false,
         valueType: "boolean",
         input: {
           type: "select",
@@ -418,7 +406,7 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         label: "automatically-retry-hooks",
         description:
           "Determines whether the uniter should automatically retry failed hooks",
-        defaultValue: "true",
+        defaultValue: true,
         valueType: "boolean",
         input: {
           type: "select",
@@ -434,7 +422,7 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         label: "transmit-vendor-metrics",
         description:
           "Determines whether metrics declared by charms deployed into this model are sent for anonymized aggregate analytics",
-        defaultValue: "true",
+        defaultValue: true,
         valueType: "boolean",
         input: {
           type: "select",
@@ -500,7 +488,7 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         label: "development",
         description:
           "Determines whether development mode is enabled for this model",
-        defaultValue: "false",
+        defaultValue: false,
         valueType: "boolean",
         input: {
           type: "select",
@@ -511,7 +499,7 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         label: "disable-telemetry",
         description:
           "Determines whether telemetry collection is disabled for this model",
-        defaultValue: "false",
+        defaultValue: false,
         valueType: "boolean",
         input: {
           type: "select",
@@ -526,7 +514,7 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
       {
         label: "test-mode",
         description: "Determines whether test mode is enabled for this model",
-        defaultValue: "false",
+        defaultValue: false,
         valueType: "boolean",
         input: {
           type: "select",

--- a/src/pages/AddModel/ConfigsConstraints/configCatalog.ts
+++ b/src/pages/AddModel/ConfigsConstraints/configCatalog.ts
@@ -15,6 +15,7 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         label: "vpc-id",
         description: "Use a specific VPC network",
         defaultValue: "false",
+        valueType: "boolean",
         input: {
           type: "select",
           options: [
@@ -28,6 +29,7 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         description:
           "Force Juju to use the GCE VPC ID specified with vpc-id, when it fails the minimum validation criteria",
         defaultValue: "false",
+        valueType: "boolean",
         input: {
           type: "select",
           options: [
@@ -62,6 +64,7 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         label: "disable-network-management",
         description: "Determines whether the provider should control networks",
         defaultValue: "false",
+        valueType: "boolean",
         input: {
           type: "select",
           options: BOOLEAN_OPTIONS,
@@ -94,6 +97,7 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         description:
           "Determines whether the machine worker should discover machine addresses on startup",
         defaultValue: "false",
+        valueType: "boolean",
         input: {
           type: "select",
           options: BOOLEAN_OPTIONS,
@@ -104,7 +108,7 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         description:
           "The amount of time in seconds to sleep between ifdown and ifup when bridging",
         defaultValue: 17,
-        isNumeric: true,
+        valueType: "number",
       },
       {
         label: "saas-ingress-allow",
@@ -122,6 +126,7 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         label: "ssl-hostname-verification",
         description: "Determines whether SSL hostname verification is enabled",
         defaultValue: "true",
+        valueType: "boolean",
         input: {
           type: "select",
           options: BOOLEAN_OPTIONS,
@@ -200,6 +205,7 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         description:
           "Determines whether SSH commands should be proxied through the API server",
         defaultValue: "false",
+        valueType: "boolean",
         input: {
           type: "select",
           options: BOOLEAN_OPTIONS,
@@ -240,6 +246,7 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         description:
           "Determines whether default simplestreams sources are used for image metadata with containers",
         defaultValue: "false",
+        valueType: "boolean",
         input: {
           type: "select",
           options: BOOLEAN_OPTIONS,
@@ -276,6 +283,7 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         description:
           "Determines whether newly provisioned instances should run their respective OS's update capability",
         defaultValue: "true",
+        valueType: "boolean",
         input: {
           type: "select",
           options: BOOLEAN_OPTIONS,
@@ -286,6 +294,7 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         description:
           "Determines whether newly provisioned instances should run their respective OS's upgrade capability",
         defaultValue: "true",
+        valueType: "boolean",
         input: {
           type: "select",
           options: BOOLEAN_OPTIONS,
@@ -296,6 +305,7 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         description:
           "Determines whether default simplestreams sources are used for image metadata",
         defaultValue: "false",
+        valueType: "boolean",
         input: {
           type: "select",
           options: BOOLEAN_OPTIONS,
@@ -323,13 +333,13 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         description:
           "The number of container provisioning workers to use per machine",
         defaultValue: 4,
-        isNumeric: true,
+        valueType: "number",
       },
       {
         label: "num-provision-workers",
         description: "The number of provisioning workers to use per model",
         defaultValue: 16,
-        isNumeric: true,
+        valueType: "number",
       },
       {
         label: "project",
@@ -367,6 +377,7 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         label: "logforward-enabled",
         description: "Determines whether syslog forwarding is enabled",
         defaultValue: "false",
+        valueType: "boolean",
         input: {
           type: "select",
           options: BOOLEAN_OPTIONS,
@@ -408,6 +419,7 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         description:
           "Determines whether the uniter should automatically retry failed hooks",
         defaultValue: "true",
+        valueType: "boolean",
         input: {
           type: "select",
           options: BOOLEAN_OPTIONS,
@@ -423,6 +435,7 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         description:
           "Determines whether metrics declared by charms deployed into this model are sent for anonymized aggregate analytics",
         defaultValue: "true",
+        valueType: "boolean",
         input: {
           type: "select",
           options: BOOLEAN_OPTIONS,
@@ -488,6 +501,7 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         description:
           "Determines whether development mode is enabled for this model",
         defaultValue: "false",
+        valueType: "boolean",
         input: {
           type: "select",
           options: BOOLEAN_OPTIONS,
@@ -498,6 +512,7 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         description:
           "Determines whether telemetry collection is disabled for this model",
         defaultValue: "false",
+        valueType: "boolean",
         input: {
           type: "select",
           options: BOOLEAN_OPTIONS,
@@ -512,6 +527,7 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         label: "test-mode",
         description: "Determines whether test mode is enabled for this model",
         defaultValue: "false",
+        valueType: "boolean",
         input: {
           type: "select",
           options: BOOLEAN_OPTIONS,

--- a/src/pages/AddModel/ConfigsConstraints/constraintsCatalog.ts
+++ b/src/pages/AddModel/ConfigsConstraints/constraintsCatalog.ts
@@ -13,12 +13,12 @@ export const CONSTRAINT_CATEGORIES: CategoryDefinition[] = [
       {
         label: "cores",
         description: "Number of effective CPU cores (alias: cpu-cores)",
-        isNumeric: true,
+        valueType: "number",
       },
       {
         label: "cpu-power",
         description: "Abstract CPU power (100 units ≈ 1 Amazon vCPU)",
-        isNumeric: true,
+        valueType: "number",
       },
       {
         label: "mem",
@@ -47,6 +47,7 @@ export const CONSTRAINT_CATEGORIES: CategoryDefinition[] = [
         label: "allocate-public-ip",
         description:
           "Supplying this constraint will determine whether machines are issued an IP address accessible outside of the cloud’s virtual network",
+        valueType: "boolean",
         input: {
           type: "select",
           options: [EMPTY_OPTION, ...BOOLEAN_OPTIONS],

--- a/src/pages/AddModel/ConfigsConstraints/types.ts
+++ b/src/pages/AddModel/ConfigsConstraints/types.ts
@@ -50,7 +50,7 @@ export enum DisableType {
   ALL = "BlockChange",
 }
 
-export type ConfigFieldValue = number | string | undefined;
+export type ConfigFieldValue = boolean | number | string | undefined;
 
 export type CategoryDefinition = {
   category: string;
@@ -59,6 +59,6 @@ export type CategoryDefinition = {
     description: string;
     defaultValue?: ConfigFieldValue;
     input?: { type: "select" } & SelectProps;
-    isNumeric?: boolean;
+    valueType?: "boolean" | "number";
   }[];
 };

--- a/src/pages/AddModel/ConfigsConstraints/utils.test.ts
+++ b/src/pages/AddModel/ConfigsConstraints/utils.test.ts
@@ -89,20 +89,20 @@ describe("utils", () => {
       expect(result).toBe(false);
     });
 
-    it("returns false when a boolean string value matches the string default", () => {
+    it("returns false when a boolean value matches the default", () => {
       const result = isConfigChanged(
         "some-label",
-        { "some-label": "false" },
-        "false",
+        { "some-label": false },
+        false,
       );
       expect(result).toBe(false);
     });
 
-    it("returns true when a boolean string value differs from the string default", () => {
+    it("returns true when a boolean value differs from the default", () => {
       const result = isConfigChanged(
         "some-label",
-        { "some-label": "true" },
-        "false",
+        { "some-label": true },
+        false,
       );
       expect(result).toBe(true);
     });
@@ -221,18 +221,16 @@ describe("utils", () => {
       });
     });
 
-    it("casts boolean string values to actual booleans in the payload", () => {
-      // "disable-network-management" is a boolean field with defaultValue "false"
-      // Setting it to "true" should produce boolean true in the payload
+    it("includes changed boolean fields in the payload", () => {
       const result = buildConfigsConstraintsPayload({
-        "disable-network-management": "true",
+        "disable-network-management": true,
       });
       expect(result["disable-network-management"]).toBe(true);
     });
 
     it("does not include boolean fields that match their default value", () => {
       const result = buildConfigsConstraintsPayload({
-        "disable-network-management": "false",
+        "disable-network-management": false,
       });
       expect(result).not.toHaveProperty("disable-network-management");
     });

--- a/src/pages/AddModel/ConfigsConstraints/utils.test.ts
+++ b/src/pages/AddModel/ConfigsConstraints/utils.test.ts
@@ -88,6 +88,24 @@ describe("utils", () => {
       const result = isConfigChanged("some-label", { "some-label": 0 }, 0);
       expect(result).toBe(false);
     });
+
+    it("returns false when a boolean string value matches the string default", () => {
+      const result = isConfigChanged(
+        "some-label",
+        { "some-label": "false" },
+        "false",
+      );
+      expect(result).toBe(false);
+    });
+
+    it("returns true when a boolean string value differs from the string default", () => {
+      const result = isConfigChanged(
+        "some-label",
+        { "some-label": "true" },
+        "false",
+      );
+      expect(result).toBe(true);
+    });
   });
 
   describe("getChangedFields", () => {
@@ -202,6 +220,22 @@ describe("utils", () => {
         arch: "amd64",
       });
     });
+
+    it("casts boolean string values to actual booleans in the payload", () => {
+      // "disable-network-management" is a boolean field with defaultValue "false"
+      // Setting it to "true" should produce boolean true in the payload
+      const result = buildConfigsConstraintsPayload({
+        "disable-network-management": "true",
+      });
+      expect(result["disable-network-management"]).toBe(true);
+    });
+
+    it("does not include boolean fields that match their default value", () => {
+      const result = buildConfigsConstraintsPayload({
+        "disable-network-management": "false",
+      });
+      expect(result).not.toHaveProperty("disable-network-management");
+    });
   });
 
   describe("getCategoriesWithVisibleFields", () => {
@@ -259,7 +293,7 @@ describe("utils", () => {
               label: "numeric-field",
               defaultValue: 17,
               description: "A numeric field",
-              isNumeric: true,
+              valueType: "number",
             },
           ],
         },

--- a/src/pages/AddModel/ConfigsConstraints/utils.ts
+++ b/src/pages/AddModel/ConfigsConstraints/utils.ts
@@ -14,10 +14,9 @@ export const isConfigChanged = (
     return false;
   }
 
-  // If there's a default value, check if current differs from it
-  // This includes catching empty string ("") vs default
+  // If there's a default value, check if current differs from it.
   if (defaultValue !== undefined) {
-    return currentValue !== defaultValue;
+    return currentValue.toString() !== defaultValue.toString();
   }
 
   // No default value: only changed if non-empty
@@ -68,14 +67,19 @@ export const buildYAML = (
 
 export const buildConfigsConstraintsPayload = (
   values: Record<string, ConfigFieldValue>,
-): Record<string, number | string> =>
+): Record<string, boolean | number | string> =>
   [...CONFIG_CATEGORIES, ...CONSTRAINT_CATEGORIES].reduce<
-    Record<string, number | string>
+    Record<string, boolean | number | string>
   >((config, category) => {
     getChangedFields(category, values).forEach((field) => {
       const value = values[field.label];
       if (value !== undefined) {
-        config[field.label] = value;
+        // Cast boolean string values to actual booleans for the API payload.
+        if (field.valueType === "boolean") {
+          config[field.label] = value === "true" || value === true;
+        } else {
+          config[field.label] = value;
+        }
       }
     });
     return config;

--- a/src/pages/AddModel/ConfigsConstraints/utils.ts
+++ b/src/pages/AddModel/ConfigsConstraints/utils.ts
@@ -74,12 +74,7 @@ export const buildConfigsConstraintsPayload = (
     getChangedFields(category, values).forEach((field) => {
       const value = values[field.label];
       if (value !== undefined) {
-        // Cast boolean string values to actual booleans for the API payload.
-        if (field.valueType === "boolean") {
-          config[field.label] = value === "true" || value === true;
-        } else {
-          config[field.label] = value;
-        }
+        config[field.label] = value;
       }
     });
     return config;

--- a/src/pages/AddModel/utils.test.ts
+++ b/src/pages/AddModel/utils.test.ts
@@ -20,7 +20,6 @@ describe("AddModel utils", () => {
     it("returns an entry for every boolean field in the catalog", () => {
       const schema = getBooleanSchema();
       // Spot-check a known boolean field from each catalog
-      console.log(schema);
       expect(schema).toHaveProperty("disable-network-management");
       expect(schema).toHaveProperty("allocate-public-ip");
     });

--- a/src/pages/AddModel/utils.test.ts
+++ b/src/pages/AddModel/utils.test.ts
@@ -1,5 +1,5 @@
 import { Label } from "./types";
-import { getCredentialError } from "./utils";
+import { getBooleanSchema, getCredentialError } from "./utils";
 
 describe("AddModel utils", () => {
   describe("getCredentialError", () => {
@@ -13,6 +13,32 @@ describe("AddModel utils", () => {
       expect(getCredentialError(undefined)).toBe(
         Label.REQUIRED_CREDENTIAL_ERROR,
       );
+    });
+  });
+
+  describe("getBooleanSchema", () => {
+    it("returns an entry for every boolean field in the catalog", () => {
+      const schema = getBooleanSchema();
+      // Spot-check a known boolean field from each catalog
+      console.log(schema);
+      expect(schema).toHaveProperty("disable-network-management");
+      expect(schema).toHaveProperty("allocate-public-ip");
+    });
+
+    it("does not include non-boolean fields", () => {
+      const schema = getBooleanSchema();
+      // Plain string and numeric fields should be absent
+      expect(schema).not.toHaveProperty("default-space");
+      expect(schema).not.toHaveProperty("net-bond-reconfigure-delay");
+    });
+
+    it("returns Yup boolean schemas for each entry", () => {
+      const schema = getBooleanSchema();
+      const entry = schema["disable-network-management"];
+      expect(entry).toBeDefined();
+      // Yup boolean schema accepts true/false and casts "true"/"false" strings
+      expect(entry.isValidSync(true)).toBe(true);
+      expect(entry.isValidSync(false)).toBe(true);
     });
   });
 });

--- a/src/pages/AddModel/utils.ts
+++ b/src/pages/AddModel/utils.ts
@@ -1,5 +1,9 @@
+import * as Yup from "yup";
+
 import { extractCloudName } from "store/juju/utils/models";
 
+import { CONFIG_CATEGORIES } from "./ConfigsConstraints/configCatalog";
+import { CONSTRAINT_CATEGORIES } from "./ConfigsConstraints/constraintsCatalog";
 import { Label } from "./types";
 
 export const getCredentialError = (cloud: unknown): string => {
@@ -8,3 +12,15 @@ export const getCredentialError = (cloud: unknown): string => {
   }
   return Label.REQUIRED_CREDENTIAL_ERROR;
 };
+
+export const getBooleanSchema = (): Record<string, Yup.BooleanSchema> =>
+  [...CONFIG_CATEGORIES, ...CONSTRAINT_CATEGORIES].reduce<
+    Record<string, Yup.BooleanSchema>
+  >((schemas, category) => {
+    for (const field of category.fields) {
+      if (field.valueType === "boolean") {
+        schemas[field.label] = Yup.boolean();
+      }
+    }
+    return schemas;
+  }, {});

--- a/src/store/juju/types.ts
+++ b/src/store/juju/types.ts
@@ -161,7 +161,7 @@ export type AddModel = {
   shareModelWith?: Record<string, AccessLevel>;
   disabledCommands: DisableType;
   region?: string;
-  config?: Record<string, number | string>;
+  config?: Record<string, boolean | number | string>;
 };
 
 export type AddModelState = {


### PR DESCRIPTION
This PR depends on https://github.com/canonical/juju-dashboard/pull/2384

## Done

- Introduced proper handling of `boolean` values in AddModel flow
- Added a new type for all acceptable form input values for configs and constraints
- Added/extended tests

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Try fiddling with the boolean fields on the ConfigsConstraints tab on AddModel page
- All should work fine
