### PR TITLE
feat(utils): add normalisation utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     ]
   },
   "dependencies": {
-    "@canonical/jujulib": "9.0.0",
+    "@canonical/jujulib": "9.1.0",
     "@canonical/macaroon-bakery": "1.3.2",
     "@canonical/react-components": "4.6.0",
     "@canonical/rebac-admin": "0.0.1-alpha.12",

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -11,6 +11,9 @@ export const OIDC_POLL_INTERVAL = 5 * 60 * 1000;
 // The local storage key for enabled feature flags list
 export const ENABLED_FLAGS = "flags";
 
+// Sentinel category string used when schema data has no grouping.
+export const FALLBACK_CATEGORY = "";
+
 // The options to build a boolean Select
 export const BOOLEAN_OPTIONS = [
   { label: "True", value: "true" },

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -11,9 +11,6 @@ export const OIDC_POLL_INTERVAL = 5 * 60 * 1000;
 // The local storage key for enabled feature flags list
 export const ENABLED_FLAGS = "flags";
 
-// Sentinel category string used when schema data has no grouping.
-export const FALLBACK_CATEGORY = "";
-
 // The options to build a boolean Select
 export const BOOLEAN_OPTIONS = [
   { label: "True", value: "true" },

--- a/src/pages/AddModel/ConfigsConstraints/StackList/StackList.test.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/StackList/StackList.test.tsx
@@ -5,6 +5,7 @@ import { vi } from "vitest";
 import { renderComponent } from "testing/utils";
 
 import type { CategoryDefinition } from "../types";
+import { InputType } from "../types";
 
 import StackList from "./StackList";
 
@@ -24,7 +25,7 @@ describe("StackList", () => {
         description: "The method of container networking setup",
         defaultValue: "local",
         input: {
-          type: "select",
+          type: InputType.SELECT,
           options: [
             { label: "local", value: "local" },
             { label: "fan", value: "fan" },

--- a/src/pages/AddModel/ConfigsConstraints/StackList/StackList.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/StackList/StackList.tsx
@@ -3,14 +3,15 @@ import { useFormikContext } from "formik";
 import { Fragment, type JSX } from "react";
 
 import type {
-  CategoryDefinition,
+  CategoryDefinitionField,
   ConfigFieldValue,
   FormFields,
 } from "../types";
+import { InputType, ValueType } from "../types";
 import { isConfigChanged } from "../utils";
 
 type Props = {
-  visibleFields: CategoryDefinition["fields"];
+  visibleFields: CategoryDefinitionField[];
 };
 
 const StackList = ({ visibleFields }: Props): JSX.Element => {
@@ -29,10 +30,11 @@ const StackList = ({ visibleFields }: Props): JSX.Element => {
         return (
           <Fragment key={field.label}>
             <FormikField
-              {...(field.input?.type === "select"
+              {...(field.input?.type === InputType.SELECT
                 ? { component: Select }
                 : {
-                    type: field.valueType === "number" ? "number" : "text",
+                    type:
+                      field.valueType === ValueType.NUMBER ? "number" : "text",
                     placeholder: field.defaultValue,
                   })}
               label={

--- a/src/pages/AddModel/ConfigsConstraints/configCatalog.ts
+++ b/src/pages/AddModel/ConfigsConstraints/configCatalog.ts
@@ -2,6 +2,7 @@
 import { BOOLEAN_OPTIONS } from "consts";
 
 import type { CategoryDefinition } from "./types";
+import { InputType, ValueType } from "./types";
 
 export const CONFIG_CATEGORIES: CategoryDefinition[] = [
   {
@@ -20,9 +21,9 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         description:
           "Force Juju to use the GCE VPC ID specified with vpc-id, when it fails the minimum validation criteria",
         defaultValue: false,
-        valueType: "boolean",
+        valueType: ValueType.BOOLEAN,
         input: {
-          type: "select",
+          type: InputType.SELECT,
           options: BOOLEAN_OPTIONS,
         },
       },
@@ -36,7 +37,7 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         description: "The method of container networking setup",
         defaultValue: "local",
         input: {
-          type: "select",
+          type: InputType.SELECT,
           options: [
             { label: "local", value: "local" },
             { label: "fan", value: "fan" },
@@ -52,9 +53,9 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         label: "disable-network-management",
         description: "Determines whether the provider should control networks",
         defaultValue: false,
-        valueType: "boolean",
+        valueType: ValueType.BOOLEAN,
         input: {
-          type: "select",
+          type: InputType.SELECT,
           options: BOOLEAN_OPTIONS,
         },
       },
@@ -72,7 +73,7 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         description: "The mode to use for network firewalling",
         defaultValue: "instance",
         input: {
-          type: "select",
+          type: InputType.SELECT,
           options: [
             { label: "Instance", value: "instance" },
             { label: "Global", value: "global" },
@@ -85,9 +86,9 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         description:
           "Determines whether the machine worker should discover machine addresses on startup",
         defaultValue: false,
-        valueType: "boolean",
+        valueType: ValueType.BOOLEAN,
         input: {
-          type: "select",
+          type: InputType.SELECT,
           options: BOOLEAN_OPTIONS,
         },
       },
@@ -96,7 +97,7 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         description:
           "The amount of time in seconds to sleep between ifdown and ifup when bridging",
         defaultValue: 17,
-        valueType: "number",
+        valueType: ValueType.NUMBER,
       },
       {
         label: "saas-ingress-allow",
@@ -114,9 +115,9 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         label: "ssl-hostname-verification",
         description: "Determines whether SSL hostname verification is enabled",
         defaultValue: true,
-        valueType: "boolean",
+        valueType: ValueType.BOOLEAN,
         input: {
-          type: "select",
+          type: InputType.SELECT,
           options: BOOLEAN_OPTIONS,
         },
       },
@@ -193,9 +194,9 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         description:
           "Determines whether SSH commands should be proxied through the API server",
         defaultValue: false,
-        valueType: "boolean",
+        valueType: ValueType.BOOLEAN,
         input: {
-          type: "select",
+          type: InputType.SELECT,
           options: BOOLEAN_OPTIONS,
         },
       },
@@ -234,9 +235,9 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         description:
           "Determines whether default simplestreams sources are used for image metadata with containers",
         defaultValue: false,
-        valueType: "boolean",
+        valueType: ValueType.BOOLEAN,
         input: {
-          type: "select",
+          type: InputType.SELECT,
           options: BOOLEAN_OPTIONS,
         },
       },
@@ -271,9 +272,9 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         description:
           "Determines whether newly provisioned instances should run their respective OS's update capability",
         defaultValue: true,
-        valueType: "boolean",
+        valueType: ValueType.BOOLEAN,
         input: {
-          type: "select",
+          type: InputType.SELECT,
           options: BOOLEAN_OPTIONS,
         },
       },
@@ -282,9 +283,9 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         description:
           "Determines whether newly provisioned instances should run their respective OS's upgrade capability",
         defaultValue: true,
-        valueType: "boolean",
+        valueType: ValueType.BOOLEAN,
         input: {
-          type: "select",
+          type: InputType.SELECT,
           options: BOOLEAN_OPTIONS,
         },
       },
@@ -293,9 +294,9 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         description:
           "Determines whether default simplestreams sources are used for image metadata",
         defaultValue: false,
-        valueType: "boolean",
+        valueType: ValueType.BOOLEAN,
         input: {
-          type: "select",
+          type: InputType.SELECT,
           options: BOOLEAN_OPTIONS,
         },
       },
@@ -321,13 +322,13 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         description:
           "The number of container provisioning workers to use per machine",
         defaultValue: 4,
-        valueType: "number",
+        valueType: ValueType.NUMBER,
       },
       {
         label: "num-provision-workers",
         description: "The number of provisioning workers to use per model",
         defaultValue: 16,
-        valueType: "number",
+        valueType: ValueType.NUMBER,
       },
       {
         label: "project",
@@ -341,7 +342,7 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
           "Sets what to do with unknown machines. Valid values: all, none, unknown, destroyed",
         defaultValue: "destroyed",
         input: {
-          type: "select",
+          type: InputType.SELECT,
           options: [
             { label: "all", value: "all" },
             { label: "none", value: "none" },
@@ -365,9 +366,9 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         label: "logforward-enabled",
         description: "Determines whether syslog forwarding is enabled",
         defaultValue: false,
-        valueType: "boolean",
+        valueType: ValueType.BOOLEAN,
         input: {
-          type: "select",
+          type: InputType.SELECT,
           options: BOOLEAN_OPTIONS,
         },
       },
@@ -407,9 +408,9 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         description:
           "Determines whether the uniter should automatically retry failed hooks",
         defaultValue: true,
-        valueType: "boolean",
+        valueType: ValueType.BOOLEAN,
         input: {
-          type: "select",
+          type: InputType.SELECT,
           options: BOOLEAN_OPTIONS,
         },
       },
@@ -423,9 +424,9 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         description:
           "Determines whether metrics declared by charms deployed into this model are sent for anonymized aggregate analytics",
         defaultValue: true,
-        valueType: "boolean",
+        valueType: ValueType.BOOLEAN,
         input: {
-          type: "select",
+          type: InputType.SELECT,
           options: BOOLEAN_OPTIONS,
         },
       },
@@ -489,9 +490,9 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         description:
           "Determines whether development mode is enabled for this model",
         defaultValue: false,
-        valueType: "boolean",
+        valueType: ValueType.BOOLEAN,
         input: {
-          type: "select",
+          type: InputType.SELECT,
           options: BOOLEAN_OPTIONS,
         },
       },
@@ -500,9 +501,9 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         description:
           "Determines whether telemetry collection is disabled for this model",
         defaultValue: false,
-        valueType: "boolean",
+        valueType: ValueType.BOOLEAN,
         input: {
-          type: "select",
+          type: InputType.SELECT,
           options: BOOLEAN_OPTIONS,
         },
       },
@@ -515,9 +516,9 @@ export const CONFIG_CATEGORIES: CategoryDefinition[] = [
         label: "test-mode",
         description: "Determines whether test mode is enabled for this model",
         defaultValue: false,
-        valueType: "boolean",
+        valueType: ValueType.BOOLEAN,
         input: {
-          type: "select",
+          type: InputType.SELECT,
           options: BOOLEAN_OPTIONS,
         },
       },

--- a/src/pages/AddModel/ConfigsConstraints/constraintsCatalog.ts
+++ b/src/pages/AddModel/ConfigsConstraints/constraintsCatalog.ts
@@ -3,6 +3,7 @@
 import { BOOLEAN_OPTIONS } from "consts";
 
 import type { CategoryDefinition } from "./types";
+import { InputType, ValueType } from "./types";
 
 const EMPTY_OPTION = { label: "Unset", value: "" };
 
@@ -13,12 +14,12 @@ export const CONSTRAINT_CATEGORIES: CategoryDefinition[] = [
       {
         label: "cores",
         description: "Number of effective CPU cores (alias: cpu-cores)",
-        valueType: "number",
+        valueType: ValueType.NUMBER,
       },
       {
         label: "cpu-power",
         description: "Abstract CPU power (100 units ≈ 1 Amazon vCPU)",
-        valueType: "number",
+        valueType: ValueType.NUMBER,
       },
       {
         label: "mem",
@@ -47,9 +48,9 @@ export const CONSTRAINT_CATEGORIES: CategoryDefinition[] = [
         label: "allocate-public-ip",
         description:
           "Supplying this constraint will determine whether machines are issued an IP address accessible outside of the cloud’s virtual network",
-        valueType: "boolean",
+        valueType: ValueType.BOOLEAN,
         input: {
-          type: "select",
+          type: InputType.SELECT,
           options: [EMPTY_OPTION, ...BOOLEAN_OPTIONS],
         },
       },
@@ -62,7 +63,7 @@ export const CONSTRAINT_CATEGORIES: CategoryDefinition[] = [
         label: "arch",
         description: "CPU architecture (amd64, arm64, ppc64el, s390x, riscv64)",
         input: {
-          type: "select",
+          type: InputType.SELECT,
           options: [
             EMPTY_OPTION,
             { label: "amd64", value: "amd64" },
@@ -82,7 +83,7 @@ export const CONSTRAINT_CATEGORIES: CategoryDefinition[] = [
         description:
           "Indicates that a machine must be the specified container type",
         input: {
-          type: "select",
+          type: InputType.SELECT,
           options: [
             EMPTY_OPTION,
             { label: "LXD", value: "lxd" },

--- a/src/pages/AddModel/ConfigsConstraints/types.ts
+++ b/src/pages/AddModel/ConfigsConstraints/types.ts
@@ -54,13 +54,25 @@ export enum DisableType {
 
 export type ConfigFieldValue = boolean | number | string | undefined;
 
+export enum ValueType {
+  BOOLEAN = "boolean",
+  NUMBER = "number",
+}
+
+export enum InputType {
+  SELECT = "select",
+}
+
+export type CategoryDefinitionField = {
+  label: string;
+  description?: string;
+  defaultValue?: ConfigFieldValue;
+  input?: { type: InputType.SELECT } & SelectProps;
+  valueType?: ValueType;
+};
+
 export type CategoryDefinition = {
-  category: string;
-  fields: {
-    label: string;
-    description: string;
-    defaultValue?: ConfigFieldValue;
-    input?: { type: "select" } & SelectProps;
-    valueType?: "boolean" | "number";
-  }[];
+  // `null` indicates no meaningful grouping (e.g. schema data from the facade).
+  category: null | string;
+  fields: CategoryDefinitionField[];
 };

--- a/src/pages/AddModel/ConfigsConstraints/utils.test.ts
+++ b/src/pages/AddModel/ConfigsConstraints/utils.test.ts
@@ -1,5 +1,6 @@
 import { YAMLErrorType } from "./YAMLErrorsModal/types";
 import type { CategoryDefinition } from "./types";
+import { InputType, ValueType } from "./types";
 import {
   buildConfigsConstraintsPayload,
   buildYAML,
@@ -38,7 +39,7 @@ describe("utils", () => {
           {
             label: "cores",
             description: "Number of cores",
-            valueType: "number",
+            valueType: ValueType.NUMBER,
           },
         ],
       },
@@ -59,7 +60,7 @@ describe("utils", () => {
             label: "vpc-id-force",
             description: "VPC ID",
             defaultValue: false,
-            valueType: "boolean",
+            valueType: ValueType.BOOLEAN,
           },
         ],
       },
@@ -316,7 +317,7 @@ describe("utils", () => {
               label: "numeric-field",
               defaultValue: 17,
               description: "A numeric field",
-              valueType: "number",
+              valueType: ValueType.NUMBER,
             },
           ],
         },
@@ -355,10 +356,10 @@ describe("utils", () => {
 
       expect(result.length).toBeGreaterThan(0);
       const allDescriptions = result.flatMap((cat) =>
-        cat.fields.map((field) => field.description.toLowerCase()),
+        cat.fields.map((field) => field.description?.toLowerCase()),
       );
 
-      const hasMatch = allDescriptions.some((desc) => desc.includes("method"));
+      const hasMatch = allDescriptions.some((desc) => desc?.includes("method"));
       expect(hasMatch).toBe(true);
     });
 
@@ -378,7 +379,7 @@ describe("utils", () => {
         const hasMatch = category.fields.some(
           (field) =>
             field.label.toLowerCase().includes("network") ||
-            field.description.toLowerCase().includes("network"),
+            field.description?.toLowerCase().includes("network"),
         );
         expect(hasMatch).toBe(true);
       });
@@ -451,7 +452,7 @@ describe("utils", () => {
               label: "my-select",
               description: "A select field",
               input: {
-                type: "select",
+                type: InputType.SELECT,
                 options: [
                   { label: "A", value: "a" },
                   { label: "B", value: "b" },
@@ -491,9 +492,9 @@ describe("utils", () => {
               label: "my-bool",
               description: "A boolean field",
               defaultValue: "false",
-              valueType: "boolean",
+              valueType: ValueType.BOOLEAN,
               input: {
-                type: "select",
+                type: InputType.SELECT,
                 options: [
                   { label: "True", value: "true" },
                   { label: "False", value: "false" },
@@ -521,9 +522,9 @@ describe("utils", () => {
               label: "my-bool",
               description: "A boolean field",
               defaultValue: "false",
-              valueType: "boolean",
+              valueType: ValueType.BOOLEAN,
               input: {
-                type: "select",
+                type: InputType.SELECT,
                 options: [
                   { label: "True", value: "true" },
                   { label: "False", value: "false" },

--- a/src/pages/AddModel/ConfigsConstraints/utils.ts
+++ b/src/pages/AddModel/ConfigsConstraints/utils.ts
@@ -14,7 +14,12 @@ import {
 } from "./YAMLErrorsModal/types";
 import { CONFIG_CATEGORIES } from "./configCatalog";
 import { CONSTRAINT_CATEGORIES } from "./constraintsCatalog";
-import type { CategoryDefinition, ConfigFieldValue } from "./types";
+import type {
+  CategoryDefinition,
+  CategoryDefinitionField,
+  ConfigFieldValue,
+} from "./types";
+import { InputType, ValueType } from "./types";
 
 export const isConfigChanged = (
   label: string,
@@ -40,7 +45,7 @@ export const isConfigChanged = (
 export const getChangedFields = (
   category: CategoryDefinition,
   values: Record<string, ConfigFieldValue>,
-): CategoryDefinition["fields"] =>
+): CategoryDefinitionField[] =>
   category.fields.filter((field) =>
     isConfigChanged(field.label, values, field.defaultValue),
   );
@@ -48,7 +53,7 @@ export const getChangedFields = (
 export const getCategoriesWithVisibleFields = (
   categories: CategoryDefinition[],
   values: Record<string, ConfigFieldValue>,
-): Array<{ category: string; fields: CategoryDefinition["fields"] }> =>
+): CategoryDefinition[] =>
   categories
     .map((cat) => ({
       category: cat.category,
@@ -74,14 +79,16 @@ export const buildYAML = (
       // Coerce boolean string values to actual booleans so stringify
       // outputs them as unquoted true/false rather than quoted strings.
       const coerced =
-        field.valueType === "boolean"
+        field.valueType === ValueType.BOOLEAN
           ? value === "true" || value === true
           : value;
       const pair = doc.createPair(field.label, coerced);
       if (index === 0) {
         // Attach the category name as a comment before the first key in each
         // category. spaceBefore inserts a blank line between categories.
-        pair.key.commentBefore = ` ${category.category}`;
+        if (category.category) {
+          pair.key.commentBefore = ` ${category.category}`;
+        }
         pair.key.spaceBefore = map.items.length > 0;
       }
       map.add(pair);
@@ -135,7 +142,7 @@ export const filterCategoriesBySearch = (
       fields: category.fields.filter(
         (field) =>
           field.label.toLowerCase().includes(lowerQuery) ||
-          field.description.toLowerCase().includes(lowerQuery),
+          field.description?.toLowerCase().includes(lowerQuery),
       ),
     }))
     .filter((category) => category.fields.length > 0);
@@ -178,7 +185,7 @@ export function validateAndParseYAML(
       }
       return acc;
     },
-    {} as Record<string, CategoryDefinition["fields"][number]>,
+    {} as Record<string, CategoryDefinitionField>,
   );
 
   const validValues: Record<string, ConfigFieldValue> = {};
@@ -252,7 +259,7 @@ export function validateAndParseYAML(
 
       const { value } = pair.value;
 
-      if (field.valueType === "number") {
+      if (field.valueType === ValueType.NUMBER) {
         if (typeof value !== "number") {
           invalidValues.push({
             line,
@@ -264,7 +271,7 @@ export function validateAndParseYAML(
           continue;
         }
         validValues[key] = value;
-      } else if (field.valueType === "boolean") {
+      } else if (field.valueType === ValueType.BOOLEAN) {
         if (typeof value !== "boolean") {
           invalidValues.push({
             line,
@@ -279,7 +286,7 @@ export function validateAndParseYAML(
       } else {
         // Plain string field. For select fields, validate against allowed values.
         const stringValue = value?.toString();
-        if (field.input?.type === "select") {
+        if (field.input?.type === InputType.SELECT) {
           const allowedValues = (field.input.options ?? []).map(
             ({ value: optionValue }) => optionValue,
           );

--- a/src/pages/AddModel/utils.ts
+++ b/src/pages/AddModel/utils.ts
@@ -4,6 +4,7 @@ import { extractCloudName } from "store/juju/utils/models";
 
 import { CONFIG_CATEGORIES } from "./ConfigsConstraints/configCatalog";
 import { CONSTRAINT_CATEGORIES } from "./ConfigsConstraints/constraintsCatalog";
+import { ValueType } from "./ConfigsConstraints/types";
 import { Label } from "./types";
 
 export const getCredentialError = (cloud: unknown): string => {
@@ -18,7 +19,7 @@ export const getBooleanSchema = (): Record<string, Yup.BooleanSchema> =>
     Record<string, Yup.BooleanSchema>
   >((schemas, category) => {
     for (const field of category.fields) {
-      if (field.valueType === "boolean") {
+      if (field.valueType === ValueType.BOOLEAN) {
         schemas[field.label] = Yup.boolean();
       }
     }

--- a/src/store/middleware/source/util.test.ts
+++ b/src/store/middleware/source/util.test.ts
@@ -1,0 +1,144 @@
+import type { ModelDefaultsResult } from "@canonical/jujulib/dist/api/facades/model-manager/ModelManagerV11";
+
+import { BOOLEAN_OPTIONS, FALLBACK_CATEGORY } from "consts";
+import { modelConfigSchemaFieldFactory } from "testing/factories/juju/CloudV8";
+
+import { generateCategoryDefinitions } from "./util";
+
+describe("generateCategoryDefinitions", () => {
+  it("returns a single category with the FALLBACK_CATEGORY sentinel", () => {
+    const result = generateCategoryDefinitions({}, {});
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe(FALLBACK_CATEGORY);
+  });
+
+  it("returns an empty fields array for an empty schema", () => {
+    const result = generateCategoryDefinitions({}, {});
+    expect(result[0].fields).toHaveLength(0);
+  });
+
+  it("handles multiple fields in the schema", () => {
+    const config: ModelDefaultsResult["config"] = {
+      "default-space": { default: { value: "my-space" } },
+    };
+    const result = generateCategoryDefinitions(
+      {
+        "default-space": modelConfigSchemaFieldFactory.build({
+          type: "string",
+          description: "The default network space",
+        }),
+        "disable-network-management": modelConfigSchemaFieldFactory.build({
+          type: "bool",
+        }),
+        "net-bond-reconfigure-delay": modelConfigSchemaFieldFactory.build({
+          type: "int",
+        }),
+      },
+      config,
+    );
+    expect(result[0].fields).toHaveLength(3);
+    expect(result[0].fields[0].label).toBe("default-space");
+    expect(result[0].fields[0].description).toBe("The default network space");
+    expect(result[0].fields[0].defaultValue).toBe("my-space");
+    expect(result[0].fields[1].valueType).toBe("boolean");
+    expect(result[0].fields[2].valueType).toBe("number");
+  });
+
+  it("leaves defaultValue undefined when field has no default", () => {
+    const result = generateCategoryDefinitions(
+      { "default-space": modelConfigSchemaFieldFactory.build() },
+      {},
+    );
+    expect(result[0].fields[0].defaultValue).toBeUndefined();
+  });
+
+  it("prefers controller override over other defaults", () => {
+    const config: ModelDefaultsResult["config"] = {
+      "default-space": {
+        default: { value: "default-space" },
+        controller: { value: "controller-space" },
+        regions: [
+          { "region-name": "us-east-1", value: { value: "us-east-space" } },
+        ],
+      },
+    };
+    const result = generateCategoryDefinitions(
+      { "default-space": modelConfigSchemaFieldFactory.build() },
+      config,
+    );
+    expect(result[0].fields[0].defaultValue).toBe("controller-space");
+  });
+
+  it("applies region default when region is provided and controller defaults are absent", () => {
+    const config: ModelDefaultsResult["config"] = {
+      "default-space": {
+        default: { value: "global-default" },
+        regions: [
+          { "region-name": "us-east-1", value: { value: "us-east-space" } },
+        ],
+      },
+    };
+    const result = generateCategoryDefinitions(
+      { "default-space": modelConfigSchemaFieldFactory.build() },
+      config,
+      "us-east-1",
+    );
+    expect(result[0].fields[0].defaultValue).toBe("us-east-space");
+  });
+
+  it("falls back to juju-wide default when other defaults are absent", () => {
+    const result = generateCategoryDefinitions(
+      { "default-space": modelConfigSchemaFieldFactory.build() },
+      {
+        "default-space": {
+          default: { value: "global-default" },
+          regions: [
+            { "region-name": "us-east-1", value: { value: "us-east-space" } },
+          ],
+        },
+      },
+    );
+    expect(result[0].fields[0].defaultValue).toBe("global-default");
+  });
+
+  it("handles bool type properly", () => {
+    const result = generateCategoryDefinitions(
+      {
+        "disable-network-management": modelConfigSchemaFieldFactory.build({
+          type: "bool",
+        }),
+      },
+      {},
+    );
+    expect(result[0].fields[0].valueType).toBe("boolean");
+    expect(result[0].fields[0].input?.type).toBe("select");
+    expect(result[0].fields[0].input?.options).toEqual(BOOLEAN_OPTIONS);
+  });
+
+  it.each(["int", "float"])("handles %s type properly", (type) => {
+    const result = generateCategoryDefinitions(
+      { "some-field": modelConfigSchemaFieldFactory.build({ type }) },
+      {},
+    );
+    expect(result[0].fields[0].valueType).toBe("number");
+    expect(result[0].fields[0].input).toBeUndefined();
+  });
+
+  it("sets a select input with options when values are present", () => {
+    const result = generateCategoryDefinitions(
+      {
+        "firewall-mode": modelConfigSchemaFieldFactory.build({
+          type: "string",
+          values: ["instance", "global", "none"] as unknown as object[],
+        }),
+      },
+      {},
+    );
+    expect(result[0].fields[0].input?.type).toBe("select");
+    expect(result[0].fields[0].input?.options).toEqual([
+      { label: "instance", value: "instance" },
+      { label: "global", value: "global" },
+      { label: "none", value: "none" },
+    ]);
+  });
+});

--- a/src/store/middleware/source/util.test.ts
+++ b/src/store/middleware/source/util.test.ts
@@ -1,15 +1,16 @@
 import type { ModelDefaultsResult } from "@canonical/jujulib/dist/api/facades/model-manager/ModelManagerV11";
 
-import { BOOLEAN_OPTIONS, FALLBACK_CATEGORY } from "consts";
+import { BOOLEAN_OPTIONS } from "consts";
+import { InputType, ValueType } from "pages/AddModel/ConfigsConstraints/types";
 import { modelConfigSchemaFieldFactory } from "testing/factories/juju/CloudV8";
 
 import { generateCategoryDefinitions } from "./util";
 
 describe("generateCategoryDefinitions", () => {
-  it("returns a single category with the FALLBACK_CATEGORY sentinel", () => {
+  it("returns a single null category (no grouping)", () => {
     const result = generateCategoryDefinitions({}, {});
     expect(result).toHaveLength(1);
-    expect(result[0].category).toBe(FALLBACK_CATEGORY);
+    expect(result[0].category).toBeNull();
   });
 
   it("returns an empty fields array for an empty schema", () => {
@@ -40,8 +41,8 @@ describe("generateCategoryDefinitions", () => {
     expect(result[0].fields[0].label).toBe("default-space");
     expect(result[0].fields[0].description).toBe("The default network space");
     expect(result[0].fields[0].defaultValue).toBe("my-space");
-    expect(result[0].fields[1].valueType).toBe("boolean");
-    expect(result[0].fields[2].valueType).toBe("number");
+    expect(result[0].fields[1].valueType).toBe(ValueType.BOOLEAN);
+    expect(result[0].fields[2].valueType).toBe(ValueType.NUMBER);
   });
 
   it("leaves defaultValue undefined when field has no default", () => {
@@ -110,8 +111,8 @@ describe("generateCategoryDefinitions", () => {
       },
       {},
     );
-    expect(result[0].fields[0].valueType).toBe("boolean");
-    expect(result[0].fields[0].input?.type).toBe("select");
+    expect(result[0].fields[0].valueType).toBe(ValueType.BOOLEAN);
+    expect(result[0].fields[0].input?.type).toBe(InputType.SELECT);
     expect(result[0].fields[0].input?.options).toEqual(BOOLEAN_OPTIONS);
   });
 
@@ -120,7 +121,7 @@ describe("generateCategoryDefinitions", () => {
       { "some-field": modelConfigSchemaFieldFactory.build({ type }) },
       {},
     );
-    expect(result[0].fields[0].valueType).toBe("number");
+    expect(result[0].fields[0].valueType).toBe(ValueType.NUMBER);
     expect(result[0].fields[0].input).toBeUndefined();
   });
 
@@ -129,16 +130,36 @@ describe("generateCategoryDefinitions", () => {
       {
         "firewall-mode": modelConfigSchemaFieldFactory.build({
           type: "string",
+          // Values are typed as `object[]` by Juju but are plain primitives
+          //  at runtime, which is why we cast here to reflect the real shape.
           values: ["instance", "global", "none"] as unknown as object[],
         }),
       },
       {},
     );
-    expect(result[0].fields[0].input?.type).toBe("select");
+    expect(result[0].fields[0].input?.type).toBe(InputType.SELECT);
     expect(result[0].fields[0].input?.options).toEqual([
       { label: "instance", value: "instance" },
       { label: "global", value: "global" },
       { label: "none", value: "none" },
+    ]);
+  });
+
+  it("filters out values that do not match the declared field type", () => {
+    const result = generateCategoryDefinitions(
+      {
+        "firewall-mode": modelConfigSchemaFieldFactory.build({
+          type: "string",
+          // Values are typed as `object[]` by Juju but are plain primitives
+          //  at runtime, which is why we cast here to reflect the real shape.
+          values: ["instance", 42, null, "global"] as unknown as object[],
+        }),
+      },
+      {},
+    );
+    expect(result[0].fields[0].input?.options).toEqual([
+      { label: "instance", value: "instance" },
+      { label: "global", value: "global" },
     ]);
   });
 });

--- a/src/store/middleware/source/util.ts
+++ b/src/store/middleware/source/util.ts
@@ -1,0 +1,80 @@
+import type { ModelConfigSchemaResult } from "@canonical/jujulib/dist/api/facades/cloud/CloudV8";
+import type { ModelDefaultsResult } from "@canonical/jujulib/dist/api/facades/model-manager/ModelManagerV11";
+
+import { BOOLEAN_OPTIONS, FALLBACK_CATEGORY } from "consts";
+import type {
+  CategoryDefinition,
+  ConfigFieldValue,
+} from "pages/AddModel/ConfigsConstraints/types";
+
+/**
+  AdditionalProperties is a single-key object where the key name is
+  arbitrary — the actual value is always the first (and only) entry.
+  Applies the priority hierarchy: controller > region (if known) > juju default.
+*/
+const resolveFieldDefault = (
+  defaults: ModelDefaultsResult["config"][string] = {},
+  selectedRegion?: string,
+): ConfigFieldValue => {
+  const { controller, regions, default: jujuDefaults } = defaults;
+
+  if (controller) {
+    return Object.values(controller)[0] as ConfigFieldValue;
+  }
+
+  if (selectedRegion && regions) {
+    const regionDefaults = regions.find(
+      (region) => region["region-name"] === selectedRegion,
+    )?.value;
+    if (regionDefaults) {
+      return Object.values(regionDefaults)[0] as ConfigFieldValue;
+    }
+  }
+
+  return Object.values(jujuDefaults ?? {})[0] as ConfigFieldValue;
+};
+
+/**
+  Converts modelConfigSchema and modelDefaultsForClouds API responses into a
+  CategoryDefinition array.
+*/
+export const generateCategoryDefinitions = (
+  schema: ModelConfigSchemaResult["schema"],
+  defaultsConfig: ModelDefaultsResult["config"],
+  selectedRegion?: string,
+): CategoryDefinition[] => {
+  const fields: CategoryDefinition["fields"] = Object.entries(schema ?? {}).map(
+    ([label, field]) => {
+      const isNumeric = field.type === "int" || field.type === "float";
+      const fieldValues = field.values ?? [];
+
+      const entry: CategoryDefinition["fields"][number] = {
+        label,
+        description: field.description ?? "",
+        defaultValue: resolveFieldDefault(
+          defaultsConfig[label],
+          selectedRegion,
+        ),
+      };
+
+      if (field.type === "bool") {
+        entry.valueType = "boolean";
+        entry.input = { type: "select", options: BOOLEAN_OPTIONS };
+      } else if (isNumeric) {
+        entry.valueType = "number";
+      } else if (fieldValues.length > 0) {
+        entry.input = {
+          type: "select",
+          options: fieldValues.map((fieldValue) => ({
+            label: `${fieldValue}`,
+            value: `${fieldValue}`,
+          })),
+        };
+      }
+
+      return entry;
+    },
+  );
+
+  return [{ category: FALLBACK_CATEGORY, fields }];
+};

--- a/src/store/middleware/source/util.ts
+++ b/src/store/middleware/source/util.ts
@@ -1,11 +1,16 @@
 import type { ModelConfigSchemaResult } from "@canonical/jujulib/dist/api/facades/cloud/CloudV8";
-import type { ModelDefaultsResult } from "@canonical/jujulib/dist/api/facades/model-manager/ModelManagerV11";
+import type {
+  ModelDefaults,
+  ModelDefaultsResult,
+} from "@canonical/jujulib/dist/api/facades/model-manager/ModelManagerV11";
 
-import { BOOLEAN_OPTIONS, FALLBACK_CATEGORY } from "consts";
+import { BOOLEAN_OPTIONS } from "consts";
 import type {
   CategoryDefinition,
+  CategoryDefinitionField,
   ConfigFieldValue,
 } from "pages/AddModel/ConfigsConstraints/types";
+import { InputType, ValueType } from "pages/AddModel/ConfigsConstraints/types";
 
 /**
   AdditionalProperties is a single-key object where the key name is
@@ -13,13 +18,19 @@ import type {
   Applies the priority hierarchy: controller > region (if known) > juju default.
 */
 const resolveFieldDefault = (
-  defaults: ModelDefaultsResult["config"][string] = {},
+  // `ModelDefaultsResult["config"]` is a `Record<string, ModelDefaults>`, so
+  // a lookup by key is typed as `ModelDefaults` but may be `undefined` at runtime.
+  defaults?: ModelDefaults,
   selectedRegion?: string,
 ): ConfigFieldValue => {
+  if (!defaults) {
+    return undefined;
+  }
+
   const { controller, regions, default: jujuDefaults } = defaults;
 
   if (controller) {
-    return Object.values(controller)[0] as ConfigFieldValue;
+    return Object.values(controller)[0];
   }
 
   if (selectedRegion && regions) {
@@ -27,11 +38,11 @@ const resolveFieldDefault = (
       (region) => region["region-name"] === selectedRegion,
     )?.value;
     if (regionDefaults) {
-      return Object.values(regionDefaults)[0] as ConfigFieldValue;
+      return Object.values(regionDefaults)[0];
     }
   }
 
-  return Object.values(jujuDefaults ?? {})[0] as ConfigFieldValue;
+  return Object.values(jujuDefaults ?? {})[0];
 };
 
 /**
@@ -43,14 +54,21 @@ export const generateCategoryDefinitions = (
   defaultsConfig: ModelDefaultsResult["config"],
   selectedRegion?: string,
 ): CategoryDefinition[] => {
-  const fields: CategoryDefinition["fields"] = Object.entries(schema ?? {}).map(
+  const fields: CategoryDefinitionField[] = Object.entries(schema ?? {}).map(
     ([label, field]) => {
       const isNumeric = field.type === "int" || field.type === "float";
-      const fieldValues = field.values ?? [];
 
-      const entry: CategoryDefinition["fields"][number] = {
+      // The response schema types `values` as `object[]`, but the underlying
+      //  Go type is `[]any` which serializes enum values as primitives on
+      //  the wire. We validate each entry matches the declared field type
+      //  to guard against unexpected API responses.
+      const fieldValues = (field.values ?? []).filter(
+        (fieldValue) => typeof fieldValue === field.type,
+      );
+
+      const entry: CategoryDefinitionField = {
         label,
-        description: field.description ?? "",
+        description: field.description,
         defaultValue: resolveFieldDefault(
           defaultsConfig[label],
           selectedRegion,
@@ -58,13 +76,13 @@ export const generateCategoryDefinitions = (
       };
 
       if (field.type === "bool") {
-        entry.valueType = "boolean";
-        entry.input = { type: "select", options: BOOLEAN_OPTIONS };
+        entry.valueType = ValueType.BOOLEAN;
+        entry.input = { type: InputType.SELECT, options: BOOLEAN_OPTIONS };
       } else if (isNumeric) {
-        entry.valueType = "number";
+        entry.valueType = ValueType.NUMBER;
       } else if (fieldValues.length > 0) {
         entry.input = {
-          type: "select",
+          type: InputType.SELECT,
           options: fieldValues.map((fieldValue) => ({
             label: `${fieldValue}`,
             value: `${fieldValue}`,
@@ -76,5 +94,5 @@ export const generateCategoryDefinitions = (
     },
   );
 
-  return [{ category: FALLBACK_CATEGORY, fields }];
+  return [{ category: null, fields }];
 };

--- a/src/testing/factories/juju/CloudV8.ts
+++ b/src/testing/factories/juju/CloudV8.ts
@@ -1,0 +1,8 @@
+import type { ModelConfigSchemaField } from "@canonical/jujulib/dist/api/facades/cloud/CloudV8";
+import { Factory } from "fishery";
+
+export const modelConfigSchemaFieldFactory =
+  Factory.define<ModelConfigSchemaField>(() => ({
+    description: "",
+    type: "string",
+  }));

--- a/yarn.lock
+++ b/yarn.lock
@@ -236,15 +236,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@canonical/jujulib@npm:9.0.0":
-  version: 9.0.0
-  resolution: "@canonical/jujulib@npm:9.0.0"
+"@canonical/jujulib@npm:9.1.0":
+  version: 9.1.0
+  resolution: "@canonical/jujulib@npm:9.1.0"
   dependencies:
     "@canonical/macaroon-bakery": "npm:1.3.2"
     btoa: "npm:1.2.1"
     websocket: "npm:1.0.34"
     xhr2: "npm:0.2.1"
-  checksum: 10c0/f8f93231924d136c69d018ac6b200bc9a785b22628be042c568583120a8570c187ce9893d84b49ba750dd9498078dfbab551b0ff9620d31effd008a1e140dfba
+  checksum: 10c0/99306bdc7811060556145ac1e953e571fd091a5824ced35ab84467e173d59c4a414dfa3ee89793cc051891c380c1277680841677422d0632450f0c4bbdf5f422
   languageName: node
   linkType: hard
 
@@ -9073,7 +9073,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "juju-dashboard@workspace:."
   dependencies:
-    "@canonical/jujulib": "npm:9.0.0"
+    "@canonical/jujulib": "npm:9.1.0"
     "@canonical/macaroon-bakery": "npm:1.3.2"
     "@canonical/react-components": "npm:4.6.0"
     "@canonical/rebac-admin": "npm:0.0.1-alpha.12"


### PR DESCRIPTION
## Done
- Bumped `@canonical/jujulib` to latest version
- Added two utilities:
  - `resolveFieldDefault` - which resolves a field's default value based on the hierarchy `controller > region (if known) > juju default`
  - `generateCategoryDefinitions` - which takes both the schema and the defaults returned by the facade methods (yet to introduce) and normalises their responses into a single `CategoryDefinition[]` which can be used by the UI allowing for easier switching between static and dynamic states.

## Details
https://warthogs.atlassian.net/browse/JUJU-10097
