### PR TITLE
feat: create `Table` components

### DIFF
--- a/src/components/Table/Body.tsx
+++ b/src/components/Table/Body.tsx
@@ -1,0 +1,11 @@
+import type { HTMLProps, JSX, ReactNode } from "react";
+
+/**
+ * Body of a table, containing the data.
+ */
+export default function TableBody({
+  children,
+  ...props
+}: { children?: ReactNode } & HTMLProps<HTMLTableSectionElement>): JSX.Element {
+  return <tbody {...props}>{children}</tbody>;
+}

--- a/src/components/Table/Cell.tsx
+++ b/src/components/Table/Cell.tsx
@@ -1,0 +1,31 @@
+import classNames from "classnames";
+import type { HTMLProps, JSX, ReactNode } from "react";
+
+/**
+ * A cell within the table body.
+ */
+export default function Cell({
+  children,
+  collapse,
+  align,
+  className,
+  ...props
+}: {
+  children?: ReactNode;
+  collapse?: boolean;
+  align?: "center" | "left" | "right";
+  className?: string;
+} & HTMLProps<HTMLTableCellElement>): JSX.Element {
+  return (
+    <td
+      {...props}
+      className={classNames(
+        className,
+        align !== undefined ? `u-align--${align}` : undefined,
+      )}
+      style={{ width: collapse ? "min-content" : undefined }}
+    >
+      {children}
+    </td>
+  );
+}

--- a/src/components/Table/Header.tsx
+++ b/src/components/Table/Header.tsx
@@ -1,0 +1,15 @@
+import type { HTMLProps, JSX, ReactNode } from "react";
+
+/**
+ * Header section of a table.
+ */
+export default function Header({
+  children,
+  ...props
+}: { children?: ReactNode } & HTMLProps<HTMLTableSectionElement>): JSX.Element {
+  return (
+    <thead {...props}>
+      <tr>{children}</tr>
+    </thead>
+  );
+}

--- a/src/components/Table/HeaderCell.tsx
+++ b/src/components/Table/HeaderCell.tsx
@@ -1,0 +1,74 @@
+import classNames from "classnames";
+import type { HTMLProps, JSX, ReactNode } from "react";
+
+type SortProps =
+  | {
+      /**
+       * Indicates this header is sortable.
+       */
+      sortable: true;
+      /**
+       * Direction in which this header is currently being sorted.
+       */
+      sortDirection: null | React.AriaAttributes["aria-sort"];
+    }
+  | {
+      sortable?: false;
+      sortDirection?: undefined;
+    };
+
+type HeaderCellProps = {
+  children?: ReactNode;
+  /**
+   * If `true`, collapse the width of this column to it's content.
+   */
+  collapse?: boolean;
+  align?: "center" | "left" | "right";
+  className?: string;
+} & Omit<HTMLProps<HTMLTableCellElement>, "onClick"> &
+  // Use a generic `onClick` handler, since the event may be emitted from a `button` or the `th`.
+  Pick<HTMLProps<HTMLElement>, "onClick"> &
+  SortProps;
+
+/**
+ * Header cell within a table.
+ *
+ * `sortable` and `sortDirection` can be used to indicate that the column is being used for
+ * sorting.
+ */
+export default function HeaderCell({
+  align,
+  children,
+  sortable,
+  sortDirection,
+  collapse,
+  className,
+  ...props
+}: HeaderCellProps): JSX.Element {
+  let ariaSort: React.AriaAttributes["aria-sort"] = undefined;
+
+  // If this column is sortable, render it in a button so that it can receive `onClick` events.
+  if (sortable) {
+    children = (
+      <button className="p-table__sort-button" onClick={props.onClick}>
+        {children}
+      </button>
+    );
+    ariaSort = sortDirection ?? "none";
+    delete props.onClick;
+  }
+
+  return (
+    <th
+      {...props}
+      aria-sort={ariaSort}
+      className={classNames(
+        className,
+        align !== undefined ? `u-align--${align}` : undefined,
+      )}
+      style={{ width: collapse ? "min-content" : undefined }}
+    >
+      {children}
+    </th>
+  );
+}

--- a/src/components/Table/Row.tsx
+++ b/src/components/Table/Row.tsx
@@ -1,0 +1,11 @@
+import type { HTMLProps, JSX, ReactNode } from "react";
+
+/**
+ * A row within a table.
+ */
+export default function Row({
+  children,
+  ...props
+}: { children?: ReactNode } & HTMLProps<HTMLTableRowElement>): JSX.Element {
+  return <tr {...props}>{children}</tr>;
+}

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -1,0 +1,13 @@
+import type { HTMLProps, JSX, ReactNode } from "react";
+
+/**
+ * Root table element.
+ */
+export default function Table({
+  children,
+  ...props
+}: {
+  children?: ReactNode;
+} & HTMLProps<HTMLTableElement>): JSX.Element {
+  return <table {...props}>{children}</table>;
+}

--- a/src/components/Table/index.ts
+++ b/src/components/Table/index.ts
@@ -1,0 +1,27 @@
+import BodyComponent from "./Body";
+import Cell from "./Cell";
+import HeaderComponent from "./Header";
+import HeaderCell from "./HeaderCell";
+import Row from "./Row";
+import TableComponent from "./Table";
+
+const Header = HeaderComponent as {
+  Cell: typeof HeaderCell;
+} & typeof HeaderComponent;
+Header.Cell = HeaderCell;
+
+/**
+ * An HTML table.
+ */
+const Table = TableComponent as {
+  Body: typeof BodyComponent;
+  Cell: typeof Cell;
+  Header: typeof Header;
+  Row: typeof Row;
+} & typeof TableComponent;
+Table.Body = BodyComponent;
+Table.Cell = Cell;
+Table.Header = Header;
+Table.Row = Row;
+
+export default Table;


### PR DESCRIPTION
Create a collection of components to mirror HTML `table` (and associated elements). They can all be accessed from a single import (eg. `<Table.Cell ...>`), and are intended to provide helpers for common patterns (see `Table.Header.Cell`) which can be expanded in the future. Required for #2391.