### PR TITLE
feat: add semver and controller version gate utilities

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -11,6 +11,9 @@ export const OIDC_POLL_INTERVAL = 5 * 60 * 1000;
 // The local storage key for enabled feature flags list
 export const ENABLED_FLAGS = "flags";
 
+// The minimum Juju version that supports the modelConfigSchema facade method.
+export const MODEL_CONFIG_SCHEMA_MIN_VERSION = "4.0.12";
+
 // The options to build a boolean Select
 export const BOOLEAN_OPTIONS = [
   { label: "True", value: "true" },

--- a/src/store/juju/selectors.test.ts
+++ b/src/store/juju/selectors.test.ts
@@ -157,6 +157,7 @@ import {
   getModelUpgradeDataLoaded,
   getHighestSupportedVersion,
   getNextSupportedVersion,
+  getControllerSupportsModelConfigSchema,
 } from "./selectors";
 
 describe("selectors", () => {
@@ -3329,6 +3330,70 @@ describe("getUserCredentialsState", () => {
       errors: null,
       loading: false,
     });
+  });
+});
+
+describe("getControllerSupportsModelConfigSchema", () => {
+  it("returns false when no controller exists for the given URL", () => {
+    expect(
+      getControllerSupportsModelConfigSchema(
+        rootStateFactory.build({
+          juju: jujuStateFactory.build({ controllers: {} }),
+        }),
+        "wss://example.com",
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false for Juju versions below 4.0.12", () => {
+    expect(
+      getControllerSupportsModelConfigSchema(
+        rootStateFactory.build({
+          juju: jujuStateFactory.build({
+            controllers: {
+              "wss://example.com": [
+                controllerFactory.build({ version: "3.6.0" }),
+              ],
+            },
+          }),
+        }),
+        "wss://example.com",
+      ),
+    ).toBe(false);
+  });
+
+  it("returns true for exactly the minimum version (4.0.12)", () => {
+    expect(
+      getControllerSupportsModelConfigSchema(
+        rootStateFactory.build({
+          juju: jujuStateFactory.build({
+            controllers: {
+              "wss://example.com": [
+                controllerFactory.build({ version: "4.0.12" }),
+              ],
+            },
+          }),
+        }),
+        "wss://example.com",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns true for Juju 4.0 above the minimum (4.0.13)", () => {
+    expect(
+      getControllerSupportsModelConfigSchema(
+        rootStateFactory.build({
+          juju: jujuStateFactory.build({
+            controllers: {
+              "wss://example.com": [
+                controllerFactory.build({ version: "4.0.13" }),
+              ],
+            },
+          }),
+        }),
+        "wss://example.com",
+      ),
+    ).toBe(true);
   });
 });
 

--- a/src/store/juju/selectors.ts
+++ b/src/store/juju/selectors.ts
@@ -11,6 +11,7 @@ import { createSelector } from "@reduxjs/toolkit";
 import cloneDeep from "clone-deep";
 import fastDeepEqual from "fast-deep-equal/es6";
 
+import { MODEL_CONFIG_SCHEMA_MIN_VERSION } from "consts";
 import type { AuditEvent } from "juju/jimm/JIMMV3";
 import type { RelationshipTuple, VersionElem } from "juju/jimm/JIMMV4";
 import type { FullStatusAnnotations, ModelInfo } from "juju/types";
@@ -326,6 +327,27 @@ export const getModelsError = createSelector(
 export const getControllerData = createSelector(
   [slice],
   (sliceState) => sliceState.controllers,
+);
+
+/**
+  Returns whether the given wsControllerURL supports modelConfigSchema.
+*/
+export const getControllerSupportsModelConfigSchema = createSelector(
+  [
+    getControllerData,
+    (_state: RootState, wsControllerURL: string): string => wsControllerURL,
+  ],
+  (controllers, wsControllerURL): boolean => {
+    const controller = controllers?.[wsControllerURL]?.[0];
+    if (!controller) {
+      return false;
+    }
+    const version = getControllerVersion(controller);
+    if (!version) {
+      return false;
+    }
+    return isHigherSemver(version, MODEL_CONFIG_SCHEMA_MIN_VERSION, true);
+  },
 );
 
 export const getControllersCount = createSelector([slice], (sliceState) => {

--- a/src/utils/isHigherSemver.test.ts
+++ b/src/utils/isHigherSemver.test.ts
@@ -18,3 +18,7 @@ it("handles higher patch version", () => {
 it("handles equal versions", () => {
   expect(isHigherSemver("1.2.30", "1.2.30")).toBe(false);
 });
+
+it("handles equal versions when orEqual is true", () => {
+  expect(isHigherSemver("1.2.30", "1.2.30", true)).toBe(true);
+});

--- a/src/utils/isHigherSemver.ts
+++ b/src/utils/isHigherSemver.ts
@@ -1,7 +1,11 @@
 import getMajorMinorVersion from "./getMajorMinorVersion";
 import getPatchVersion from "./getPatchVersion";
 
-const isHigherSemver = (versionA: string, versionB: string): boolean => {
+const isHigherSemver = (
+  versionA: string,
+  versionB: string,
+  orEqual = false,
+): boolean => {
   const majorMinorA = getMajorMinorVersion(versionA);
   const majorMinorB = getMajorMinorVersion(versionB);
   if (majorMinorA === null || majorMinorB === null) {
@@ -10,7 +14,10 @@ const isHigherSemver = (versionA: string, versionB: string): boolean => {
   if (majorMinorA === majorMinorB) {
     const patchA = getPatchVersion(versionA);
     const patchB = getPatchVersion(versionB);
-    return patchA && patchB ? patchA > patchB : false;
+    if (patchA === null || patchB === null) {
+      return false;
+    }
+    return orEqual ? patchA >= patchB : patchA > patchB;
   }
   return majorMinorA > majorMinorB;
 };


### PR DESCRIPTION
## Done

- Added selector `getControllerSupportsModelConfigSchema` that evaluates the controller for its version and if it is above the minimum version to support `ModelConfigSchema` facade method
- Extended `isHigherSemver` to support checking for "higher than or equal to: cases
- Added tests

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- All tests should pass

## Details

https://warthogs.atlassian.net/browse/JUJU-9831
