### PR TITLE
feat: add preset-defaults middleware

### DIFF
--- a/src/juju/types.ts
+++ b/src/juju/types.ts
@@ -8,6 +8,7 @@ import type CharmsV6 from "@canonical/jujulib/dist/api/facades/charms/CharmsV6";
 import type ClientV8 from "@canonical/jujulib/dist/api/facades/client/ClientV8";
 import type { FullStatus } from "@canonical/jujulib/dist/api/facades/client/ClientV8";
 import type CloudV7 from "@canonical/jujulib/dist/api/facades/cloud/CloudV7";
+import type CloudV8 from "@canonical/jujulib/dist/api/facades/cloud/CloudV8";
 import type ControllerV12 from "@canonical/jujulib/dist/api/facades/controller/ControllerV12";
 import type ModelManagerV10 from "@canonical/jujulib/dist/api/facades/model-manager/ModelManagerV10";
 import type {
@@ -48,7 +49,7 @@ export type Facades = {
   block?: BlockV2;
   charms?: CharmsV6;
   client?: ClientV8;
-  cloud?: CloudV7;
+  cloud?: CloudV7 | CloudV8;
   controller?: ControllerV12;
   modelManager?: ModelManagerV10 | ModelManagerV11;
   modelUpgrader?: ModelUpgraderV1;

--- a/src/pages/AddModel/ConfigsConstraints/types.ts
+++ b/src/pages/AddModel/ConfigsConstraints/types.ts
@@ -1,6 +1,14 @@
-import type { SelectProps } from "@canonical/react-components";
+import type { DisableType } from "store/juju/types";
 
 import type { InputMode } from "../types";
+
+export type {
+  CategoryDefinition,
+  CategoryDefinitionField,
+  ConfigFieldValue,
+} from "store/middleware/source/types";
+export { InputType, ValueType } from "store/middleware/source/types";
+export { DisableType } from "store/juju/types";
 
 export enum TestId {
   CONFIGS_CONSTRAINTS_FORM = "configs-constraints-form",
@@ -43,36 +51,4 @@ export type FormFields = {
   [FieldName.CONFIG_YAML]: string;
   [FieldName.CONSTRAINT_YAML]: string;
   [FieldName.DISABLED_COMMANDS]: DisableType;
-};
-
-export enum DisableType {
-  NONE = "none",
-  DESTROY_MODEL = "BlockDestroy",
-  REMOVE_OBJECT = "BlockRemove",
-  ALL = "BlockChange",
-}
-
-export type ConfigFieldValue = boolean | number | string | undefined;
-
-export enum ValueType {
-  BOOLEAN = "boolean",
-  NUMBER = "number",
-}
-
-export enum InputType {
-  SELECT = "select",
-}
-
-export type CategoryDefinitionField = {
-  label: string;
-  description?: string;
-  defaultValue?: ConfigFieldValue;
-  input?: { type: InputType.SELECT } & SelectProps;
-  valueType?: ValueType;
-};
-
-export type CategoryDefinition = {
-  // `null` indicates no meaningful grouping (e.g. schema data from the facade).
-  category: null | string;
-  fields: CategoryDefinitionField[];
 };

--- a/src/pages/AddModel/ConfigsConstraints/utils.ts
+++ b/src/pages/AddModel/ConfigsConstraints/utils.ts
@@ -290,7 +290,10 @@ export function validateAndParseYAML(
           const allowedValues = (field.input.options ?? []).map(
             ({ value: optionValue }) => optionValue,
           );
-          if (!allowedValues.includes(stringValue)) {
+          if (
+            stringValue === undefined ||
+            !allowedValues.includes(stringValue)
+          ) {
             invalidValues.push({
               line,
               message: getYAMLErrorMessage(YAMLErrorType.INVALID_VALUES, {

--- a/src/store/juju/slice.ts
+++ b/src/store/juju/slice.ts
@@ -22,6 +22,7 @@ import type {
   ModelInfoResults,
   UserModelList,
 } from "juju/types";
+import type { CategoryDefinition } from "store/middleware/source/types";
 
 import type {
   Controllers,
@@ -148,6 +149,11 @@ const slice = createSlice({
     },
     userCredentials: {
       credentials: {},
+      errors: null,
+      loading: false,
+    },
+    modelConfigDefaults: {
+      defaults: {},
       errors: null,
       loading: false,
     },
@@ -781,6 +787,25 @@ const slice = createSlice({
       value.loading = payload.update.loading ?? value.loading;
       if (payload.update.data !== undefined) {
         value.clouds = payload.update.data;
+      }
+      if (payload.update.error !== undefined) {
+        value.errors = payload.update.error;
+      }
+    },
+    updateModelConfigDefaults: (
+      state,
+      {
+        payload,
+      }: PayloadAction<{
+        providerType: string;
+        update: Partial<SourceData<CategoryDefinition[]>>;
+      }>,
+    ) => {
+      const value = state.modelConfigDefaults;
+
+      value.loading = payload.update.loading ?? value.loading;
+      if (payload.update.data !== undefined && payload.update.data !== null) {
+        value.defaults[payload.providerType] = payload.update.data;
       }
       if (payload.update.error !== undefined) {
         value.errors = payload.update.error;

--- a/src/store/juju/types.ts
+++ b/src/store/juju/types.ts
@@ -19,10 +19,17 @@ import type {
   VersionElem,
 } from "juju/jimm/JIMMV4";
 import type { FullStatusWithAnnotations, ModelInfo } from "juju/types";
-import type { DisableType } from "pages/AddModel/ConfigsConstraints/types";
 import type { ProcessOutcome } from "store/middleware/process";
+import type { CategoryDefinition } from "store/middleware/source/types";
 import type { GenericItemsState, GenericState } from "store/types";
 import type { AccessLevel } from "types";
+
+export enum DisableType {
+  NONE = "none",
+  DESTROY_MODEL = "BlockDestroy",
+  REMOVE_OBJECT = "BlockRemove",
+  ALL = "BlockChange",
+}
 
 /**
  * Data derived from a `Source`.
@@ -153,6 +160,12 @@ export type SupportedJujuVersionsState = SourceData<VersionElem[]>;
 
 export type ModelMigrationTargetsState = Record<string, SourceData<string[]>>;
 
+export type ModelConfigDefaultsState = {
+  errors: null | string | unknown;
+  loading: boolean;
+  defaults: Record<string, CategoryDefinition[]>;
+};
+
 export type AddModel = {
   modelName: string;
   credential: string;
@@ -203,6 +216,7 @@ export type JujuState = {
   secrets: SecretsState;
   cloudInfo: CloudState;
   userCredentials: UserCredentialsState;
+  modelConfigDefaults: ModelConfigDefaultsState;
   selectedApplications: Record<string, ApplicationStatus>;
   supportedJujuVersions: SupportedJujuVersionsState;
   addModelState: AddModelState;

--- a/src/store/middleware/model-poller.ts
+++ b/src/store/middleware/model-poller.ts
@@ -14,7 +14,6 @@ import {
   findAuditEvents,
 } from "juju/jimm/api";
 import type { DestroyModelErrors } from "juju/types";
-import { DisableType } from "pages/AddModel/ConfigsConstraints/types";
 import { actions as appActions, thunks as appThunks } from "store/app";
 import { updateModelStatuses } from "store/app/actions";
 import { actions as generalActions } from "store/general";
@@ -22,7 +21,7 @@ import { isLoggedIn } from "store/general/selectors";
 import { actions as jujuActions } from "store/juju";
 import { getDestructionState, getModelList } from "store/juju/selectors";
 import { addControllerCloudRegion } from "store/juju/thunks";
-import type { ModelDestructionParams } from "store/juju/types";
+import { type ModelDestructionParams, DisableType } from "store/juju/types";
 import type { RootState, Store } from "store/store";
 import { AccessLevel, isSpecificAction } from "types";
 import { getUserName, toErrorString } from "utils";

--- a/src/store/middleware/source/index.ts
+++ b/src/store/middleware/source/index.ts
@@ -8,6 +8,7 @@ import createMiddleware from "../source-middleware";
 import cloudInfo from "./cloud-info";
 import jimmSupportedVersions from "./jimm-supported-versions";
 import migrationTargets from "./migration-targets";
+import modelConfigDefaults from "./model-config-defaults";
 import modelList from "./model-list";
 import userCredentials from "./user-credentials";
 
@@ -22,5 +23,6 @@ export default function createSourceMiddleware(): Middleware<
     migrationTargets as SourceInstance<unknown, unknown>,
     userCredentials as SourceInstance<unknown, unknown>,
     cloudInfo as SourceInstance<unknown, unknown>,
+    modelConfigDefaults as SourceInstance<unknown, unknown>,
   ]);
 }

--- a/src/store/middleware/source/model-config-defaults.test.ts
+++ b/src/store/middleware/source/model-config-defaults.test.ts
@@ -1,0 +1,159 @@
+import type { MockInstance } from "vitest";
+
+import type { ConnectionWithFacades } from "juju/types";
+import { modelConfigSchemaFieldFactory } from "testing/factories/juju/CloudV8";
+
+import middleware, { getModelConfigDefaults } from "./model-config-defaults";
+
+describe("getModelConfigDefaults", () => {
+  let connection: ConnectionWithFacades;
+  let mockModelDefaultsForClouds: MockInstance;
+  let mockModelConfigSchema: MockInstance;
+
+  beforeEach(() => {
+    mockModelDefaultsForClouds = vi.fn().mockResolvedValue({ results: [] });
+    mockModelConfigSchema = vi.fn().mockResolvedValue({ schema: undefined });
+    connection = {
+      facades: {
+        modelManager: {
+          modelDefaultsForClouds: mockModelDefaultsForClouds,
+        },
+        cloud: {
+          modelConfigSchema: mockModelConfigSchema,
+        },
+      },
+    } as unknown as ConnectionWithFacades;
+    vi.useFakeTimers();
+  });
+
+  it("calls both facades in parallel when schema is available", async ({
+    expect,
+  }) => {
+    await getModelConfigDefaults(connection, "cloud-aws", "ec2");
+    expect(mockModelDefaultsForClouds).toHaveBeenCalledExactlyOnceWith({
+      entities: [{ tag: "cloud-aws" }],
+    });
+    expect(mockModelConfigSchema).toHaveBeenCalledExactlyOnceWith({
+      "provider-type": "ec2",
+    });
+  });
+
+  it("returns an empty array and skips both calls when modelConfigSchema is not available on the facade", async ({
+    expect,
+  }) => {
+    connection = {
+      ...connection,
+      facades: { ...connection.facades, cloud: {} },
+    } as unknown as ConnectionWithFacades;
+    const result = await getModelConfigDefaults(connection, "cloud-aws", "ec2");
+    expect(result).toStrictEqual([]);
+    expect(mockModelDefaultsForClouds).not.toHaveBeenCalled();
+    expect(mockModelConfigSchema).not.toHaveBeenCalled();
+  });
+
+  it("returns category definitions combining schema and defaults", async ({
+    expect,
+  }) => {
+    mockModelDefaultsForClouds.mockResolvedValue({
+      results: [
+        {
+          config: {
+            "default-space": { default: { value: "my-space" } },
+          },
+        },
+      ],
+    });
+    mockModelConfigSchema.mockResolvedValue({
+      schema: {
+        "default-space": modelConfigSchemaFieldFactory.build({
+          type: "string",
+          description: "The default network space",
+        }),
+      },
+    });
+
+    const result = await getModelConfigDefaults(connection, "cloud-aws", "ec2");
+    expect(result).toHaveLength(1);
+    expect(result[0].fields).toHaveLength(1);
+    expect(result[0].fields[0]).toMatchObject({
+      label: "default-space",
+      description: "The default network space",
+      defaultValue: "my-space",
+    });
+  });
+
+  it("passes the selected region through to generateCategoryDefinitions", async ({
+    expect,
+  }) => {
+    mockModelDefaultsForClouds.mockResolvedValue({
+      results: [
+        {
+          config: {
+            "default-space": {
+              regions: [
+                {
+                  "region-name": "us-east-1",
+                  value: { value: "region-space" },
+                },
+              ],
+            },
+          },
+        },
+      ],
+    });
+    mockModelConfigSchema.mockResolvedValue({
+      schema: {
+        "default-space": modelConfigSchemaFieldFactory.build({
+          type: "string",
+        }),
+      },
+    });
+
+    const result = await getModelConfigDefaults(
+      connection,
+      "cloud-aws",
+      "ec2",
+      "us-east-1",
+    );
+    expect(result[0].fields[0].defaultValue).toBe("region-space");
+  });
+
+  it("throws a combined error if both calls fail", async ({ expect }) => {
+    mockModelDefaultsForClouds.mockRejectedValue("defaults error");
+    mockModelConfigSchema.mockRejectedValue("schema error");
+    await expect(
+      getModelConfigDefaults(connection, "cloud-aws", "ec2"),
+    ).rejects.toThrow(
+      "Failed to fetch model config defaults and schema: defaults error; schema error",
+    );
+  });
+
+  it("throws if only the defaults call fails", async ({ expect }) => {
+    mockModelDefaultsForClouds.mockRejectedValue("defaults error");
+    await expect(
+      getModelConfigDefaults(connection, "cloud-aws", "ec2"),
+    ).rejects.toThrow("Failed to fetch model config defaults: defaults error");
+  });
+
+  it("throws if only the schema call fails", async ({ expect }) => {
+    mockModelConfigSchema.mockRejectedValue("schema error");
+    await expect(
+      getModelConfigDefaults(connection, "cloud-aws", "ec2"),
+    ).rejects.toThrow("Failed to fetch model config schema: schema error");
+  });
+
+  describe("actions", () => {
+    it("start action includes `withConnection`", ({ expect }) => {
+      const action = middleware.actions.start({
+        wsControllerURL: "wss://example.com",
+        cloudTag: "cloud-aws",
+        providerType: "ec2",
+      });
+      expect(action).toEqual(
+        expect.objectContaining({
+          meta: { withConnection: true },
+        }),
+      );
+    });
+  });
+});

--- a/src/store/middleware/source/model-config-defaults.ts
+++ b/src/store/middleware/source/model-config-defaults.ts
@@ -1,0 +1,126 @@
+import { createPollingSource } from "data/pollingSource";
+import type { ConnectionWithFacades } from "juju/types";
+import { actions as jujuActions } from "store/juju";
+import { toSerializableSourceError } from "store/util";
+
+import { hasConnections } from "../connection/util";
+import { createSourceInstance } from "../source-middleware";
+
+import type { CategoryDefinition } from "./types";
+import { generateCategoryDefinitions } from "./util";
+
+export const NOT_AUTHENTICATED_ERROR = "not authenticated with controller";
+export const NO_MODEL_MANAGER_FACADE =
+  "ModelManager facade is not available on the connection";
+export const NO_CLOUD_FACADE =
+  "Cloud facade is not available on the connection";
+
+export async function getModelConfigDefaults(
+  connection: ConnectionWithFacades,
+  cloudTag: string,
+  providerType: string,
+  selectedRegion?: string,
+): Promise<CategoryDefinition[]> {
+  if (!connection.facades.modelManager) {
+    throw new Error(NO_MODEL_MANAGER_FACADE);
+  }
+  if (!connection.facades.cloud) {
+    throw new Error(NO_CLOUD_FACADE);
+  }
+
+  // modelConfigSchema is only available on CloudV8 (Juju >= 4.0.12).
+  // Skip both calls if the schema method is unavailable — the UI will fall
+  // back to the static catalog. A follow-up PR will handle the defaults-only
+  // path for older Juju versions.
+  if (!("modelConfigSchema" in connection.facades.cloud)) {
+    return [];
+  }
+
+  const [defaultsResult, schemaResult] = await Promise.allSettled([
+    connection.facades.modelManager.modelDefaultsForClouds({
+      entities: [{ tag: cloudTag }],
+    }),
+    connection.facades.cloud.modelConfigSchema({
+      "provider-type": providerType,
+    }),
+  ]);
+
+  if (
+    defaultsResult.status === "rejected" &&
+    schemaResult.status === "rejected"
+  ) {
+    throw new Error(
+      `Failed to fetch model config defaults and schema: ${defaultsResult.reason}; ${schemaResult.reason}`,
+    );
+  }
+  if (defaultsResult.status === "rejected") {
+    throw new Error(
+      `Failed to fetch model config defaults: ${defaultsResult.reason}`,
+    );
+  }
+  if (schemaResult.status === "rejected") {
+    throw new Error(
+      `Failed to fetch model config schema: ${schemaResult.reason}`,
+    );
+  }
+
+  return generateCategoryDefinitions(
+    schemaResult.value.schema,
+    defaultsResult.value.results[0]?.config,
+    selectedRegion,
+  );
+}
+
+export default createSourceInstance<
+  {
+    wsControllerURL: string;
+    cloudTag: string;
+    providerType: string;
+    selectedRegion?: string;
+  },
+  CategoryDefinition[]
+>(
+  "model-config-defaults",
+  ({ wsControllerURL: _, cloudTag, providerType, selectedRegion, meta }) => {
+    if (!hasConnections(meta, ["wsControllerURL"])) {
+      throw new Error("connection not provided");
+    }
+
+    const connection = meta.connections.wsControllerURL;
+
+    if (!connection?.info.user?.identity) {
+      throw new Error(NOT_AUTHENTICATED_ERROR);
+    }
+
+    return createPollingSource(
+      async () =>
+        getModelConfigDefaults(
+          connection,
+          cloudTag,
+          providerType,
+          selectedRegion,
+        ),
+      { interval: { seconds: 300 } },
+    );
+  },
+  {
+    setData: ({ providerType }, data) =>
+      jujuActions.updateModelConfigDefaults({
+        providerType,
+        update: { data },
+      }),
+    setError: ({ providerType }, error) =>
+      jujuActions.updateModelConfigDefaults({
+        providerType,
+        update: { error: toSerializableSourceError(error) },
+      }),
+    setLoading: ({ providerType }, loading) =>
+      jujuActions.updateModelConfigDefaults({
+        providerType,
+        update: { loading },
+      }),
+  },
+  {
+    addActionMeta: (_payload) => ({ withConnection: true }),
+  },
+);

--- a/src/store/middleware/source/types.ts
+++ b/src/store/middleware/source/types.ts
@@ -1,0 +1,26 @@
+export type ConfigFieldValue = boolean | number | string | undefined;
+
+export type SelectOption = { label: string; value: string };
+
+export enum ValueType {
+  BOOLEAN = "boolean",
+  NUMBER = "number",
+}
+
+export enum InputType {
+  SELECT = "select",
+}
+
+export type CategoryDefinitionField = {
+  label: string;
+  description?: string;
+  defaultValue?: ConfigFieldValue;
+  input?: { type: InputType.SELECT; options: SelectOption[] };
+  valueType?: ValueType;
+};
+
+export type CategoryDefinition = {
+  // `null` indicates no meaningful grouping (e.g. schema data from the facade).
+  category: null | string;
+  fields: CategoryDefinitionField[];
+};

--- a/src/store/middleware/source/util.ts
+++ b/src/store/middleware/source/util.ts
@@ -5,12 +5,14 @@ import type {
 } from "@canonical/jujulib/dist/api/facades/model-manager/ModelManagerV11";
 
 import { BOOLEAN_OPTIONS } from "consts";
-import type {
-  CategoryDefinition,
-  CategoryDefinitionField,
-  ConfigFieldValue,
-} from "pages/AddModel/ConfigsConstraints/types";
-import { InputType, ValueType } from "pages/AddModel/ConfigsConstraints/types";
+
+import {
+  type CategoryDefinition,
+  type CategoryDefinitionField,
+  type ConfigFieldValue,
+  InputType,
+  ValueType,
+} from "./types";
 
 /**
   AdditionalProperties is a single-key object where the key name is

--- a/src/testing/factories/juju/juju.ts
+++ b/src/testing/factories/juju/juju.ts
@@ -11,6 +11,7 @@ import type {
   CrossModelQueryState,
   HistoryItem,
   JujuState,
+  ModelConfigDefaultsState,
   ModelData,
   ModelFeatures,
   ModelFeaturesState,
@@ -131,6 +132,13 @@ export const cloudInfoStateFactory = Factory.define<CloudState>(() => ({
   loading: false,
 }));
 
+export const modelConfigDefaultsStateFactory =
+  Factory.define<ModelConfigDefaultsState>(() => ({
+    defaults: {},
+    errors: null,
+    loading: false,
+  }));
+
 export const addModelStateFactory = Factory.define<AddModelState>(() => ({
   loaded: false,
   loading: false,
@@ -187,6 +195,7 @@ export const jujuStateFactory = Factory.define<JujuState>(() => ({
   secrets: {},
   cloudInfo: cloudInfoStateFactory.build(),
   userCredentials: userCredentialsStateFactory.build(),
+  modelConfigDefaults: modelConfigDefaultsStateFactory.build(),
   selectedApplications: {},
   supportedJujuVersions: supportedJujuVersionsStateFactory.build(),
   modelMigrationTargets: modelMigrationTargetsStateFactory.build(),


### PR DESCRIPTION
## Done

- Added `model-config-defaults` source which calls both `modelDefaultsForClouds` and `modelConfigSchema` methods
- It leverages the normalisation util `generateCategoryDefinitions` to consolidate the responses from both into `CategoryDefinition[]` for the UI
- The UI is currently NOT wired to this middleware
- Moved types around so that the middleware is not importing from the UI 

## Details
https://warthogs.atlassian.net/browse/JUJU-10099

