### PR TITLE
feat: create `InlineCheckbox`

### DIFF
--- a/src/components/InlineCheckbox/InlineCheckbox.test.tsx
+++ b/src/components/InlineCheckbox/InlineCheckbox.test.tsx
@@ -1,0 +1,35 @@
+import { render } from "@testing-library/react";
+
+import InlineCheckbox from "./InlineCheckbox";
+
+describe("InlineCheckbox", () => {
+  it("renders with label", async ({ expect }) => {
+    const result = render(<InlineCheckbox label="some label" />);
+    await expect(result.findByLabelText("some label")).resolves.toHaveRole(
+      "checkbox",
+    );
+  });
+
+  it("has indeterminate state", async ({ expect }) => {
+    const result = render(<InlineCheckbox label="some label" indeterminate />);
+    await expect(result.findByRole("checkbox")).resolves.toBePartiallyChecked();
+  });
+
+  it("has checked state", async ({ expect }) => {
+    const result = render(
+      <InlineCheckbox label="some label" checked readOnly />,
+    );
+    await expect(result.findByRole("checkbox")).resolves.toBeChecked();
+  });
+
+  it("rerenders with states", async ({ expect }) => {
+    const result = render(
+      <InlineCheckbox label="some label" checked readOnly />,
+    );
+    await expect(result.findByRole("checkbox")).resolves.toBeChecked();
+    result.rerender(
+      <InlineCheckbox label="some label" indeterminate checked={false} />,
+    );
+    await expect(result.findByRole("checkbox")).resolves.toBePartiallyChecked();
+  });
+});

--- a/src/components/InlineCheckbox/InlineCheckbox.tsx
+++ b/src/components/InlineCheckbox/InlineCheckbox.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useRef, type HTMLProps, type JSX } from "react";
+
+/**
+ * An inline checkbox which does not have a label associated with it. Do not use unless you know
+ * you should.
+ *
+ * Based on the Vanilla checkbox, but removes the padding adjacent to the label.
+ *
+ * @link https://vanillaframework.io/docs/base/forms#checkbox
+ */
+export default function InlineCheckbox<L extends string>({
+  indeterminate,
+  label,
+  ...props
+}: {
+  /**
+   * If `true`, the checkbox will present an indeterminate state.
+   */
+  indeterminate?: boolean;
+  /**
+   * Aria label to announce the checkbox. This must be included for accessibility, and cannot be
+   * an empty string.
+   */
+  label: L extends "" ? never : L;
+} & HTMLProps<HTMLInputElement>): JSX.Element {
+  const input = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (input.current === null || indeterminate === undefined) {
+      return;
+    }
+    input.current.indeterminate = indeterminate;
+  }, [indeterminate]);
+
+  return (
+    <label className="p-checkbox">
+      <input
+        {...props}
+        ref={input}
+        type="checkbox"
+        className="p-checkbox__input"
+        aria-label={label}
+      />
+      <span className="p-checkbox__label" style={{ paddingLeft: 0 }}></span>
+    </label>
+  );
+}

--- a/src/components/InlineCheckbox/index.ts
+++ b/src/components/InlineCheckbox/index.ts
@@ -1,0 +1,3 @@
+import InlineCheckbox from "./InlineCheckbox";
+
+export default InlineCheckbox;


### PR DESCRIPTION
Create an `InlineCheckbox` component, which is based on the Vanilla checkbox, however it does not contain any text on screen (instead relying on `aria-label` to describe functionality). 

This component is needed for the new `DataTable` component (#2391) to display checkboxes in the table rows.