### PR TITLE
refactor: make configs-constraints array fields in Formik

### DIFF
--- a/src/pages/AddModel/AddModel.tsx
+++ b/src/pages/AddModel/AddModel.tsx
@@ -23,8 +23,8 @@ import { toastNotification } from "utils/toastNotification";
 import AccessManagement from "./AccessManagement";
 import AddModelStepper from "./AddModelStepper";
 import ConfigsConstraints from "./ConfigsConstraints";
-import { CONFIG_CATEGORIES } from "./ConfigsConstraints/configCatalog";
-import { CONSTRAINT_CATEGORIES } from "./ConfigsConstraints/constraintsCatalog";
+import { CONFIG_DEFINITIONS } from "./ConfigsConstraints/configCatalog";
+import { CONSTRAINT_DEFINITIONS } from "./ConfigsConstraints/constraintsCatalog";
 import { FieldName as ConfigFieldName } from "./ConfigsConstraints/types";
 import { DisableType } from "./ConfigsConstraints/types";
 import {
@@ -106,7 +106,10 @@ const AddModel: FC = () => {
       return;
     }
 
-    const config = buildConfigsConstraintsPayload(values);
+    const config = buildConfigsConstraintsPayload(
+      values[ConfigFieldName.CONFIG_FIELDS],
+      values[ConfigFieldName.CONSTRAINT_FIELDS],
+    );
     const shareModelWith = values.shareModelWith ?? {};
 
     dispatch(
@@ -169,15 +172,16 @@ const AddModel: FC = () => {
               cloud: "",
               region: "",
               credential: "",
+              [ConfigFieldName.CONFIG_FIELDS]:
+                getConfigInitialValues(CONFIG_DEFINITIONS),
+              [ConfigFieldName.CONSTRAINT_FIELDS]: getConfigInitialValues(
+                CONSTRAINT_DEFINITIONS,
+              ),
               [ConfigFieldName.CONFIG_INPUT_MODE]: InputMode.LIST,
               [ConfigFieldName.CONSTRAINT_INPUT_MODE]: InputMode.LIST,
               [ConfigFieldName.CONFIG_YAML]: "",
               [ConfigFieldName.CONSTRAINT_YAML]: "",
               [ConfigFieldName.DISABLED_COMMANDS]: DisableType.NONE,
-              ...getConfigInitialValues([
-                ...CONFIG_CATEGORIES,
-                ...CONSTRAINT_CATEGORIES,
-              ]),
             }}
             validationSchema={validationSchema}
             // Mark credential as touched on mount as Vanilla doesn't display validation until the field loses focus.

--- a/src/pages/AddModel/AddModelStepper/AddModelStepper.test.tsx
+++ b/src/pages/AddModel/AddModelStepper/AddModelStepper.test.tsx
@@ -42,6 +42,8 @@ describe("AddModelStepper", () => {
       cloud: "",
       region: "",
       credential: "",
+      [FieldName.CONFIG_FIELDS]: [],
+      [FieldName.CONSTRAINT_FIELDS]: [],
       [FieldName.CONFIG_INPUT_MODE]: InputMode.LIST,
       [FieldName.CONSTRAINT_INPUT_MODE]: InputMode.LIST,
       [FieldName.CONFIG_YAML]: "",

--- a/src/pages/AddModel/ConfigsConstraints/CategoriesListing/CategoriesListing.test.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/CategoriesListing/CategoriesListing.test.tsx
@@ -3,22 +3,61 @@ import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 import { vi } from "vitest";
 
+import { BOOLEAN_OPTIONS } from "consts";
 import { externalURLs } from "urls";
 
 import { InputMode } from "../../types";
-import { CONFIG_CATEGORIES } from "../configCatalog";
-import { FieldName, Label } from "../types";
+import { ConfigCategory } from "../configCatalog";
+import {
+  type ConfigFieldEntry,
+  FieldName,
+  InputType,
+  Label,
+  ValueType,
+} from "../types";
 
 import CategoriesListing from "./CategoriesListing";
 import type { Props as CategoriesListingProps } from "./types";
 
 describe("CategoriesListing", () => {
   let defaultProps: CategoriesListingProps;
+  let initialValues: {
+    [FieldName.CONFIG_FIELDS]: ConfigFieldEntry[];
+    [FieldName.CONFIG_INPUT_MODE]: InputMode;
+  };
 
   beforeEach(() => {
+    initialValues = {
+      [FieldName.CONFIG_FIELDS]: [
+        {
+          label: "default-space",
+          value: "my-space",
+          defaultValue: "",
+          category: ConfigCategory.NETWORKING,
+          arrayIndex: 0,
+        },
+        {
+          label: "net-bond-reconfigure-delay",
+          value: 15,
+          defaultValue: 17,
+          category: ConfigCategory.NETWORKING,
+          arrayIndex: 1,
+          valueType: ValueType.NUMBER,
+        },
+        {
+          label: "disable-network-management",
+          value: true,
+          defaultValue: false,
+          category: ConfigCategory.NETWORKING,
+          arrayIndex: 2,
+          valueType: ValueType.BOOLEAN,
+        },
+      ],
+      [FieldName.CONFIG_INPUT_MODE]: InputMode.LIST,
+    };
     defaultProps = {
       title: Label.CONFIGS_TITLE,
-      categoriesList: CONFIG_CATEGORIES,
+      arrayName: FieldName.CONFIG_FIELDS,
       inputMode: FieldName.CONFIG_INPUT_MODE,
       yamlKey: FieldName.CONFIG_YAML,
       changedOnlyLabel: Label.CHANGED_CONFIGS_ONLY,
@@ -39,10 +78,7 @@ describe("CategoriesListing", () => {
 
   it("renders properly", () => {
     render(
-      <Formik
-        initialValues={{ [FieldName.CONFIG_INPUT_MODE]: InputMode.LIST }}
-        onSubmit={vi.fn()}
-      >
+      <Formik initialValues={initialValues} onSubmit={vi.fn()}>
         <CategoriesListing {...defaultProps} />
       </Formik>,
     );
@@ -64,10 +100,7 @@ describe("CategoriesListing", () => {
 
   it("shows list mode content by default", () => {
     render(
-      <Formik
-        initialValues={{ [FieldName.CONFIG_INPUT_MODE]: InputMode.LIST }}
-        onSubmit={vi.fn()}
-      >
+      <Formik initialValues={initialValues} onSubmit={vi.fn()}>
         <CategoriesListing {...defaultProps} />
       </Formik>,
     );
@@ -84,7 +117,10 @@ describe("CategoriesListing", () => {
   it("shows yaml mode content when initialised in yaml mode", () => {
     render(
       <Formik
-        initialValues={{ [FieldName.CONFIG_INPUT_MODE]: InputMode.YAML }}
+        initialValues={{
+          ...initialValues,
+          [FieldName.CONFIG_INPUT_MODE]: InputMode.YAML,
+        }}
         onSubmit={vi.fn()}
       >
         <CategoriesListing {...defaultProps} />
@@ -104,10 +140,32 @@ describe("CategoriesListing", () => {
     render(
       <Formik
         initialValues={{
+          [FieldName.CONFIG_FIELDS]: [
+            {
+              label: "default-space",
+              value: "my-space",
+              defaultValue: "",
+              category: ConfigCategory.NETWORKING,
+              arrayIndex: 0,
+            },
+            {
+              label: "net-bond-reconfigure-delay",
+              value: 15,
+              defaultValue: 17,
+              category: ConfigCategory.NETWORKING,
+              arrayIndex: 1,
+              valueType: ValueType.NUMBER,
+            },
+            {
+              label: "disable-network-management",
+              value: true,
+              defaultValue: false,
+              category: ConfigCategory.NETWORKING,
+              arrayIndex: 2,
+              valueType: ValueType.BOOLEAN,
+            },
+          ],
           [FieldName.CONFIG_INPUT_MODE]: InputMode.LIST,
-          "default-space": "my-space",
-          "net-bond-reconfigure-delay": 15,
-          "disable-network-management": true,
         }}
         onSubmit={vi.fn()}
       >
@@ -128,7 +186,10 @@ describe("CategoriesListing", () => {
   it("switches back to list mode from yaml mode", async () => {
     render(
       <Formik
-        initialValues={{ [FieldName.CONFIG_INPUT_MODE]: InputMode.YAML }}
+        initialValues={{
+          ...initialValues,
+          [FieldName.CONFIG_INPUT_MODE]: InputMode.YAML,
+        }}
         onSubmit={vi.fn()}
       >
         <CategoriesListing {...defaultProps} />
@@ -150,8 +211,23 @@ describe("CategoriesListing", () => {
     render(
       <Formik
         initialValues={{
+          [FieldName.CONFIG_FIELDS]: [
+            {
+              label: "default-space",
+              value: "my-space",
+              defaultValue: "",
+              category: ConfigCategory.NETWORKING,
+              arrayIndex: 0,
+            },
+            {
+              label: "apt-http-proxy",
+              value: "",
+              defaultValue: "",
+              category: ConfigCategory.PROXY,
+              arrayIndex: 1,
+            },
+          ],
           [FieldName.CONFIG_INPUT_MODE]: InputMode.LIST,
-          "default-space": "my-space",
         }}
         onSubmit={vi.fn()}
       >
@@ -167,8 +243,8 @@ describe("CategoriesListing", () => {
     expect(textarea.value).not.toContain("# Proxy & Mirror");
 
     await userEvent.click(screen.getByRole("radio", { name: InputMode.LIST }));
-    const aptHttpProxyInput = document.querySelector(
-      'input[name="apt-http-proxy"]',
+    const aptHttpProxyInput = screen.getByLabelText(
+      "apt-http-proxy",
     ) as HTMLInputElement;
     await userEvent.type(aptHttpProxyInput, "http://proxy.example");
     await userEvent.click(screen.getByRole("radio", { name: InputMode.YAML }));
@@ -185,7 +261,10 @@ describe("CategoriesListing", () => {
   it("calls setYAMLErrors and stays in YAML mode when YAML has invalid keys", async () => {
     render(
       <Formik
-        initialValues={{ [FieldName.CONFIG_INPUT_MODE]: InputMode.YAML }}
+        initialValues={{
+          ...initialValues,
+          [FieldName.CONFIG_INPUT_MODE]: InputMode.YAML,
+        }}
         onSubmit={vi.fn()}
       >
         <CategoriesListing {...defaultProps} />
@@ -207,10 +286,7 @@ describe("CategoriesListing", () => {
   it("filters categories by field name", () => {
     vi.useFakeTimers();
     render(
-      <Formik
-        initialValues={{ [FieldName.CONFIG_INPUT_MODE]: InputMode.LIST }}
-        onSubmit={vi.fn()}
-      >
+      <Formik initialValues={initialValues} onSubmit={vi.fn()}>
         <CategoriesListing {...defaultProps} />
       </Formik>,
     );
@@ -231,23 +307,22 @@ describe("CategoriesListing", () => {
   it("filters categories by description", () => {
     vi.useFakeTimers();
     render(
-      <Formik
-        initialValues={{ [FieldName.CONFIG_INPUT_MODE]: InputMode.LIST }}
-        onSubmit={vi.fn()}
-      >
+      <Formik initialValues={initialValues} onSubmit={vi.fn()}>
         <CategoriesListing {...defaultProps} />
       </Formik>,
     );
 
     const searchInput = screen.getByRole("searchbox");
     fireEvent.change(searchInput, {
-      target: { value: "network firewalling" },
+      target: { value: "reconfigure" },
     });
     act(() => {
       vi.advanceTimersByTime(250);
     });
 
-    expect(screen.getByLabelText("firewall-mode")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("net-bond-reconfigure-delay"),
+    ).toBeInTheDocument();
     expect(screen.queryByLabelText("default-space")).not.toBeInTheDocument();
 
     fireEvent.change(searchInput, { target: { value: "" } });
@@ -269,8 +344,23 @@ describe("CategoriesListing", () => {
     render(
       <Formik
         initialValues={{
+          [FieldName.CONFIG_FIELDS]: [
+            {
+              label: "default-space",
+              value: "my-space",
+              defaultValue: "",
+              category: ConfigCategory.NETWORKING,
+              arrayIndex: 0,
+            },
+            {
+              label: "container-networking-method",
+              value: "local",
+              defaultValue: "local",
+              category: ConfigCategory.NETWORKING,
+              arrayIndex: 1,
+            },
+          ],
           [FieldName.CONFIG_INPUT_MODE]: InputMode.LIST,
-          "default-space": "my-space",
         }}
         onSubmit={vi.fn()}
       >
@@ -292,11 +382,28 @@ describe("CategoriesListing", () => {
   });
 
   it("does not toggle and shows a tooltip when there are no changed fields", async () => {
+    const noChangesValues = {
+      [FieldName.CONFIG_FIELDS]: [
+        {
+          label: "default-space",
+          value: "",
+          defaultValue: "",
+          category: ConfigCategory.NETWORKING,
+          arrayIndex: 0,
+        },
+        {
+          label: "net-bond-reconfigure-delay",
+          value: 17,
+          defaultValue: 17,
+          category: ConfigCategory.NETWORKING,
+          arrayIndex: 1,
+          valueType: ValueType.NUMBER,
+        },
+      ],
+      [FieldName.CONFIG_INPUT_MODE]: InputMode.LIST,
+    };
     render(
-      <Formik
-        initialValues={{ [FieldName.CONFIG_INPUT_MODE]: InputMode.LIST }}
-        onSubmit={vi.fn()}
-      >
+      <Formik initialValues={noChangesValues} onSubmit={vi.fn()}>
         <CategoriesListing {...defaultProps} />
       </Formik>,
     );
@@ -314,10 +421,7 @@ describe("CategoriesListing", () => {
   it("clears the search and restores the full list", () => {
     vi.useFakeTimers();
     render(
-      <Formik
-        initialValues={{ [FieldName.CONFIG_INPUT_MODE]: InputMode.LIST }}
-        onSubmit={vi.fn()}
-      >
+      <Formik initialValues={initialValues} onSubmit={vi.fn()}>
         <CategoriesListing {...defaultProps} />
       </Formik>,
     );
@@ -329,7 +433,7 @@ describe("CategoriesListing", () => {
       vi.advanceTimersByTime(250);
     });
     expect(
-      screen.queryByLabelText("container-networking-method"),
+      screen.queryByLabelText("net-bond-reconfigure-delay"),
     ).not.toBeInTheDocument();
 
     fireEvent.click(
@@ -343,16 +447,13 @@ describe("CategoriesListing", () => {
 
     expect(screen.getByLabelText("default-space")).toBeInTheDocument();
     expect(
-      screen.getByLabelText("container-networking-method"),
+      screen.getByLabelText("net-bond-reconfigure-delay"),
     ).toBeInTheDocument();
   });
 
   it("renders numeric fields correctly", () => {
     render(
-      <Formik
-        initialValues={{ [FieldName.CONFIG_INPUT_MODE]: InputMode.LIST }}
-        onSubmit={vi.fn()}
-      >
+      <Formik initialValues={initialValues} onSubmit={vi.fn()}>
         <CategoriesListing {...defaultProps} />
       </Formik>,
     );
@@ -365,8 +466,17 @@ describe("CategoriesListing", () => {
     render(
       <Formik
         initialValues={{
+          [FieldName.CONFIG_FIELDS]: [
+            {
+              label: "net-bond-reconfigure-delay",
+              value: 15,
+              defaultValue: 17,
+              category: ConfigCategory.NETWORKING,
+              arrayIndex: 0,
+              valueType: ValueType.NUMBER,
+            },
+          ],
           [FieldName.CONFIG_INPUT_MODE]: InputMode.LIST,
-          "net-bond-reconfigure-delay": 15,
         }}
         onSubmit={vi.fn()}
       >
@@ -389,8 +499,18 @@ describe("CategoriesListing", () => {
     render(
       <Formik
         initialValues={{
+          [FieldName.CONFIG_FIELDS]: [
+            {
+              label: "disable-network-management",
+              value: true,
+              defaultValue: false,
+              category: ConfigCategory.NETWORKING,
+              arrayIndex: 0,
+              valueType: ValueType.BOOLEAN,
+              input: { type: InputType.SELECT, options: BOOLEAN_OPTIONS },
+            },
+          ],
           [FieldName.CONFIG_INPUT_MODE]: InputMode.LIST,
-          "disable-network-management": true,
         }}
         onSubmit={vi.fn()}
       >
@@ -405,7 +525,7 @@ describe("CategoriesListing", () => {
 
     expect(changedOnlySwitch).toBeChecked();
     expect(
-      document.querySelector('select[name="disable-network-management"]'),
+      document.querySelector('select[name^="configFields"]'),
     ).toBeInTheDocument();
   });
 });

--- a/src/pages/AddModel/ConfigsConstraints/CategoriesListing/CategoriesListing.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/CategoriesListing/CategoriesListing.tsx
@@ -17,11 +17,11 @@ import useDebounce from "hooks/useDebounce";
 import { InputMode } from "../../types";
 import StackList from "../StackList";
 import { YAMLErrorType } from "../YAMLErrorsModal/types";
-import type { ConfigFieldValue, FormFields } from "../types";
+import type { ConfigFieldEntry, FormFields } from "../types";
 import {
   buildYAML,
-  filterCategoriesBySearch,
-  getCategoriesWithVisibleFields,
+  filterEntriesBySearch,
+  groupEntriesByCategory,
   validateAndParseYAML,
 } from "../utils";
 
@@ -29,7 +29,7 @@ import type { Props } from "./types";
 
 const CategoriesListing = ({
   title,
-  categoriesList,
+  arrayName,
   inputMode,
   yamlKey,
   changedOnlyLabel,
@@ -44,28 +44,24 @@ const CategoriesListing = ({
 }: Props): JSX.Element => {
   const id = useId();
   const { values, setFieldError, setFieldTouched, setFieldValue } =
-    useFormikContext<FormFields & Record<string, ConfigFieldValue>>();
+    useFormikContext<FormFields>();
   const [searchQuery, setSearchQuery] = useDebounce("", 250);
   const [changedOnly, setChangedOnly] = useState(false);
+
+  const entries: ConfigFieldEntry[] = values[arrayName];
 
   const isListMode = values[inputMode] === InputMode.LIST;
   const handleModeChange = (isListModeSelected: boolean): void => {
     if (!isListModeSelected) {
-      void setFieldValue(yamlKey, buildYAML(categoriesList, values));
+      void setFieldValue(yamlKey, buildYAML(entries));
     } else {
       const yamlString = values[yamlKey];
       if (!yamlString) {
         void setFieldValue(inputMode, InputMode.LIST);
         return;
       }
-      const { validValues, errors } = validateAndParseYAML(
-        yamlString,
-        categoriesList,
-        values,
-      );
-      for (const [label, value] of Object.entries(validValues)) {
-        void setFieldValue(label, value);
-      }
+      const { validValues, errors } = validateAndParseYAML(yamlString, entries);
+      void setFieldValue(arrayName, validValues);
 
       if (
         errors[YAMLErrorType.UNKNOWN_KEYS].length > 0 ||
@@ -91,18 +87,12 @@ const CategoriesListing = ({
     );
   };
 
-  const filteredCategories = filterCategoriesBySearch(
-    searchQuery,
-    categoriesList,
-  );
-  const categoriesWithChangedFields = getCategoriesWithVisibleFields(
-    filteredCategories,
-    values,
-  );
-  const hasChangedFields = categoriesWithChangedFields.length > 0;
-  const visibleCategories = changedOnly
-    ? categoriesWithChangedFields
-    : filteredCategories;
+  const filteredEntries = filterEntriesBySearch(searchQuery, entries);
+  const changedGroups = groupEntriesByCategory(filteredEntries, true);
+  const hasChangedFields = changedGroups.length > 0;
+  const visibleGroups = changedOnly
+    ? changedGroups
+    : groupEntriesByCategory(filteredEntries);
 
   const changedOnlySwitch = (
     <Switch
@@ -180,8 +170,8 @@ const CategoriesListing = ({
             </Tooltip>
           )}
           <div className="categories__form-scroll u-sv-1--top">
-            {visibleCategories.length > 0 ? (
-              visibleCategories.map(({ category, fields }, index) => (
+            {visibleGroups.length > 0 ? (
+              visibleGroups.map(({ category, fields }, index) => (
                 <Row
                   key={category}
                   className={classNames("u-no-padding", {
@@ -192,9 +182,9 @@ const CategoriesListing = ({
                     <h5>{category}</h5>
                   </Col>
                   <Col size={9}>
-                    <StackList visibleFields={fields} />
+                    <StackList visibleFields={fields} arrayName={arrayName} />
                   </Col>
-                  {index < visibleCategories.length - 1 ? (
+                  {index < visibleGroups.length - 1 ? (
                     <hr className="p-rule--muted" />
                   ) : null}
                 </Row>

--- a/src/pages/AddModel/ConfigsConstraints/CategoriesListing/types.ts
+++ b/src/pages/AddModel/ConfigsConstraints/CategoriesListing/types.ts
@@ -1,9 +1,9 @@
 import type { YAMLErrorsModalState } from "../YAMLErrorsModal/types";
-import type { CategoryDefinition, FieldName } from "../types";
+import type { FieldName } from "../types";
 
 export type Props = {
   title: string;
-  categoriesList: CategoryDefinition[];
+  arrayName: FieldName.CONFIG_FIELDS | FieldName.CONSTRAINT_FIELDS;
   inputMode: FieldName.CONFIG_INPUT_MODE | FieldName.CONSTRAINT_INPUT_MODE;
   yamlKey: FieldName.CONFIG_YAML | FieldName.CONSTRAINT_YAML;
   changedOnlyLabel: string;

--- a/src/pages/AddModel/ConfigsConstraints/ConfigsConstraints.test.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/ConfigsConstraints.test.tsx
@@ -9,18 +9,37 @@ import { externalURLs } from "urls";
 import { InputMode } from "../types";
 
 import ConfigsConstraints from "./ConfigsConstraints";
-import { DisableType, FieldName, Label } from "./types";
+import { DisableType, type FormFields, FieldName, Label } from "./types";
 
 describe("ConfigsConstraints", () => {
+  let initialValues: FormFields;
+
+  beforeEach(() => {
+    initialValues = {
+      [FieldName.CONFIG_FIELDS]: [
+        { label: "default-space", value: "", category: null, arrayIndex: 0 },
+        {
+          label: "container-networking-method",
+          value: "",
+          category: null,
+          arrayIndex: 1,
+        },
+      ],
+      [FieldName.CONSTRAINT_FIELDS]: [
+        { label: "cores", value: "", category: null, arrayIndex: 0 },
+        { label: "zones", value: "", category: null, arrayIndex: 1 },
+      ],
+      [FieldName.CONFIG_INPUT_MODE]: InputMode.LIST,
+      [FieldName.CONSTRAINT_INPUT_MODE]: InputMode.LIST,
+      [FieldName.CONFIG_YAML]: "",
+      [FieldName.CONSTRAINT_YAML]: "",
+      [FieldName.DISABLED_COMMANDS]: DisableType.NONE,
+    };
+  });
+
   it("renders properly", () => {
     renderComponent(
-      <Formik
-        initialValues={{
-          [FieldName.CONFIG_INPUT_MODE]: InputMode.LIST,
-          [FieldName.CONSTRAINT_INPUT_MODE]: InputMode.LIST,
-        }}
-        onSubmit={vi.fn()}
-      >
+      <Formik initialValues={initialValues} onSubmit={vi.fn()}>
         <ConfigsConstraints />
       </Formik>,
     );
@@ -53,13 +72,7 @@ describe("ConfigsConstraints", () => {
   it("keeps config and constraint searches independent", async () => {
     vi.useFakeTimers();
     renderComponent(
-      <Formik
-        initialValues={{
-          [FieldName.CONFIG_INPUT_MODE]: InputMode.LIST,
-          [FieldName.CONSTRAINT_INPUT_MODE]: InputMode.LIST,
-        }}
-        onSubmit={vi.fn()}
-      >
+      <Formik initialValues={initialValues} onSubmit={vi.fn()}>
         <ConfigsConstraints />
       </Formik>,
     );
@@ -118,8 +131,7 @@ describe("ConfigsConstraints", () => {
     renderComponent(
       <Formik
         initialValues={{
-          [FieldName.CONFIG_INPUT_MODE]: InputMode.LIST,
-          [FieldName.CONSTRAINT_INPUT_MODE]: InputMode.LIST,
+          ...initialValues,
           disabledCommands: DisableType.NONE,
         }}
         onSubmit={vi.fn()}
@@ -152,8 +164,7 @@ describe("ConfigsConstraints", () => {
     renderComponent(
       <Formik
         initialValues={{
-          [FieldName.CONFIG_INPUT_MODE]: InputMode.LIST,
-          [FieldName.CONSTRAINT_INPUT_MODE]: InputMode.LIST,
+          ...initialValues,
           disabledCommands: DisableType.NONE,
         }}
         onSubmit={vi.fn()}
@@ -174,8 +185,8 @@ describe("ConfigsConstraints", () => {
     renderComponent(
       <Formik
         initialValues={{
+          ...initialValues,
           [FieldName.CONFIG_INPUT_MODE]: InputMode.YAML,
-          [FieldName.CONSTRAINT_INPUT_MODE]: InputMode.LIST,
           [FieldName.CONFIG_YAML]: "unknown-field: value",
         }}
         onSubmit={vi.fn()}
@@ -198,14 +209,16 @@ describe("ConfigsConstraints", () => {
     expect(
       within(dialog).getByText(/invalid configuration values/i),
     ).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(dialog).not.toBeInTheDocument();
   });
 
   it("wipes invalid YAML entries when switching to list mode forcefully", async () => {
     renderComponent(
       <Formik
         initialValues={{
+          ...initialValues,
           [FieldName.CONFIG_INPUT_MODE]: InputMode.YAML,
-          [FieldName.CONSTRAINT_INPUT_MODE]: InputMode.LIST,
           [FieldName.CONFIG_YAML]:
             "default-space: my-space\nunknown-field: value",
         }}

--- a/src/pages/AddModel/ConfigsConstraints/ConfigsConstraints.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/ConfigsConstraints.tsx
@@ -11,15 +11,11 @@ import CategoriesListing from "./CategoriesListing";
 import TruncatedCommands from "./TruncatedCommands";
 import YAMLErrorsModal from "./YAMLErrorsModal";
 import type { YAMLErrorsModalState } from "./YAMLErrorsModal/types";
-import { CONFIG_CATEGORIES } from "./configCatalog";
-import { CONSTRAINT_CATEGORIES } from "./constraintsCatalog";
 import { DISABLED_COMMAND_OPTIONS } from "./disabledCommandOptions";
 import { FieldName, type FormFields, Label, TestId } from "./types";
 
 const ConfigsConstraints = (): JSX.Element => {
-  const { setFieldValue } = useFormikContext<
-    FormFields & Record<string, string>
-  >();
+  const { setFieldValue } = useFormikContext<FormFields>();
   const [yamlErrorsModalState, setYAMLErrors] =
     useState<null | YAMLErrorsModalState>(null);
 
@@ -42,7 +38,7 @@ const ConfigsConstraints = (): JSX.Element => {
       ) : null}
       <CategoriesListing
         title={Label.CONFIGS_TITLE}
-        categoriesList={CONFIG_CATEGORIES}
+        arrayName={FieldName.CONFIG_FIELDS}
         inputMode={FieldName.CONFIG_INPUT_MODE}
         yamlKey={FieldName.CONFIG_YAML}
         changedOnlyLabel={Label.CHANGED_CONFIGS_ONLY}
@@ -57,7 +53,7 @@ const ConfigsConstraints = (): JSX.Element => {
       />
       <CategoriesListing
         title={Label.CONSTRAINTS_TITLE}
-        categoriesList={CONSTRAINT_CATEGORIES}
+        arrayName={FieldName.CONSTRAINT_FIELDS}
         inputMode={FieldName.CONSTRAINT_INPUT_MODE}
         yamlKey={FieldName.CONSTRAINT_YAML}
         changedOnlyLabel={Label.CHANGED_CONSTRAINTS_ONLY}

--- a/src/pages/AddModel/ConfigsConstraints/StackList/StackList.test.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/StackList/StackList.test.tsx
@@ -4,26 +4,34 @@ import { vi } from "vitest";
 
 import { renderComponent } from "testing/utils";
 
-import type { CategoryDefinition } from "../types";
-import { InputType } from "../types";
+import { ConfigCategory } from "../configCatalog";
+import type { ConfigFieldEntry } from "../types";
+import { FieldName, InputType } from "../types";
 
 import StackList from "./StackList";
 
 const iconClass = ".p-icon--status-in-progress-small";
 
 describe("StackList", () => {
-  const mockCategory: CategoryDefinition = {
-    category: "Networking",
-    fields: [
+  let mockFields: ConfigFieldEntry[];
+
+  beforeEach(() => {
+    mockFields = [
       {
         label: "default-space",
         description: "The default network space",
         defaultValue: "alpha",
+        category: ConfigCategory.NETWORKING,
+        value: "alpha",
+        arrayIndex: 0,
       },
       {
         label: "container-networking-method",
         description: "The method of container networking setup",
         defaultValue: "local",
+        category: ConfigCategory.NETWORKING,
+        value: "local",
+        arrayIndex: 1,
         input: {
           type: InputType.SELECT,
           options: [
@@ -35,14 +43,23 @@ describe("StackList", () => {
       {
         label: "egress-subnets",
         description: "Subnets to use for egress",
+        category: ConfigCategory.NETWORKING,
+        value: "",
+        arrayIndex: 2,
       },
-    ],
-  };
+    ];
+  });
 
   it("renders properly", () => {
     renderComponent(
-      <Formik initialValues={{}} onSubmit={vi.fn()}>
-        <StackList visibleFields={mockCategory.fields} />
+      <Formik
+        initialValues={{ [FieldName.CONFIG_FIELDS]: mockFields }}
+        onSubmit={vi.fn()}
+      >
+        <StackList
+          visibleFields={mockFields}
+          arrayName={FieldName.CONFIG_FIELDS}
+        />
       </Formik>,
     );
 
@@ -53,13 +70,13 @@ describe("StackList", () => {
   it("does not show a changed indicator when fields have default values", () => {
     renderComponent(
       <Formik
-        initialValues={{
-          "default-space": "alpha",
-          "container-networking-method": "local",
-        }}
+        initialValues={{ [FieldName.CONFIG_FIELDS]: mockFields }}
         onSubmit={vi.fn()}
       >
-        <StackList visibleFields={mockCategory.fields} />
+        <StackList
+          visibleFields={mockFields}
+          arrayName={FieldName.CONFIG_FIELDS}
+        />
       </Formik>,
     );
 
@@ -68,15 +85,16 @@ describe("StackList", () => {
   });
 
   it("shows a changed indicator when field value differs from default", () => {
+    mockFields[0].value = "modified-space";
     renderComponent(
       <Formik
-        initialValues={{
-          "default-space": "modified-space",
-          "container-networking-method": "local",
-        }}
+        initialValues={{ [FieldName.CONFIG_FIELDS]: mockFields }}
         onSubmit={vi.fn()}
       >
-        <StackList visibleFields={mockCategory.fields} />
+        <StackList
+          visibleFields={mockFields}
+          arrayName={FieldName.CONFIG_FIELDS}
+        />
       </Formik>,
     );
 

--- a/src/pages/AddModel/ConfigsConstraints/StackList/StackList.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/StackList/StackList.tsx
@@ -1,52 +1,41 @@
 import { FormikField, Icon, Select } from "@canonical/react-components";
-import { useFormikContext } from "formik";
 import { Fragment, type JSX } from "react";
 
-import type {
-  CategoryDefinitionField,
-  ConfigFieldValue,
-  FormFields,
-} from "../types";
+import type { ConfigFieldEntry, FieldName } from "../types";
 import { InputType, ValueType } from "../types";
 import { isConfigChanged } from "../utils";
 
 type Props = {
-  visibleFields: CategoryDefinitionField[];
+  visibleFields: ConfigFieldEntry[];
+  arrayName: FieldName.CONFIG_FIELDS | FieldName.CONSTRAINT_FIELDS;
 };
 
-const StackList = ({ visibleFields }: Props): JSX.Element => {
-  const { values } = useFormikContext<
-    FormFields & Record<string, ConfigFieldValue>
-  >();
-
+const StackList = ({ visibleFields, arrayName }: Props): JSX.Element => {
   return (
     <>
-      {visibleFields.map((field, index) => {
-        const changed = isConfigChanged(
-          field.label,
-          values,
-          field.defaultValue,
-        );
+      {visibleFields.map((entry, index) => {
+        const fieldName = `${arrayName}[${entry.arrayIndex}].value`;
+        const changed = isConfigChanged(entry);
         return (
-          <Fragment key={field.label}>
+          <Fragment key={entry.label}>
             <FormikField
-              {...(field.input?.type === InputType.SELECT
+              {...(entry.input?.type === InputType.SELECT
                 ? { component: Select }
                 : {
                     type:
-                      field.valueType === ValueType.NUMBER ? "number" : "text",
-                    placeholder: field.defaultValue,
+                      entry.valueType === ValueType.NUMBER ? "number" : "text",
+                    placeholder: entry.defaultValue,
                   })}
               label={
                 <>
                   {changed ? (
                     <Icon name="status-in-progress-small u-sh-3 u-sh1--right" />
                   ) : null}
-                  {field.label}
+                  {entry.label}
                 </>
               }
-              name={field.label}
-              help={field.description}
+              name={fieldName}
+              help={entry.description}
               helpAfterLabel
               stacked
               stackedFieldColumns={4}
@@ -55,7 +44,7 @@ const StackList = ({ visibleFields }: Props): JSX.Element => {
               helpClassName="u-no-margin--bottom"
               wrapperClassName="stack__list-row"
               className="u-no-margin--bottom stack__list-field"
-              {...field.input}
+              {...entry.input}
             />
             {index < visibleFields.length - 1 ? (
               <hr className="p-rule--muted u-no-margin--bottom" />

--- a/src/pages/AddModel/ConfigsConstraints/configCatalog.ts
+++ b/src/pages/AddModel/ConfigsConstraints/configCatalog.ts
@@ -1,527 +1,571 @@
 /* eslint-disable @cspell/spellchecker -- This file contains values as they come from Juju */
 import { BOOLEAN_OPTIONS } from "consts";
 
-import type { CategoryDefinition } from "./types";
+import type { ConfigFieldEntry } from "./types";
 import { InputType, ValueType } from "./types";
 
-export const CONFIG_CATEGORIES: CategoryDefinition[] = [
+export enum ConfigCategory {
+  CLOUD = "Cloud-specific configurations",
+  NETWORKING = "Networking & Firewall",
+  PROXY = "Proxy & Mirror",
+  PROVISIONING = "Provisioning & Machines",
+  LOGGING = "Logging",
+  AGENTS = "Agents & Workloads",
+  STORAGE = "Storage & Secrets",
+  OPERATIONS = "Operations & Miscellaneous",
+}
+
+export const CONFIG_DEFINITIONS: Omit<
+  ConfigFieldEntry,
+  "arrayIndex" | "value"
+>[] = [
   {
-    category: "Cloud-specific configurations",
-    fields: [
-      {
-        label: "base-image-path",
-        description: "Base path to look for machine disk images",
-      },
-      {
-        label: "vpc-id",
-        description: "Use a specific VPC network",
-      },
-      {
-        label: "vpc-id-force",
-        description:
-          "Force Juju to use the GCE VPC ID specified with vpc-id, when it fails the minimum validation criteria",
-        defaultValue: false,
-        valueType: ValueType.BOOLEAN,
-        input: {
-          type: InputType.SELECT,
-          options: BOOLEAN_OPTIONS,
-        },
-      },
-    ],
+    label: "base-image-path",
+    description: "Base path to look for machine disk images",
+    category: ConfigCategory.CLOUD,
   },
   {
-    category: "Networking & Firewall",
-    fields: [
-      {
-        label: "container-networking-method",
-        description: "The method of container networking setup",
-        defaultValue: "local",
-        input: {
-          type: InputType.SELECT,
-          options: [
-            { label: "local", value: "local" },
-            { label: "fan", value: "fan" },
-            { label: "provider", value: "provider" },
-          ],
-        },
-      },
-      {
-        label: "default-space",
-        description: "The default network space used for application endpoints",
-      },
-      {
-        label: "disable-network-management",
-        description: "Determines whether the provider should control networks",
-        defaultValue: false,
-        valueType: ValueType.BOOLEAN,
-        input: {
-          type: InputType.SELECT,
-          options: BOOLEAN_OPTIONS,
-        },
-      },
-      {
-        label: "egress-subnets",
-        description:
-          "The source address(es) for traffic originating from this model",
-      },
-      {
-        label: "fan-config",
-        description: "The configuration for fan networking for this model",
-      },
-      {
-        label: "firewall-mode",
-        description: "The mode to use for network firewalling",
-        defaultValue: "instance",
-        input: {
-          type: InputType.SELECT,
-          options: [
-            { label: "Instance", value: "instance" },
-            { label: "Global", value: "global" },
-            { label: "None", value: "none" },
-          ],
-        },
-      },
-      {
-        label: "ignore-machine-addresses",
-        description:
-          "Determines whether the machine worker should discover machine addresses on startup",
-        defaultValue: false,
-        valueType: ValueType.BOOLEAN,
-        input: {
-          type: InputType.SELECT,
-          options: BOOLEAN_OPTIONS,
-        },
-      },
-      {
-        label: "net-bond-reconfigure-delay",
-        description:
-          "The amount of time in seconds to sleep between ifdown and ifup when bridging",
-        defaultValue: 17,
-        valueType: ValueType.NUMBER,
-      },
-      {
-        label: "saas-ingress-allow",
-        description:
-          "The CIDR allowlist for SAAS ingress traffic to this model",
-        defaultValue: "0.0.0.0/0,::/0",
-      },
-      {
-        label: "ssh-allow",
-        description:
-          "The CIDR allowlist for SSH access to instances in this model",
-        defaultValue: "0.0.0.0/0,::/0",
-      },
-      {
-        label: "ssl-hostname-verification",
-        description: "Determines whether SSL hostname verification is enabled",
-        defaultValue: true,
-        valueType: ValueType.BOOLEAN,
-        input: {
-          type: InputType.SELECT,
-          options: BOOLEAN_OPTIONS,
-        },
-      },
-    ],
+    label: "vpc-id",
+    description: "Use a specific VPC network",
+    category: ConfigCategory.CLOUD,
   },
   {
-    category: "Proxy & Mirror",
-    fields: [
-      {
-        label: "apt-ftp-proxy",
-        description: "The APT FTP proxy for the model",
-      },
-      {
-        label: "apt-http-proxy",
-        description: "The APT HTTP proxy for the model",
-      },
-      {
-        label: "apt-https-proxy",
-        description: "The APT HTTPS proxy for the model",
-      },
-      {
-        label: "apt-mirror",
-        description: "The APT mirror for the model",
-      },
-      {
-        label: "apt-no-proxy",
-        description:
-          "The list of domain addresses not to be proxied for APT (comma-separated)",
-      },
-      {
-        label: "ftp-proxy",
-        description:
-          "The FTP proxy value to configure on instances, in the FTP_PROXY environment variable",
-      },
-      {
-        label: "http-proxy",
-        description:
-          "The HTTP proxy value to configure on instances, in the HTTP_PROXY environment variable",
-      },
-      {
-        label: "https-proxy",
-        description:
-          "The HTTPS proxy value to configure on instances, in the HTTPS_PROXY environment variable",
-      },
-      {
-        label: "juju-ftp-proxy",
-        description:
-          "The FTP proxy value to pass to charms in the JUJU_CHARM_FTP_PROXY environment variable",
-      },
-      {
-        label: "juju-http-proxy",
-        description:
-          "The HTTP proxy value to pass to charms in the JUJU_CHARM_HTTP_PROXY environment variable",
-      },
-      {
-        label: "juju-https-proxy",
-        description:
-          "The HTTPS proxy value to pass to charms in the JUJU_CHARM_HTTPS_PROXY environment variable",
-      },
-      {
-        label: "juju-no-proxy",
-        description:
-          "The list of domain addresses not to be proxied (comma-separated), may contain CIDRs. Passed to charms in the JUJU_CHARM_NO_PROXY environment variable",
-        defaultValue: "127.0.0.1,localhost,::1",
-      },
-      {
-        label: "no-proxy",
-        description:
-          "The list of domain addresses not to be proxied (comma-separated)",
-        defaultValue: "127.0.0.1,localhost,::1",
-      },
-      {
-        label: "proxy-ssh",
-        description:
-          "Determines whether SSH commands should be proxied through the API server",
-        defaultValue: false,
-        valueType: ValueType.BOOLEAN,
-        input: {
-          type: InputType.SELECT,
-          options: BOOLEAN_OPTIONS,
-        },
-      },
-      {
-        label: "snap-http-proxy",
-        description: "The HTTP proxy value for installing snaps",
-      },
-      {
-        label: "snap-https-proxy",
-        description: "The snap-centric HTTPS proxy value",
-      },
-      {
-        label: "snap-store-assertions",
-        description: "The store assertions for the defined snap store proxy",
-      },
-      {
-        label: "snap-store-proxy",
-        description: "The snap store proxy for installing snaps",
-      },
-      {
-        label: "snap-store-proxy-url",
-        description: "The URL for the defined snap store proxy",
-      },
-    ],
+    label: "vpc-id-force",
+    description:
+      "Force Juju to use the GCE VPC ID specified with vpc-id, when it fails the minimum validation criteria",
+    defaultValue: false,
+    valueType: ValueType.BOOLEAN,
+    input: {
+      type: InputType.SELECT,
+      options: BOOLEAN_OPTIONS,
+    },
+    category: ConfigCategory.CLOUD,
   },
   {
-    category: "Provisioning & Machines",
-    fields: [
-      {
-        label: "cloudinit-userdata",
-        description:
-          "Cloud-init user-data (in yaml format) to be added to userdata for new machines created in this model",
-      },
-      {
-        label: "container-image-metadata-defaults-disabled",
-        description:
-          "Determines whether default simplestreams sources are used for image metadata with containers",
-        defaultValue: false,
-        valueType: ValueType.BOOLEAN,
-        input: {
-          type: InputType.SELECT,
-          options: BOOLEAN_OPTIONS,
-        },
-      },
-      {
-        label: "container-image-metadata-url",
-        description:
-          "The URL at which the metadata used to locate container OS image ids is located",
-      },
-      {
-        label: "container-image-stream",
-        description:
-          "The simplestreams stream used to identify which image ids to search when starting a container",
-        defaultValue: "released",
-      },
-      {
-        label: "container-inherit-properties",
-        description:
-          "The list of properties to be copied from the host machine to new containers created in this model (comma-separated)",
-      },
-      {
-        label: "default-base",
-        description:
-          "The default base image to use for deploying charms, will act like --base when deploying charms",
-      },
-      {
-        label: "default-series",
-        description:
-          "The default OS series to use for deploying charms (deprecated in favour of default-base)",
-      },
-      {
-        label: "enable-os-refresh-update",
-        description:
-          "Determines whether newly provisioned instances should run their respective OS's update capability",
-        defaultValue: true,
-        valueType: ValueType.BOOLEAN,
-        input: {
-          type: InputType.SELECT,
-          options: BOOLEAN_OPTIONS,
-        },
-      },
-      {
-        label: "enable-os-upgrade",
-        description:
-          "Determines whether newly provisioned instances should run their respective OS's upgrade capability",
-        defaultValue: true,
-        valueType: ValueType.BOOLEAN,
-        input: {
-          type: InputType.SELECT,
-          options: BOOLEAN_OPTIONS,
-        },
-      },
-      {
-        label: "image-metadata-defaults-disabled",
-        description:
-          "Determines whether default simplestreams sources are used for image metadata",
-        defaultValue: false,
-        valueType: ValueType.BOOLEAN,
-        input: {
-          type: InputType.SELECT,
-          options: BOOLEAN_OPTIONS,
-        },
-      },
-      {
-        label: "image-metadata-url",
-        description:
-          "The URL at which the metadata used to locate OS image ids is located",
-      },
-      {
-        label: "image-stream",
-        description:
-          "The simplestreams stream used to identify which image ids to search when starting an instance",
-        defaultValue: "released",
-      },
-      {
-        label: "lxd-snap-channel",
-        description:
-          "The channel to use when installing LXD from a snap (cosmic and later)",
-        defaultValue: "5.0/stable",
-      },
-      {
-        label: "num-container-provision-workers",
-        description:
-          "The number of container provisioning workers to use per machine",
-        defaultValue: 4,
-        valueType: ValueType.NUMBER,
-      },
-      {
-        label: "num-provision-workers",
-        description: "The number of provisioning workers to use per model",
-        defaultValue: 16,
-        valueType: ValueType.NUMBER,
-      },
-      {
-        label: "project",
-        description:
-          "The name of the cloud project or namespace to use for this model",
-        defaultValue: "default",
-      },
-      {
-        label: "provisioner-harvest-mode",
-        description:
-          "Sets what to do with unknown machines. Valid values: all, none, unknown, destroyed",
-        defaultValue: "destroyed",
-        input: {
-          type: InputType.SELECT,
-          options: [
-            { label: "all", value: "all" },
-            { label: "none", value: "none" },
-            { label: "unknown", value: "unknown" },
-            { label: "destroyed", value: "destroyed" },
-          ],
-        },
-      },
-      {
-        label: "resource-tags",
-        description:
-          "A space-separated list of key=value pairs used to apply as tags on supported cloud models",
-        defaultValue: "{}",
-      },
-    ],
+    label: "container-networking-method",
+    description: "The method of container networking setup",
+    defaultValue: "local",
+    input: {
+      type: InputType.SELECT,
+      options: [
+        { label: "local", value: "local" },
+        { label: "fan", value: "fan" },
+        { label: "provider", value: "provider" },
+      ],
+    },
+    category: ConfigCategory.NETWORKING,
   },
   {
-    category: "Logging",
-    fields: [
-      {
-        label: "logforward-enabled",
-        description: "Determines whether syslog forwarding is enabled",
-        defaultValue: false,
-        valueType: ValueType.BOOLEAN,
-        input: {
-          type: InputType.SELECT,
-          options: BOOLEAN_OPTIONS,
-        },
-      },
-      {
-        label: "logging-config",
-        description:
-          "The configuration string to use when configuring Juju agent logging",
-        defaultValue: "<root>=INFO",
-      },
-      {
-        label: "logging-output",
-        description: "The logging output destination: database and/or syslog",
-      },
-    ],
+    label: "default-space",
+    description: "The default network space used for application endpoints",
+    category: ConfigCategory.NETWORKING,
   },
   {
-    category: "Agents & Workloads",
-    fields: [
-      {
-        label: "agent-metadata-url",
-        description: "The URL of the private stream",
-      },
-      {
-        label: "agent-stream",
-        description: "The version of Juju to use for deploy/upgrades",
-        defaultValue: "released",
-      },
-      {
-        label: "agent-version",
-        description: "The desired Juju agent version to use",
-        // This value is the same as the controller version that the model will be on. Leaving it blank by default allows the UI to send any value explicitly set by the user.
-        // This is important to avoid the need for constant updates to this list and to support JIMM-cases where we don't know what the default would be ahead of time.
-        defaultValue: "",
-      },
-      {
-        label: "automatically-retry-hooks",
-        description:
-          "Determines whether the uniter should automatically retry failed hooks",
-        defaultValue: true,
-        valueType: ValueType.BOOLEAN,
-        input: {
-          type: InputType.SELECT,
-          options: BOOLEAN_OPTIONS,
-        },
-      },
-      {
-        label: "charmhub-url",
-        description: "The url for Charmhub API calls",
-        defaultValue: "https://api.charmhub.io",
-      },
-      {
-        label: "transmit-vendor-metrics",
-        description:
-          "Determines whether metrics declared by charms deployed into this model are sent for anonymized aggregate analytics",
-        defaultValue: true,
-        valueType: ValueType.BOOLEAN,
-        input: {
-          type: InputType.SELECT,
-          options: BOOLEAN_OPTIONS,
-        },
-      },
-      {
-        label: "update-status-hook-interval",
-        description:
-          "Sets how often to run the charm update-status hook, in human-readable time format (default 5m, range 1-60m)",
-        defaultValue: "5m",
-      },
-    ],
+    label: "disable-network-management",
+    description: "Determines whether the provider should control networks",
+    defaultValue: false,
+    valueType: ValueType.BOOLEAN,
+    input: {
+      type: InputType.SELECT,
+      options: BOOLEAN_OPTIONS,
+    },
+    category: ConfigCategory.NETWORKING,
   },
   {
-    category: "Storage & Secrets",
-    fields: [
-      {
-        label: "backup-dir",
-        description: "The directory used to store the backup working directory",
-      },
-      {
-        label: "secret-backend",
-        description:
-          "The name of the secret store backend. Valid values: internal, auto, or a backend name",
-        defaultValue: "auto",
-      },
-      {
-        label: "storage-default-filesystem-source",
-        description: "The default filesystem storage source for the model",
-        defaultValue: "lxd",
-      },
-      {
-        label: "max-action-results-age",
-        description:
-          "The maximum age for action entries before they are pruned, in human-readable time format",
-        defaultValue: "336h",
-      },
-      {
-        label: "max-action-results-size",
-        description:
-          "The maximum size for the action collection, in human-readable memory format",
-        defaultValue: "5G",
-      },
-      {
-        label: "max-status-history-age",
-        description:
-          "The maximum age for status history entries before they are pruned, in human-readable time format",
-        defaultValue: "336h",
-      },
-      {
-        label: "max-status-history-size",
-        description:
-          "The maximum size for the status history collection, in human-readable memory format",
-        defaultValue: "5G",
-      },
-    ],
+    label: "egress-subnets",
+    description:
+      "The source address(es) for traffic originating from this model",
+    category: ConfigCategory.NETWORKING,
   },
   {
-    category: "Operations & Miscellaneous",
-    fields: [
-      {
-        label: "development",
-        description:
-          "Determines whether development mode is enabled for this model",
-        defaultValue: false,
-        valueType: ValueType.BOOLEAN,
-        input: {
-          type: InputType.SELECT,
-          options: BOOLEAN_OPTIONS,
-        },
-      },
-      {
-        label: "disable-telemetry",
-        description:
-          "Determines whether telemetry collection is disabled for this model",
-        defaultValue: false,
-        valueType: ValueType.BOOLEAN,
-        input: {
-          type: InputType.SELECT,
-          options: BOOLEAN_OPTIONS,
-        },
-      },
-      {
-        label: "mode",
-        description: "The operation mode for model commands",
-        defaultValue: "requires-prompts",
-      },
-      {
-        label: "test-mode",
-        description: "Determines whether test mode is enabled for this model",
-        defaultValue: false,
-        valueType: ValueType.BOOLEAN,
-        input: {
-          type: InputType.SELECT,
-          options: BOOLEAN_OPTIONS,
-        },
-      },
-    ],
+    label: "fan-config",
+    description: "The configuration for fan networking for this model",
+    category: ConfigCategory.NETWORKING,
+  },
+  {
+    label: "firewall-mode",
+    description: "The mode to use for network firewalling",
+    defaultValue: "instance",
+    input: {
+      type: InputType.SELECT,
+      options: [
+        { label: "Instance", value: "instance" },
+        { label: "Global", value: "global" },
+        { label: "None", value: "none" },
+      ],
+    },
+    category: ConfigCategory.NETWORKING,
+  },
+  {
+    label: "ignore-machine-addresses",
+    description:
+      "Determines whether the machine worker should discover machine addresses on startup",
+    defaultValue: false,
+    valueType: ValueType.BOOLEAN,
+    input: {
+      type: InputType.SELECT,
+      options: BOOLEAN_OPTIONS,
+    },
+    category: ConfigCategory.NETWORKING,
+  },
+  {
+    label: "net-bond-reconfigure-delay",
+    description:
+      "The amount of time in seconds to sleep between ifdown and ifup when bridging",
+    defaultValue: 17,
+    valueType: ValueType.NUMBER,
+    category: ConfigCategory.NETWORKING,
+  },
+  {
+    label: "saas-ingress-allow",
+    description: "The CIDR allowlist for SAAS ingress traffic to this model",
+    defaultValue: "0.0.0.0/0,::/0",
+    category: ConfigCategory.NETWORKING,
+  },
+  {
+    label: "ssh-allow",
+    description: "The CIDR allowlist for SSH access to instances in this model",
+    defaultValue: "0.0.0.0/0,::/0",
+    category: ConfigCategory.NETWORKING,
+  },
+  {
+    label: "ssl-hostname-verification",
+    description: "Determines whether SSL hostname verification is enabled",
+    defaultValue: true,
+    valueType: ValueType.BOOLEAN,
+    input: {
+      type: InputType.SELECT,
+      options: BOOLEAN_OPTIONS,
+    },
+    category: ConfigCategory.NETWORKING,
+  },
+  {
+    label: "apt-ftp-proxy",
+    description: "The APT FTP proxy for the model",
+    category: ConfigCategory.PROXY,
+  },
+  {
+    label: "apt-http-proxy",
+    description: "The APT HTTP proxy for the model",
+    category: ConfigCategory.PROXY,
+  },
+  {
+    label: "apt-https-proxy",
+    description: "The APT HTTPS proxy for the model",
+    category: ConfigCategory.PROXY,
+  },
+  {
+    label: "apt-mirror",
+    description: "The APT mirror for the model",
+    category: ConfigCategory.PROXY,
+  },
+  {
+    label: "apt-no-proxy",
+    description:
+      "The list of domain addresses not to be proxied for APT (comma-separated)",
+    category: ConfigCategory.PROXY,
+  },
+  {
+    label: "ftp-proxy",
+    description:
+      "The FTP proxy value to configure on instances, in the FTP_PROXY environment variable",
+    category: ConfigCategory.PROXY,
+  },
+  {
+    label: "http-proxy",
+    description:
+      "The HTTP proxy value to configure on instances, in the HTTP_PROXY environment variable",
+    category: ConfigCategory.PROXY,
+  },
+  {
+    label: "https-proxy",
+    description:
+      "The HTTPS proxy value to configure on instances, in the HTTPS_PROXY environment variable",
+    category: ConfigCategory.PROXY,
+  },
+  {
+    label: "juju-ftp-proxy",
+    description:
+      "The FTP proxy value to pass to charms in the JUJU_CHARM_FTP_PROXY environment variable",
+    category: ConfigCategory.PROXY,
+  },
+  {
+    label: "juju-http-proxy",
+    description:
+      "The HTTP proxy value to pass to charms in the JUJU_CHARM_HTTP_PROXY environment variable",
+    category: ConfigCategory.PROXY,
+  },
+  {
+    label: "juju-https-proxy",
+    description:
+      "The HTTPS proxy value to pass to charms in the JUJU_CHARM_HTTPS_PROXY environment variable",
+    category: ConfigCategory.PROXY,
+  },
+  {
+    label: "juju-no-proxy",
+    description:
+      "The list of domain addresses not to be proxied (comma-separated), may contain CIDRs. Passed to charms in the JUJU_CHARM_NO_PROXY environment variable",
+    defaultValue: "127.0.0.1,localhost,::1",
+    category: ConfigCategory.PROXY,
+  },
+  {
+    label: "no-proxy",
+    description:
+      "The list of domain addresses not to be proxied (comma-separated)",
+    defaultValue: "127.0.0.1,localhost,::1",
+    category: ConfigCategory.PROXY,
+  },
+  {
+    label: "proxy-ssh",
+    description:
+      "Determines whether SSH commands should be proxied through the API server",
+    defaultValue: false,
+    valueType: ValueType.BOOLEAN,
+    input: {
+      type: InputType.SELECT,
+      options: BOOLEAN_OPTIONS,
+    },
+    category: ConfigCategory.PROXY,
+  },
+  {
+    label: "snap-http-proxy",
+    description: "The HTTP proxy value for installing snaps",
+    category: ConfigCategory.PROXY,
+  },
+  {
+    label: "snap-https-proxy",
+    description: "The snap-centric HTTPS proxy value",
+    category: ConfigCategory.PROXY,
+  },
+  {
+    label: "snap-store-assertions",
+    description: "The store assertions for the defined snap store proxy",
+    category: ConfigCategory.PROXY,
+  },
+  {
+    label: "snap-store-proxy",
+    description: "The snap store proxy for installing snaps",
+    category: ConfigCategory.PROXY,
+  },
+  {
+    label: "snap-store-proxy-url",
+    description: "The URL for the defined snap store proxy",
+    category: ConfigCategory.PROXY,
+  },
+  {
+    label: "cloudinit-userdata",
+    description:
+      "Cloud-init user-data (in yaml format) to be added to userdata for new machines created in this model",
+    category: ConfigCategory.PROVISIONING,
+  },
+  {
+    label: "container-image-metadata-defaults-disabled",
+    description:
+      "Determines whether default simplestreams sources are used for image metadata with containers",
+    defaultValue: false,
+    valueType: ValueType.BOOLEAN,
+    input: {
+      type: InputType.SELECT,
+      options: BOOLEAN_OPTIONS,
+    },
+    category: ConfigCategory.PROVISIONING,
+  },
+  {
+    label: "container-image-metadata-url",
+    description:
+      "The URL at which the metadata used to locate container OS image ids is located",
+    category: ConfigCategory.PROVISIONING,
+  },
+  {
+    label: "container-image-stream",
+    description:
+      "The simplestreams stream used to identify which image ids to search when starting a container",
+    defaultValue: "released",
+    category: ConfigCategory.PROVISIONING,
+  },
+  {
+    label: "container-inherit-properties",
+    description:
+      "The list of properties to be copied from the host machine to new containers created in this model (comma-separated)",
+    category: ConfigCategory.PROVISIONING,
+  },
+  {
+    label: "default-base",
+    description:
+      "The default base image to use for deploying charms, will act like --base when deploying charms",
+    category: ConfigCategory.PROVISIONING,
+  },
+  {
+    label: "default-series",
+    description:
+      "The default OS series to use for deploying charms (deprecated in favour of default-base)",
+    category: ConfigCategory.PROVISIONING,
+  },
+  {
+    label: "enable-os-refresh-update",
+    description:
+      "Determines whether newly provisioned instances should run their respective OS's update capability",
+    defaultValue: true,
+    valueType: ValueType.BOOLEAN,
+    input: {
+      type: InputType.SELECT,
+      options: BOOLEAN_OPTIONS,
+    },
+    category: ConfigCategory.PROVISIONING,
+  },
+  {
+    label: "enable-os-upgrade",
+    description:
+      "Determines whether newly provisioned instances should run their respective OS's upgrade capability",
+    defaultValue: true,
+    valueType: ValueType.BOOLEAN,
+    input: {
+      type: InputType.SELECT,
+      options: BOOLEAN_OPTIONS,
+    },
+    category: ConfigCategory.PROVISIONING,
+  },
+  {
+    label: "image-metadata-defaults-disabled",
+    description:
+      "Determines whether default simplestreams sources are used for image metadata",
+    defaultValue: false,
+    valueType: ValueType.BOOLEAN,
+    input: {
+      type: InputType.SELECT,
+      options: BOOLEAN_OPTIONS,
+    },
+    category: ConfigCategory.PROVISIONING,
+  },
+  {
+    label: "image-metadata-url",
+    description:
+      "The URL at which the metadata used to locate OS image ids is located",
+    category: ConfigCategory.PROVISIONING,
+  },
+  {
+    label: "image-stream",
+    description:
+      "The simplestreams stream used to identify which image ids to search when starting an instance",
+    defaultValue: "released",
+    category: ConfigCategory.PROVISIONING,
+  },
+  {
+    label: "lxd-snap-channel",
+    description:
+      "The channel to use when installing LXD from a snap (cosmic and later)",
+    defaultValue: "5.0/stable",
+    category: ConfigCategory.PROVISIONING,
+  },
+  {
+    label: "num-container-provision-workers",
+    description:
+      "The number of container provisioning workers to use per machine",
+    defaultValue: 4,
+    valueType: ValueType.NUMBER,
+    category: ConfigCategory.PROVISIONING,
+  },
+  {
+    label: "num-provision-workers",
+    description: "The number of provisioning workers to use per model",
+    defaultValue: 16,
+    valueType: ValueType.NUMBER,
+    category: ConfigCategory.PROVISIONING,
+  },
+  {
+    label: "project",
+    description:
+      "The name of the cloud project or namespace to use for this model",
+    defaultValue: "default",
+    category: ConfigCategory.PROVISIONING,
+  },
+  {
+    label: "provisioner-harvest-mode",
+    description:
+      "Sets what to do with unknown machines. Valid values: all, none, unknown, destroyed",
+    defaultValue: "destroyed",
+    input: {
+      type: InputType.SELECT,
+      options: [
+        { label: "all", value: "all" },
+        { label: "none", value: "none" },
+        { label: "unknown", value: "unknown" },
+        { label: "destroyed", value: "destroyed" },
+      ],
+    },
+    category: ConfigCategory.PROVISIONING,
+  },
+  {
+    label: "resource-tags",
+    description:
+      "A space-separated list of key=value pairs used to apply as tags on supported cloud models",
+    defaultValue: "{}",
+    category: ConfigCategory.PROVISIONING,
+  },
+  {
+    label: "logforward-enabled",
+    description: "Determines whether syslog forwarding is enabled",
+    defaultValue: false,
+    valueType: ValueType.BOOLEAN,
+    input: {
+      type: InputType.SELECT,
+      options: BOOLEAN_OPTIONS,
+    },
+    category: ConfigCategory.LOGGING,
+  },
+  {
+    label: "logging-config",
+    description:
+      "The configuration string to use when configuring Juju agent logging",
+    defaultValue: "<root>=INFO",
+    category: ConfigCategory.LOGGING,
+  },
+  {
+    label: "logging-output",
+    description: "The logging output destination: database and/or syslog",
+    category: ConfigCategory.LOGGING,
+  },
+  {
+    label: "agent-metadata-url",
+    description: "The URL of the private stream",
+    category: ConfigCategory.AGENTS,
+  },
+  {
+    label: "agent-stream",
+    description: "The version of Juju to use for deploy/upgrades",
+    defaultValue: "released",
+    category: ConfigCategory.AGENTS,
+  },
+  {
+    label: "agent-version",
+    description: "The desired Juju agent version to use",
+    // This value is the same as the controller version that the model will be on. Leaving it blank by default allows the UI to send any value explicitly set by the user.
+    // This is important to avoid the need for constant updates to this list and to support JIMM-cases where we don't know what the default would be ahead of time.
+    defaultValue: "",
+    category: ConfigCategory.AGENTS,
+  },
+  {
+    label: "automatically-retry-hooks",
+    description:
+      "Determines whether the uniter should automatically retry failed hooks",
+    defaultValue: true,
+    valueType: ValueType.BOOLEAN,
+    input: {
+      type: InputType.SELECT,
+      options: BOOLEAN_OPTIONS,
+    },
+    category: ConfigCategory.AGENTS,
+  },
+  {
+    label: "charmhub-url",
+    description: "The url for Charmhub API calls",
+    defaultValue: "https://api.charmhub.io",
+    category: ConfigCategory.AGENTS,
+  },
+  {
+    label: "transmit-vendor-metrics",
+    description:
+      "Determines whether metrics declared by charms deployed into this model are sent for anonymized aggregate analytics",
+    defaultValue: true,
+    valueType: ValueType.BOOLEAN,
+    input: {
+      type: InputType.SELECT,
+      options: BOOLEAN_OPTIONS,
+    },
+    category: ConfigCategory.AGENTS,
+  },
+  {
+    label: "update-status-hook-interval",
+    description:
+      "Sets how often to run the charm update-status hook, in human-readable time format (default 5m, range 1-60m)",
+    defaultValue: "5m",
+    category: ConfigCategory.AGENTS,
+  },
+  {
+    label: "backup-dir",
+    description: "The directory used to store the backup working directory",
+    category: ConfigCategory.STORAGE,
+  },
+  {
+    label: "secret-backend",
+    description:
+      "The name of the secret store backend. Valid values: internal, auto, or a backend name",
+    defaultValue: "auto",
+    category: ConfigCategory.STORAGE,
+  },
+  {
+    label: "storage-default-filesystem-source",
+    description: "The default filesystem storage source for the model",
+    defaultValue: "lxd",
+    category: ConfigCategory.STORAGE,
+  },
+  {
+    label: "max-action-results-age",
+    description:
+      "The maximum age for action entries before they are pruned, in human-readable time format",
+    defaultValue: "336h",
+    category: ConfigCategory.STORAGE,
+  },
+  {
+    label: "max-action-results-size",
+    description:
+      "The maximum size for the action collection, in human-readable memory format",
+    defaultValue: "5G",
+    category: ConfigCategory.STORAGE,
+  },
+  {
+    label: "max-status-history-age",
+    description:
+      "The maximum age for status history entries before they are pruned, in human-readable time format",
+    defaultValue: "336h",
+    category: ConfigCategory.STORAGE,
+  },
+  {
+    label: "max-status-history-size",
+    description:
+      "The maximum size for the status history collection, in human-readable memory format",
+    defaultValue: "5G",
+    category: ConfigCategory.STORAGE,
+  },
+  {
+    label: "development",
+    description:
+      "Determines whether development mode is enabled for this model",
+    defaultValue: false,
+    valueType: ValueType.BOOLEAN,
+    input: {
+      type: InputType.SELECT,
+      options: BOOLEAN_OPTIONS,
+    },
+    category: ConfigCategory.OPERATIONS,
+  },
+  {
+    label: "disable-telemetry",
+    description:
+      "Determines whether telemetry collection is disabled for this model",
+    defaultValue: false,
+    valueType: ValueType.BOOLEAN,
+    input: {
+      type: InputType.SELECT,
+      options: BOOLEAN_OPTIONS,
+    },
+    category: ConfigCategory.OPERATIONS,
+  },
+  {
+    label: "mode",
+    description: "The operation mode for model commands",
+    defaultValue: "requires-prompts",
+    category: ConfigCategory.OPERATIONS,
+  },
+  {
+    label: "test-mode",
+    description: "Determines whether test mode is enabled for this model",
+    defaultValue: false,
+    valueType: ValueType.BOOLEAN,
+    input: {
+      type: InputType.SELECT,
+      options: BOOLEAN_OPTIONS,
+    },
+    category: ConfigCategory.OPERATIONS,
   },
 ];

--- a/src/pages/AddModel/ConfigsConstraints/constraintsCatalog.ts
+++ b/src/pages/AddModel/ConfigsConstraints/constraintsCatalog.ts
@@ -2,127 +2,127 @@
 
 import { BOOLEAN_OPTIONS } from "consts";
 
-import type { CategoryDefinition } from "./types";
+import type { ConfigFieldEntry } from "./types";
 import { InputType, ValueType } from "./types";
+
+export enum ConstraintCategory {
+  COMPUTE = "Compute",
+  NETWORKING = "Networking & Placement",
+  PLATFORM = "Platform & Image",
+  STORAGE = "Storage",
+  IDENTITY = "Identity & Tagging",
+}
 
 const EMPTY_OPTION = { label: "Unset", value: "" };
 
-export const CONSTRAINT_CATEGORIES: CategoryDefinition[] = [
+export const CONSTRAINT_DEFINITIONS: Omit<
+  ConfigFieldEntry,
+  "arrayIndex" | "value"
+>[] = [
   {
-    category: "Compute",
-    fields: [
-      {
-        label: "cores",
-        description: "Number of effective CPU cores (alias: cpu-cores)",
-        valueType: ValueType.NUMBER,
-      },
-      {
-        label: "cpu-power",
-        description: "Abstract CPU power (100 units ≈ 1 Amazon vCPU)",
-        valueType: ValueType.NUMBER,
-      },
-      {
-        label: "mem",
-        description: "Memory in MiB (supports M/G/T/P suffixes)",
-      },
-      {
-        label: "instance-type",
-        description: "Cloud-specific instance type name (e.g. m6i.large)",
-      },
-    ],
+    label: "cores",
+    description: "Number of effective CPU cores (alias: cpu-cores)",
+    valueType: ValueType.NUMBER,
+    category: ConstraintCategory.COMPUTE,
   },
   {
-    category: "Networking & Placement",
-    fields: [
-      {
-        label: "spaces",
-        description:
-          "A comma-delimited list of Juju network space names that a unit or machine needs access to",
-      },
-      {
-        label: "zones",
-        description:
-          "A list of availability zones. Multiple values present a range of zones that a machine must be created within",
-      },
-      {
-        label: "allocate-public-ip",
-        description:
-          "Supplying this constraint will determine whether machines are issued an IP address accessible outside of the cloud’s virtual network",
-        valueType: ValueType.BOOLEAN,
-        input: {
-          type: InputType.SELECT,
-          options: [EMPTY_OPTION, ...BOOLEAN_OPTIONS],
-        },
-      },
-    ],
+    label: "cpu-power",
+    description: "Abstract CPU power (100 units ≈ 1 Amazon vCPU)",
+    valueType: ValueType.NUMBER,
+    category: ConstraintCategory.COMPUTE,
   },
   {
-    category: "Platform & Image",
-    fields: [
-      {
-        label: "arch",
-        description: "CPU architecture (amd64, arm64, ppc64el, s390x, riscv64)",
-        input: {
-          type: InputType.SELECT,
-          options: [
-            EMPTY_OPTION,
-            { label: "amd64", value: "amd64" },
-            { label: "arm64", value: "arm64" },
-            { label: "ppc64el", value: "ppc64el" },
-            { label: "s390x", value: "s390x" },
-            { label: "riscv64", value: "riscv64" },
-          ],
-        },
-      },
-      {
-        label: "virt-type",
-        description: "Virtualisation type (LXD, OpenStack only)",
-      },
-      {
-        label: "container",
-        description:
-          "Indicates that a machine must be the specified container type",
-        input: {
-          type: InputType.SELECT,
-          options: [
-            EMPTY_OPTION,
-            { label: "LXD", value: "lxd" },
-            { label: "KVM", value: "kvm" },
-          ],
-        },
-      },
-      {
-        label: "image-id",
-        description: "Indicates that a machine must use the specified image",
-      },
-    ],
+    label: "mem",
+    description: "Memory in MiB (supports M/G/T/P suffixes)",
+    category: ConstraintCategory.COMPUTE,
   },
   {
-    category: "Storage",
-    fields: [
-      {
-        label: "root-disk",
-        description:
-          "Disk space on root drive in MiB (supports M/G/T/P suffixes)",
-      },
-      {
-        label: "root-disk-source",
-        description: "Name of storage pool or location the root disk is from",
-      },
-    ],
+    label: "instance-type",
+    description: "Cloud-specific instance type name (e.g. m6i.large)",
+    category: ConstraintCategory.COMPUTE,
   },
   {
-    category: "Identity & Tagging",
-    fields: [
-      {
-        label: "instance-role",
-        description:
-          "Cloud IAM role/profile (AWS instance profiles, Azure managed identities)",
-      },
-      {
-        label: "tags",
-        description: "Comma-delimited tags assigned to the machine",
-      },
-    ],
+    label: "spaces",
+    description:
+      "A comma-delimited list of Juju network space names that a unit or machine needs access to",
+    category: ConstraintCategory.NETWORKING,
+  },
+  {
+    label: "zones",
+    description:
+      "A list of availability zones. Multiple values present a range of zones that a machine must be created within",
+    category: ConstraintCategory.NETWORKING,
+  },
+  {
+    label: "allocate-public-ip",
+    description:
+      "Supplying this constraint will determine whether machines are issued an IP address accessible outside of the cloud’s virtual network",
+    valueType: ValueType.BOOLEAN,
+    input: {
+      type: InputType.SELECT,
+      options: [EMPTY_OPTION, ...BOOLEAN_OPTIONS],
+    },
+    category: ConstraintCategory.NETWORKING,
+  },
+  {
+    label: "arch",
+    description: "CPU architecture (amd64, arm64, ppc64el, s390x, riscv64)",
+    input: {
+      type: InputType.SELECT,
+      options: [
+        EMPTY_OPTION,
+        { label: "amd64", value: "amd64" },
+        { label: "arm64", value: "arm64" },
+        { label: "ppc64el", value: "ppc64el" },
+        { label: "s390x", value: "s390x" },
+        { label: "riscv64", value: "riscv64" },
+      ],
+    },
+    category: ConstraintCategory.PLATFORM,
+  },
+  {
+    label: "virt-type",
+    description: "Virtualisation type (LXD, OpenStack only)",
+    category: ConstraintCategory.PLATFORM,
+  },
+  {
+    label: "container",
+    description:
+      "Indicates that a machine must be the specified container type",
+    input: {
+      type: InputType.SELECT,
+      options: [
+        EMPTY_OPTION,
+        { label: "LXD", value: "lxd" },
+        { label: "KVM", value: "kvm" },
+      ],
+    },
+    category: ConstraintCategory.PLATFORM,
+  },
+  {
+    label: "image-id",
+    description: "Indicates that a machine must use the specified image",
+    category: ConstraintCategory.PLATFORM,
+  },
+  {
+    label: "root-disk",
+    description: "Disk space on root drive in MiB (supports M/G/T/P suffixes)",
+    category: ConstraintCategory.STORAGE,
+  },
+  {
+    label: "root-disk-source",
+    description: "Name of storage pool or location the root disk is from",
+    category: ConstraintCategory.STORAGE,
+  },
+  {
+    label: "instance-role",
+    description:
+      "Cloud IAM role/profile (AWS instance profiles, Azure managed identities)",
+    category: ConstraintCategory.IDENTITY,
+  },
+  {
+    label: "tags",
+    description: "Comma-delimited tags assigned to the machine",
+    category: ConstraintCategory.IDENTITY,
   },
 ];

--- a/src/pages/AddModel/ConfigsConstraints/types.ts
+++ b/src/pages/AddModel/ConfigsConstraints/types.ts
@@ -1,10 +1,11 @@
 import type { DisableType } from "store/juju/types";
+import type { ConfigFieldEntry } from "store/middleware/source/types";
 
 import type { InputMode } from "../types";
 
 export type {
-  CategoryDefinition,
   CategoryDefinitionField,
+  ConfigFieldEntry,
   ConfigFieldValue,
 } from "store/middleware/source/types";
 export { InputType, ValueType } from "store/middleware/source/types";
@@ -13,6 +14,11 @@ export { DisableType } from "store/juju/types";
 export enum TestId {
   CONFIGS_CONSTRAINTS_FORM = "configs-constraints-form",
 }
+
+export type CategoryDefinition = {
+  category: null | string;
+  fields: ConfigFieldEntry[];
+};
 
 export enum Label {
   CONFIGS_TITLE = "Configurations (optional)",
@@ -38,6 +44,8 @@ export enum Label {
 }
 
 export enum FieldName {
+  CONFIG_FIELDS = "configFields",
+  CONSTRAINT_FIELDS = "constraintFields",
   CONFIG_INPUT_MODE = "configInputMode",
   CONSTRAINT_INPUT_MODE = "constraintInputMode",
   CONFIG_YAML = "configYAML",
@@ -46,6 +54,8 @@ export enum FieldName {
 }
 
 export type FormFields = {
+  [FieldName.CONFIG_FIELDS]: ConfigFieldEntry[];
+  [FieldName.CONSTRAINT_FIELDS]: ConfigFieldEntry[];
   [FieldName.CONFIG_INPUT_MODE]: InputMode;
   [FieldName.CONSTRAINT_INPUT_MODE]: InputMode;
   [FieldName.CONFIG_YAML]: string;

--- a/src/pages/AddModel/ConfigsConstraints/utils.test.ts
+++ b/src/pages/AddModel/ConfigsConstraints/utils.test.ts
@@ -1,431 +1,291 @@
+import * as yaml from "yaml";
+
 import { YAMLErrorType } from "./YAMLErrorsModal/types";
-import type { CategoryDefinition } from "./types";
+import { ConfigCategory } from "./configCatalog";
+import { ConstraintCategory } from "./constraintsCatalog";
+import type { ConfigFieldEntry, ConfigFieldValue } from "./types";
 import { InputType, ValueType } from "./types";
 import {
   buildConfigsConstraintsPayload,
   buildYAML,
-  filterCategoriesBySearch,
-  getChangedFields,
-  getCategoriesWithVisibleFields,
-  getConfigInitialValues,
+  filterEntriesBySearch,
   getYAMLErrorMessage,
+  groupEntriesByCategory,
   isConfigChanged,
   validateAndParseYAML,
 } from "./utils";
 
+vi.mock("yaml", async (importActual) => ({
+  ...(await importActual<typeof yaml>()),
+}));
+
 describe("utils", () => {
-  let categories: CategoryDefinition[];
+  let entries: ConfigFieldEntry[];
 
   beforeEach(() => {
-    categories = [
+    entries = [
       {
-        category: "Networking",
-        fields: [
-          {
-            label: "default-space",
-            defaultValue: "alpha",
-            description: "Default space",
-          },
-          {
-            label: "container-networking-method",
-            defaultValue: "provider",
-            description: "Networking method",
-          },
-        ],
+        label: "default-space",
+        category: ConfigCategory.NETWORKING,
+        defaultValue: "alpha",
+        value: "alpha",
+        description: "Default space",
+        arrayIndex: 0,
       },
       {
-        category: "Compute",
-        fields: [
-          {
-            label: "cores",
-            description: "Number of cores",
-            valueType: ValueType.NUMBER,
-          },
-        ],
+        label: "container-networking-method",
+        category: ConfigCategory.NETWORKING,
+        defaultValue: "provider",
+        value: "provider",
+        description: "Networking method",
+        arrayIndex: 1,
       },
       {
-        category: "Logging",
-        fields: [
-          {
-            label: "logging-config",
-            defaultValue: "",
-            description: "Logging config",
-          },
-        ],
+        label: "cores",
+        category: ConstraintCategory.COMPUTE,
+        value: "",
+        valueType: ValueType.NUMBER,
+        arrayIndex: 2,
       },
       {
-        category: "Cloud-specific configurations",
-        fields: [
-          {
-            label: "vpc-id-force",
-            description: "VPC ID",
-            defaultValue: false,
-            valueType: ValueType.BOOLEAN,
-          },
-        ],
+        label: "logging-config",
+        category: ConfigCategory.LOGGING,
+        defaultValue: "",
+        value: "",
+        description: "Logging config",
+        arrayIndex: 3,
+      },
+      {
+        label: "vpc-id-force",
+        category: ConfigCategory.CLOUD,
+        defaultValue: false,
+        value: false,
+        valueType: ValueType.BOOLEAN,
+        arrayIndex: 4,
       },
     ];
   });
 
   describe("isConfigChanged", () => {
-    it("returns false when value is undefined", () => {
-      const result = isConfigChanged("some-label", {}, "default-value");
-      expect(result).toBe(false);
-    });
-
-    it("returns false when value matches the default value", () => {
-      const result = isConfigChanged(
-        "some-label",
-        { "some-label": "default-value" },
-        "default-value",
-      );
-      expect(result).toBe(false);
-    });
-
-    it("returns true when value differs from the default value", () => {
-      const result = isConfigChanged(
-        "some-label",
-        { "some-label": "different-value" },
-        "default-value",
-      );
-      expect(result).toBe(true);
-    });
-
-    it("returns true when value is non-empty and no default is provided", () => {
-      const result = isConfigChanged(
-        "some-label",
-        { "some-label": "some-value" },
-        undefined,
-      );
-      expect(result).toBe(true);
-    });
-
-    it("returns true when a numeric value has no default", () => {
-      const result = isConfigChanged(
-        "some-label",
-        { "some-label": 0 },
-        undefined,
-      );
-      expect(result).toBe(true);
-    });
-
-    it("returns false when a numeric value matches a numeric default", () => {
-      const result = isConfigChanged("some-label", { "some-label": 0 }, 0);
-      expect(result).toBe(false);
-    });
-
-    it("returns false when a boolean value matches the default", () => {
-      const result = isConfigChanged(
-        "some-label",
-        { "some-label": false },
-        false,
-      );
-      expect(result).toBe(false);
-    });
-
-    it("returns true when a boolean value differs from the default", () => {
-      const result = isConfigChanged(
-        "some-label",
-        { "some-label": true },
-        false,
-      );
-      expect(result).toBe(true);
+    it.each([
+      {
+        description: "returns false when value is undefined",
+        value: undefined,
+        defaultValue: "d",
+        expected: false,
+      },
+      {
+        description: "returns false when value matches the default value",
+        value: "default-value",
+        defaultValue: "default-value",
+        expected: false,
+      },
+      {
+        description: "returns true when value differs from the default value",
+        value: "different",
+        defaultValue: "default-value",
+        expected: true,
+      },
+      {
+        description:
+          "returns true when value is non-empty and no default is provided",
+        value: "some-value",
+        defaultValue: undefined,
+        expected: true,
+      },
+      {
+        description: "returns true when a numeric value has no default",
+        value: 0,
+        defaultValue: undefined,
+        expected: true,
+      },
+      {
+        description:
+          "returns false when a numeric value matches a numeric default",
+        value: 0,
+        defaultValue: 0,
+        expected: false,
+      },
+      {
+        description: "returns false when a boolean value matches the default",
+        value: false,
+        defaultValue: false,
+        expected: false,
+      },
+      {
+        description:
+          "returns true when a boolean value differs from the default",
+        value: true,
+        defaultValue: false,
+        expected: true,
+      },
+    ])("$description", ({ value, defaultValue, expected }) => {
+      expect(
+        isConfigChanged({
+          label: "x",
+          category: null,
+          value,
+          arrayIndex: 0,
+          defaultValue,
+        }),
+      ).toBe(expected);
     });
   });
 
-  describe("getChangedFields", () => {
-    const category: CategoryDefinition = {
-      category: "Networking",
-      fields: [
-        {
-          label: "default-space",
-          defaultValue: "alpha",
-          description: "Default space",
-        },
-        {
-          label: "container-networking-method",
-          defaultValue: "provider",
-          description: "Networking method",
-        },
-        {
-          label: "logging-config",
-          defaultValue: "",
-          description: "Logging config",
-        },
-      ],
-    };
-
-    it("returns empty array when nothing has changed", () => {
-      const result = getChangedFields(category, {
-        "default-space": "alpha",
-        "container-networking-method": "provider",
-        "logging-config": "",
-      });
-      expect(result).toEqual([]);
-    });
-
-    it("filters changed fields", () => {
-      const result = getChangedFields(category, {
-        "default-space": "modified-space",
-        "container-networking-method": "provider",
-        "logging-config": "debug",
-      });
-      expect(result).toHaveLength(2);
-      expect(result.map((field) => field.label)).toEqual([
-        "default-space",
-        "logging-config",
-      ]);
+  describe("groupEntriesByCategory", () => {
+    it("groups entries preserving category order", () => {
+      const groups = groupEntriesByCategory(entries);
+      expect(groups).toHaveLength(4);
+      expect(groups[0].category).toBe(ConfigCategory.NETWORKING);
+      expect(groups[0].fields).toHaveLength(2);
+      expect(groups[1].category).toBe(ConstraintCategory.COMPUTE);
     });
   });
 
   describe("buildYAML", () => {
     it("returns empty string when no fields have changed", () => {
-      const result = buildYAML(categories, {});
-      expect(result).toBe("");
+      expect(buildYAML(entries)).toBe("");
     });
 
     it("builds YAML with category headers and field values", () => {
-      const result = buildYAML(categories, {
-        "default-space": "custom-space",
-      });
-
+      entries[0].value = "custom-space";
+      const result = buildYAML(entries);
       expect(result).toContain("# Networking");
       expect(result).toContain("default-space: custom-space");
       expect(result).not.toContain("# Logging");
     });
 
     it("includes multiple categories separated by blank lines", () => {
-      const result = buildYAML(categories, {
-        "default-space": "custom-space",
-        "logging-config": "debug",
-      });
+      entries[0].value = "custom-space";
+      entries[3].value = "debug";
 
-      const sections = result.split("\n\n");
+      const sections = buildYAML(entries).split("\n\n");
       expect(sections).toHaveLength(2);
       expect(sections[0]).toContain("# Networking");
       expect(sections[1]).toContain("# Logging");
     });
 
     it("includes only changed fields in the output", () => {
-      const result = buildYAML(categories, {
-        "default-space": "custom-space",
-        "container-networking-method": "provider",
-        "logging-config": "debug",
-        "logging-level": "warning",
-      });
+      entries[0].value = "custom-space";
+      entries[3].value = "debug";
 
+      const result = buildYAML(entries);
       expect(result).toContain("default-space: custom-space");
       expect(result).not.toContain("container-networking-method");
       expect(result).toContain("logging-config: debug");
-      expect(result).not.toContain("logging-level");
     });
   });
 
   describe("buildConfigsConstraintsPayload", () => {
     it("returns empty object when no fields have changed", () => {
-      const result = buildConfigsConstraintsPayload({
-        "container-networking-method": "local",
-        "logging-config": "<root>=INFO",
-        arch: "",
-      });
-      expect(result).toEqual({});
+      expect(buildConfigsConstraintsPayload(entries, [])).toEqual({});
     });
 
     it("returns only changed field labels and values", () => {
-      const result = buildConfigsConstraintsPayload({
+      entries[0].value = "custom-space";
+      entries[3].value = "debug";
+      expect(buildConfigsConstraintsPayload(entries, [])).toEqual({
         "default-space": "custom-space",
-        "container-networking-method": "local",
-        "logging-config": "<root>=DEBUG",
-        arch: "amd64",
-      });
-      expect(result).toEqual({
-        "default-space": "custom-space",
-        "logging-config": "<root>=DEBUG",
-        arch: "amd64",
+        "logging-config": "debug",
       });
     });
 
     it("includes changed boolean fields in the payload", () => {
-      const result = buildConfigsConstraintsPayload({
-        "disable-network-management": true,
-      });
-      expect(result["disable-network-management"]).toBe(true);
+      entries[4].value = true;
+      expect(buildConfigsConstraintsPayload(entries, [])["vpc-id-force"]).toBe(
+        true,
+      );
     });
 
     it("does not include boolean fields that match their default value", () => {
-      const result = buildConfigsConstraintsPayload({
-        "disable-network-management": false,
-      });
-      expect(result).not.toHaveProperty("disable-network-management");
+      expect(buildConfigsConstraintsPayload(entries, [])).not.toHaveProperty(
+        "vpc-id-force",
+      );
+    });
+
+    it("merges config and constraint entries", () => {
+      const constraintEntry: ConfigFieldEntry = {
+        label: "cores",
+        category: ConstraintCategory.COMPUTE,
+        value: 4,
+        arrayIndex: 0,
+        defaultValue: undefined,
+        valueType: ValueType.NUMBER,
+      };
+      expect(
+        buildConfigsConstraintsPayload([], [constraintEntry])["cores"],
+      ).toBe(4);
     });
   });
 
-  describe("getCategoriesWithVisibleFields", () => {
-    it("returns empty array when no fields have changed", () => {
-      const result = getCategoriesWithVisibleFields(categories, {});
-      expect(result).toHaveLength(0);
+  describe("filterEntriesBySearch", () => {
+    it("returns all entries when query is empty", () => {
+      expect(filterEntriesBySearch("", entries)).toHaveLength(entries.length);
     });
 
-    it("returns categories with only changed fields visible", () => {
-      const result = getCategoriesWithVisibleFields(categories, {
-        "default-space": "modified-space",
-      });
-
-      expect(result).toHaveLength(1);
-      expect(result[0].category).toBe("Networking");
-      expect(result[0].fields).toHaveLength(1);
-      expect(result[0].fields[0].label).toBe("default-space");
-    });
-  });
-
-  describe("getConfigInitialValues", () => {
-    it("returns object with all fields and their default values", () => {
-      const result = getConfigInitialValues(categories);
-      expect(result).toEqual({
-        "default-space": "alpha",
-        "container-networking-method": "provider",
-        cores: "",
-        "logging-config": "",
-        "vpc-id-force": false,
-      });
+    it("filters entries by label", () => {
+      const result = filterEntriesBySearch("network", entries);
+      expect(result.length).toBeGreaterThan(0);
+      expect(
+        result.every(
+          (entry) =>
+            entry.label.toLowerCase().includes("network") ||
+            entry.description?.toLowerCase().includes("network"),
+        ),
+      ).toBe(true);
     });
 
-    it("handles fields with undefined default values", () => {
-      const categoriesWithUndefinedDefaults: CategoryDefinition[] = [
-        {
-          category: "Test",
-          fields: [
-            {
-              label: "test-field",
-              defaultValue: undefined,
-              description: "Test",
-            },
-          ],
-        },
-      ];
-
-      const result = getConfigInitialValues(categoriesWithUndefinedDefaults);
-      expect(result["test-field"]).toBe("");
-    });
-
-    it("preserves numeric default values without converting to strings", () => {
-      const categoriesWithNumericDefaults: CategoryDefinition[] = [
-        {
-          category: "Test",
-          fields: [
-            {
-              label: "numeric-field",
-              defaultValue: 17,
-              description: "A numeric field",
-              valueType: ValueType.NUMBER,
-            },
-          ],
-        },
-      ];
-
-      const result = getConfigInitialValues(categoriesWithNumericDefaults);
-      expect(result["numeric-field"]).toBe(17);
-    });
-
-    it("returns empty object when categories are empty", () => {
-      const result = getConfigInitialValues([]);
-      expect(result).toEqual({});
-    });
-  });
-
-  describe("filterCategoriesBySearch", () => {
-    it("returns all categories when query is empty", () => {
-      const result = filterCategoriesBySearch("", categories);
+    it("filters entries by description", () => {
+      const result = filterEntriesBySearch("method", entries);
       expect(result.length).toBeGreaterThan(0);
     });
 
-    it("filters fields by label", () => {
-      const result = filterCategoriesBySearch("network", categories);
-
-      expect(result.length).toBeGreaterThan(0);
-      const allLabels = result.flatMap((cat) =>
-        cat.fields.map((field) => field.label.toLowerCase()),
-      );
-
-      const hasMatch = allLabels.some((label) => label.includes("network"));
-      expect(hasMatch).toBe(true);
-    });
-
-    it("filters fields by description", () => {
-      const result = filterCategoriesBySearch("method", categories);
-
-      expect(result.length).toBeGreaterThan(0);
-      const allDescriptions = result.flatMap((cat) =>
-        cat.fields.map((field) => field.description?.toLowerCase()),
-      );
-
-      const hasMatch = allDescriptions.some((desc) => desc?.includes("method"));
-      expect(hasMatch).toBe(true);
-    });
-
-    it("returns empty array when no fields match", () => {
-      const result = filterCategoriesBySearch(
-        "non-existent-query123456",
-        categories,
-      );
-      expect(result).toEqual([]);
-    });
-
-    it("filters out categories with no matching fields", () => {
-      const result = filterCategoriesBySearch("network", categories);
-
-      // All returned categories should have at least one field matching the query
-      result.forEach((category) => {
-        const hasMatch = category.fields.some(
-          (field) =>
-            field.label.toLowerCase().includes("network") ||
-            field.description?.toLowerCase().includes("network"),
-        );
-        expect(hasMatch).toBe(true);
-      });
+    it("returns empty array when no entries match", () => {
+      expect(
+        filterEntriesBySearch("non-existent-query123456", entries),
+      ).toEqual([]);
     });
   });
 
   describe("validateAndParseYAML", () => {
+    const getVal = (
+      result: ConfigFieldEntry[],
+      label: string,
+    ): ConfigFieldValue => result.find((entry) => entry.label === label)?.value;
+
     it("parses the YAML into valid key-value pairs", () => {
       const { validValues, errors } = validateAndParseYAML(
         "# a comment\n\ndefault-space: custom\nvpc-id-force: true\ncores: 4",
-        categories,
+        entries,
       );
 
-      expect(validValues).toEqual({
-        "default-space": "custom",
-        "vpc-id-force": true,
-        cores: 4,
-      });
+      expect(getVal(validValues, "default-space")).toBe("custom");
+      expect(getVal(validValues, "vpc-id-force")).toBe(true);
+      expect(getVal(validValues, "cores")).toBe(4);
       expect(errors.invalidKeys).toHaveLength(0);
       expect(errors.invalidValues).toHaveLength(0);
       expect(errors.otherErrors).toHaveLength(0);
     });
 
     it("rejects YAML 1.1 equivalents", () => {
-      // YAML 1.2: true/false are booleans, plain integers are numbers
-      // YAML 1.1 equivalents: 'off' and '1_234' are strings in YAML 1.2
-      const { errors: invalidErrors } = validateAndParseYAML(
+      const { errors } = validateAndParseYAML(
         "vpc-id-force: off\ncores: 1_234",
-        categories,
+        entries,
       );
-      expect(invalidErrors[YAMLErrorType.INVALID_VALUES]).toHaveLength(2);
+      expect(errors[YAMLErrorType.INVALID_VALUES]).toHaveLength(2);
     });
 
     it("accepts scientific notation for numeric fields", () => {
       const { validValues, errors } = validateAndParseYAML(
         "cores: 1.23456e13",
-        categories,
+        entries,
       );
-
       expect(errors[YAMLErrorType.INVALID_VALUES]).toHaveLength(0);
-      expect(validValues["cores"]).toBe(1.23456e13);
+      expect(getVal(validValues, "cores")).toBe(1.23456e13);
     });
 
     it("reports an invalid key for unknown fields", () => {
-      const { errors } = validateAndParseYAML("unknown-key: value", categories);
-
+      const { errors } = validateAndParseYAML("unknown-key: value", entries);
       expect(errors.invalidKeys).toHaveLength(1);
       expect(errors.invalidKeys[0].message).toContain(
         "Unknown key: unknown-key",
@@ -436,36 +296,32 @@ describe("utils", () => {
     it("reports other error for malformed YAML syntax", () => {
       const { errors } = validateAndParseYAML(
         "key: value\n  bad-indent: oops",
-        categories,
+        entries,
       );
-
       expect(errors.otherErrors.length).toBeGreaterThanOrEqual(1);
       expect(errors.otherErrors[0].line).toBeGreaterThan(0);
     });
 
     it("reports an invalid value for select fields with disallowed values", () => {
-      const selectCategories: CategoryDefinition[] = [
+      const selectEntries: ConfigFieldEntry[] = [
         {
+          label: "my-select",
+          description: "A select field",
           category: "Test",
-          fields: [
-            {
-              label: "my-select",
-              description: "A select field",
-              input: {
-                type: InputType.SELECT,
-                options: [
-                  { label: "A", value: "a" },
-                  { label: "B", value: "b" },
-                ],
-              },
-            },
-          ],
+          arrayIndex: 0,
+          value: "",
+          input: {
+            type: InputType.SELECT,
+            options: [
+              { label: "A", value: "a" },
+              { label: "B", value: "b" },
+            ],
+          },
         },
       ];
-
       const { errors } = validateAndParseYAML(
         "my-select: invalid",
-        selectCategories,
+        selectEntries,
       );
       expect(errors.invalidValues).toHaveLength(1);
       expect(errors.invalidValues[0].message).toContain(
@@ -474,70 +330,60 @@ describe("utils", () => {
     });
 
     it("reports an invalid value for numeric fields with non-numeric input", () => {
-      const { errors } = validateAndParseYAML(
-        "cores: not-a-number",
-        categories,
-      );
-
+      const { errors } = validateAndParseYAML("cores: not-a-number", entries);
       expect(errors.invalidValues).toHaveLength(1);
       expect(errors.invalidValues[0].message).toContain("Expected a number");
     });
 
-    it("parses boolean YAML scalars as 'true'/'false' strings", () => {
-      const boolCategories: CategoryDefinition[] = [
+    it("parses boolean YAML scalars correctly", () => {
+      const boolEntries: ConfigFieldEntry[] = [
         {
+          label: "my-bool",
+          description: "A boolean field",
+          defaultValue: false,
           category: "Test",
-          fields: [
-            {
-              label: "my-bool",
-              description: "A boolean field",
-              defaultValue: "false",
-              valueType: ValueType.BOOLEAN,
-              input: {
-                type: InputType.SELECT,
-                options: [
-                  { label: "True", value: "true" },
-                  { label: "False", value: "false" },
-                ],
-              },
-            },
-          ],
+          arrayIndex: 0,
+          value: false,
+          valueType: ValueType.BOOLEAN,
+          input: {
+            type: InputType.SELECT,
+            options: [
+              { label: "True", value: "true" },
+              { label: "False", value: "false" },
+            ],
+          },
         },
       ];
-
       const { validValues, errors } = validateAndParseYAML(
         "my-bool: true",
-        boolCategories,
+        boolEntries,
       );
-      expect(validValues["my-bool"]).toBe(true);
+      expect(getVal(validValues, "my-bool")).toBe(true);
       expect(errors.invalidValues).toHaveLength(0);
     });
 
     it("reports an invalid value for boolean fields with non-boolean input", () => {
-      const boolCategories: CategoryDefinition[] = [
+      const boolEntries: ConfigFieldEntry[] = [
         {
+          label: "my-bool",
+          description: "A boolean field",
+          defaultValue: false,
           category: "Test",
-          fields: [
-            {
-              label: "my-bool",
-              description: "A boolean field",
-              defaultValue: "false",
-              valueType: ValueType.BOOLEAN,
-              input: {
-                type: InputType.SELECT,
-                options: [
-                  { label: "True", value: "true" },
-                  { label: "False", value: "false" },
-                ],
-              },
-            },
-          ],
+          arrayIndex: 0,
+          value: false,
+          valueType: ValueType.BOOLEAN,
+          input: {
+            type: InputType.SELECT,
+            options: [
+              { label: "True", value: "true" },
+              { label: "False", value: "false" },
+            ],
+          },
         },
       ];
-
       const { errors } = validateAndParseYAML(
         'my-bool: "not-a-bool"',
-        boolCategories,
+        boolEntries,
       );
       expect(errors.invalidValues).toHaveLength(1);
       expect(errors.invalidValues[0].message).toContain(
@@ -548,9 +394,8 @@ describe("utils", () => {
     it("reports an invalid value when a field has a sequence or mapping value", () => {
       const { errors } = validateAndParseYAML(
         "default-space:\n  - item1\n  - item2",
-        categories,
+        entries,
       );
-
       expect(errors.invalidValues).toHaveLength(1);
       expect(errors.invalidValues[0].message).toContain(
         "Invalid value for default-space",
@@ -559,8 +404,7 @@ describe("utils", () => {
     });
 
     it("reports an other error when the top-level YAML is not a key-value map", () => {
-      const { errors } = validateAndParseYAML("- item1\n- item2", categories);
-
+      const { errors } = validateAndParseYAML("- item1\n- item2", entries);
       expect(errors.otherErrors.length).toBeGreaterThanOrEqual(1);
       expect(
         errors.otherErrors.some((error) =>
@@ -569,17 +413,58 @@ describe("utils", () => {
       ).toBe(true);
     });
 
-    it("includes catalog default for previously changed fields absent from YAML", () => {
+    it("reports an other error when a map item is not a Pair node", () => {
+      // Inject a non-Pair item (a plain Scalar) directly into a YAMLMap.
+      const map = new yaml.YAMLMap();
+      map.items.push(new yaml.Scalar("not-a-pair") as unknown as yaml.Pair);
+      const parseDocumentSpy = vi
+        .spyOn(yaml, "parseDocument")
+        .mockReturnValue({ errors: [], contents: map } as unknown as ReturnType<
+          typeof yaml.parseDocument
+        >);
+      const { errors } = validateAndParseYAML("key: value", entries);
+
+      expect(parseDocumentSpy).toHaveBeenCalledTimes(1);
+      expect(
+        errors.otherErrors.some((error) =>
+          error.message.includes("Unexpected non-key-value item in map"),
+        ),
+      ).toBe(true);
+      parseDocumentSpy.mockRestore();
+    });
+
+    it("reports an other error when a map key is not a scalar", () => {
+      // Inject a Pair whose key is a YAMLSeq (non-scalar).
+      const map = new yaml.YAMLMap();
+      const seq = new yaml.YAMLSeq();
+      seq.add(new yaml.Scalar("nested"));
+      map.items.push(new yaml.Pair(seq, new yaml.Scalar("value")));
+      const parseDocumentSpy = vi
+        .spyOn(yaml, "parseDocument")
+        .mockReturnValue({ errors: [], contents: map } as unknown as ReturnType<
+          typeof yaml.parseDocument
+        >);
+      const { errors } = validateAndParseYAML("key: value", entries);
+      parseDocumentSpy.mockRestore();
+
+      expect(
+        errors.otherErrors.some((error) =>
+          error.message.includes("Unexpected non-scalar key"),
+        ),
+      ).toBe(true);
+    });
+
+    it("resets previously-changed fields absent from YAML to their default", () => {
+      entries[0].value = "my-space";
       const { validValues } = validateAndParseYAML(
         "logging-config: debug",
-        categories,
-        { "default-space": "my-space" },
+        entries,
       );
 
       // logging-config is in the YAML
-      expect(validValues["logging-config"]).toBe("debug");
-      // default-space was changed but absent from YAML — should reset to default
-      expect(validValues["default-space"]).toBe("alpha");
+      expect(getVal(validValues, "logging-config")).toBe("debug");
+      // default-space was changed but absent — reset to catalog default.
+      expect(getVal(validValues, "default-space")).toBe("alpha");
     });
   });
 

--- a/src/pages/AddModel/ConfigsConstraints/utils.ts
+++ b/src/pages/AddModel/ConfigsConstraints/utils.ts
@@ -1,3 +1,4 @@
+import cloneDeep from "clone-deep";
 import {
   Document as YAMLDocument,
   YAMLMap,
@@ -12,21 +13,16 @@ import {
   YAMLErrorType,
   type YAMLValidationError,
 } from "./YAMLErrorsModal/types";
-import { CONFIG_CATEGORIES } from "./configCatalog";
-import { CONSTRAINT_CATEGORIES } from "./constraintsCatalog";
-import type {
-  CategoryDefinition,
-  CategoryDefinitionField,
-  ConfigFieldValue,
+import {
+  type CategoryDefinition,
+  type ConfigFieldEntry,
+  type ConfigFieldValue,
+  InputType,
+  ValueType,
 } from "./types";
-import { InputType, ValueType } from "./types";
 
-export const isConfigChanged = (
-  label: string,
-  values: Record<string, ConfigFieldValue>,
-  defaultValue?: ConfigFieldValue,
-): boolean => {
-  const currentValue = values[label];
+export const isConfigChanged = (entry: ConfigFieldEntry): boolean => {
+  const { value: currentValue, defaultValue } = entry;
 
   // If value is undefined, it hasn't been set - not changed
   if (currentValue === undefined) {
@@ -42,40 +38,37 @@ export const isConfigChanged = (
   return currentValue !== "";
 };
 
-export const getChangedFields = (
-  category: CategoryDefinition,
-  values: Record<string, ConfigFieldValue>,
-): CategoryDefinitionField[] =>
-  category.fields.filter((field) =>
-    isConfigChanged(field.label, values, field.defaultValue),
-  );
+export const groupEntriesByCategory = (
+  entries: ConfigFieldEntry[],
+  changedOnly?: boolean,
+): CategoryDefinition[] => {
+  const groups: CategoryDefinition[] = [];
 
-export const getCategoriesWithVisibleFields = (
-  categories: CategoryDefinition[],
-  values: Record<string, ConfigFieldValue>,
-): CategoryDefinition[] =>
-  categories
-    .map((cat) => ({
-      category: cat.category,
-      fields: getChangedFields(cat, values),
-    }))
-    .filter(({ fields }) => fields.length > 0);
+  const entriesToGroup = changedOnly
+    ? entries.filter(isConfigChanged)
+    : entries;
+  for (const entry of entriesToGroup) {
+    const groupWithCategory = groups.find(
+      (group) => group.category === entry.category,
+    );
+    if (groupWithCategory) {
+      groupWithCategory.fields.push(entry);
+    } else {
+      groups.push({ category: entry.category, fields: [entry] });
+    }
+  }
 
-export const buildYAML = (
-  categories: CategoryDefinition[],
-  values: Record<string, ConfigFieldValue>,
-): string => {
+  return groups;
+};
+
+export const buildYAML = (entries: ConfigFieldEntry[]): string => {
   const doc = new YAMLDocument(new YAMLMap());
   const map = doc.contents as YAMLMap;
+  const changedCategories = groupEntriesByCategory(entries, true);
 
-  for (const category of categories) {
-    const changedFields = getChangedFields(category, values);
-    if (changedFields.length === 0) {
-      continue;
-    }
-
-    for (const [index, field] of changedFields.entries()) {
-      const value = values[field.label];
+  for (const category of changedCategories) {
+    for (const [index, field] of category.fields.entries()) {
+      const { value } = field;
       // Coerce boolean string values to actual booleans so stringify
       // outputs them as unquoted true/false rather than quoted strings.
       const coerced =
@@ -103,49 +96,45 @@ export const buildYAML = (
 };
 
 export const buildConfigsConstraintsPayload = (
-  values: Record<string, ConfigFieldValue>,
-): Record<string, boolean | number | string> =>
-  [...CONFIG_CATEGORIES, ...CONSTRAINT_CATEGORIES].reduce<
-    Record<string, boolean | number | string>
-  >((config, category) => {
-    getChangedFields(category, values).forEach((field) => {
-      const value = values[field.label];
-      if (value !== undefined) {
-        config[field.label] = value;
-      }
-    });
-    return config;
-  }, {});
+  configEntries: ConfigFieldEntry[],
+  constraintEntries: ConfigFieldEntry[],
+): Record<string, boolean | number | string> => {
+  const config: Record<string, boolean | number | string> = {};
+  const changedEntries = [...configEntries, ...constraintEntries].filter(
+    isConfigChanged,
+  );
+  for (const { value, label } of changedEntries) {
+    if (value !== undefined) {
+      config[label] = value;
+    }
+  }
+  return config;
+};
 
 export const getConfigInitialValues = (
-  categories: CategoryDefinition[],
-): Record<string, ConfigFieldValue> =>
-  categories.reduce<Record<string, ConfigFieldValue>>((values, category) => {
-    category.fields.forEach((field) => {
-      // Coerce undefined to '' so the <input> is always controlled.
-      values[field.label] = field.defaultValue ?? "";
-    });
-    return values;
-  }, {});
+  definitions: Omit<ConfigFieldEntry, "arrayIndex" | "value">[],
+): ConfigFieldEntry[] =>
+  definitions.map((definition, index) => ({
+    ...definition,
+    // Coerce undefined to '' so the <input> is always controlled.
+    value: definition.defaultValue ?? "",
+    // Stamp an index at mount time so referencing the fields is easier.
+    arrayIndex: index,
+  }));
 
-export const filterCategoriesBySearch = (
+export const filterEntriesBySearch = (
   query: string,
-  categoryList: CategoryDefinition[],
-): CategoryDefinition[] => {
+  entries: ConfigFieldEntry[],
+): ConfigFieldEntry[] => {
   const lowerQuery = query.toLowerCase().trim();
   if (!lowerQuery) {
-    return categoryList;
+    return entries;
   }
-  return categoryList
-    .map((category) => ({
-      ...category,
-      fields: category.fields.filter(
-        (field) =>
-          field.label.toLowerCase().includes(lowerQuery) ||
-          field.description?.toLowerCase().includes(lowerQuery),
-      ),
-    }))
-    .filter((category) => category.fields.length > 0);
+  return entries.filter(
+    (entry) =>
+      entry.label.toLowerCase().includes(lowerQuery) ||
+      entry.description?.toLowerCase().includes(lowerQuery),
+  );
 };
 
 export const getYAMLErrorMessage = (
@@ -172,23 +161,14 @@ export const getYAMLErrorMessage = (
 
 export function validateAndParseYAML(
   yamlString: string,
-  categories: CategoryDefinition[],
-  currentValues: Record<string, ConfigFieldValue> = {},
+  entries: ConfigFieldEntry[],
 ): {
-  validValues: Record<string, ConfigFieldValue>;
+  validValues: ConfigFieldEntry[];
   errors: YAMLErrors;
 } {
-  const fieldsByLabel = categories.reduce(
-    (acc, { fields }) => {
-      for (const field of fields) {
-        acc[field.label] = field;
-      }
-      return acc;
-    },
-    {} as Record<string, CategoryDefinitionField>,
-  );
-
-  const validValues: Record<string, ConfigFieldValue> = {};
+  // Deep clone so we can safely mutate values without affecting the original data inside Formik.
+  const validValues = cloneDeep(entries);
+  const touchedLabels = new Set<string>();
   const invalidKeys: YAMLValidationError[] = [];
   const invalidValues: YAMLValidationError[] = [];
   const otherErrors: YAMLValidationError[] = [];
@@ -236,13 +216,11 @@ export function validateAndParseYAML(
         ? yamlString.slice(0, pair.key.range[0]).split("\n").length
         : 0;
 
-      const field = fieldsByLabel[key];
+      const field = validValues.find((entry) => entry.label === key);
       if (!field) {
         invalidKeys.push({
           line,
-          message: getYAMLErrorMessage(YAMLErrorType.UNKNOWN_KEYS, {
-            key,
-          }),
+          message: getYAMLErrorMessage(YAMLErrorType.UNKNOWN_KEYS, { key }),
         });
         continue;
       }
@@ -250,9 +228,7 @@ export function validateAndParseYAML(
       if (!isScalar(pair.value)) {
         invalidValues.push({
           line,
-          message: getYAMLErrorMessage(YAMLErrorType.INVALID_VALUES, {
-            key,
-          }),
+          message: getYAMLErrorMessage(YAMLErrorType.INVALID_VALUES, { key }),
         });
         continue;
       }
@@ -270,7 +246,6 @@ export function validateAndParseYAML(
           });
           continue;
         }
-        validValues[key] = value;
       } else if (field.valueType === ValueType.BOOLEAN) {
         if (typeof value !== "boolean") {
           invalidValues.push({
@@ -282,12 +257,11 @@ export function validateAndParseYAML(
           });
           continue;
         }
-        validValues[key] = value;
       } else {
         // Plain string field. For select fields, validate against allowed values.
         const stringValue = value?.toString();
         if (field.input?.type === InputType.SELECT) {
-          const allowedValues = (field.input.options ?? []).map(
+          const allowedValues = field.input.options.map(
             ({ value: optionValue }) => optionValue,
           );
           if (
@@ -304,20 +278,19 @@ export function validateAndParseYAML(
             continue;
           }
         }
-        validValues[key] = stringValue;
       }
+
+      // Treat null as an empty string so inputs stay controlled.
+      field.value = (value ?? "") as ConfigFieldValue;
+      touchedLabels.add(key);
     }
   }
 
   // For fields that were previously changed but absent from the YAML, reset
   // them to their catalog default so the caller can apply in a single pass.
-  for (const label in fieldsByLabel) {
-    const { defaultValue } = fieldsByLabel[label];
-    if (
-      !(label in validValues) &&
-      isConfigChanged(label, currentValues, defaultValue)
-    ) {
-      validValues[label] = defaultValue;
+  for (const entry of validValues) {
+    if (!touchedLabels.has(entry.label) && isConfigChanged(entry)) {
+      entry.value = entry.defaultValue ?? "";
     }
   }
 

--- a/src/pages/AddModel/types.ts
+++ b/src/pages/AddModel/types.ts
@@ -22,8 +22,7 @@ export type AddModelFormState = {
   region: string;
   credential: string;
   shareModelWith?: Record<string, AccessLevel>;
-} & FormFields &
-  Record<string, number | string>;
+} & FormFields;
 
 export type StepDefinition = {
   key: StepType;

--- a/src/pages/AddModel/utils.ts
+++ b/src/pages/AddModel/utils.ts
@@ -2,8 +2,8 @@ import * as Yup from "yup";
 
 import { extractCloudName } from "store/juju/utils/models";
 
-import { CONFIG_CATEGORIES } from "./ConfigsConstraints/configCatalog";
-import { CONSTRAINT_CATEGORIES } from "./ConfigsConstraints/constraintsCatalog";
+import { CONFIG_DEFINITIONS } from "./ConfigsConstraints/configCatalog";
+import { CONSTRAINT_DEFINITIONS } from "./ConfigsConstraints/constraintsCatalog";
 import { ValueType } from "./ConfigsConstraints/types";
 import { Label } from "./types";
 
@@ -15,13 +15,11 @@ export const getCredentialError = (cloud: unknown): string => {
 };
 
 export const getBooleanSchema = (): Record<string, Yup.BooleanSchema> =>
-  [...CONFIG_CATEGORIES, ...CONSTRAINT_CATEGORIES].reduce<
+  [...CONFIG_DEFINITIONS, ...CONSTRAINT_DEFINITIONS].reduce<
     Record<string, Yup.BooleanSchema>
-  >((schemas, category) => {
-    for (const field of category.fields) {
-      if (field.valueType === ValueType.BOOLEAN) {
-        schemas[field.label] = Yup.boolean();
-      }
+  >((schemas, entry) => {
+    if (entry.valueType === ValueType.BOOLEAN) {
+      schemas[entry.label] = Yup.boolean();
     }
     return schemas;
   }, {});

--- a/src/store/juju/slice.ts
+++ b/src/store/juju/slice.ts
@@ -22,7 +22,7 @@ import type {
   ModelInfoResults,
   UserModelList,
 } from "juju/types";
-import type { CategoryDefinition } from "store/middleware/source/types";
+import type { ConfigFieldEntry } from "store/middleware/source/types";
 
 import type {
   Controllers,
@@ -798,7 +798,7 @@ const slice = createSlice({
         payload,
       }: PayloadAction<{
         providerType: string;
-        update: Partial<SourceData<CategoryDefinition[]>>;
+        update: Partial<SourceData<ConfigFieldEntry[]>>;
       }>,
     ) => {
       const value = state.modelConfigDefaults;

--- a/src/store/juju/types.ts
+++ b/src/store/juju/types.ts
@@ -20,7 +20,7 @@ import type {
 } from "juju/jimm/JIMMV4";
 import type { FullStatusWithAnnotations, ModelInfo } from "juju/types";
 import type { ProcessOutcome } from "store/middleware/process";
-import type { CategoryDefinition } from "store/middleware/source/types";
+import type { ConfigFieldEntry } from "store/middleware/source/types";
 import type { GenericItemsState, GenericState } from "store/types";
 import type { AccessLevel } from "types";
 
@@ -163,7 +163,7 @@ export type ModelMigrationTargetsState = Record<string, SourceData<string[]>>;
 export type ModelConfigDefaultsState = {
   errors: null | string | unknown;
   loading: boolean;
-  defaults: Record<string, CategoryDefinition[]>;
+  defaults: Record<string, ConfigFieldEntry[]>;
 };
 
 export type AddModel = {

--- a/src/store/middleware/source/model-config-defaults.test.ts
+++ b/src/store/middleware/source/model-config-defaults.test.ts
@@ -58,7 +58,9 @@ describe("getModelConfigDefaults", () => {
       results: [
         {
           config: {
-            "default-space": { default: { value: "my-space" } },
+            "default-space": {
+              default: "my-space",
+            },
           },
         },
       ],
@@ -74,15 +76,17 @@ describe("getModelConfigDefaults", () => {
 
     const result = await getModelConfigDefaults(connection, "cloud-aws", "ec2");
     expect(result).toHaveLength(1);
-    expect(result[0].fields).toHaveLength(1);
-    expect(result[0].fields[0]).toMatchObject({
+    expect(result[0]).toMatchObject({
       label: "default-space",
       description: "The default network space",
       defaultValue: "my-space",
+      value: "my-space",
+      arrayIndex: 0,
+      category: null,
     });
   });
 
-  it("passes the selected region through to generateCategoryDefinitions", async ({
+  it("passes the selected region through to generateFieldEntries", async ({
     expect,
   }) => {
     mockModelDefaultsForClouds.mockResolvedValue({
@@ -93,7 +97,7 @@ describe("getModelConfigDefaults", () => {
               regions: [
                 {
                   "region-name": "us-east-1",
-                  value: { value: "region-space" },
+                  value: "region-space",
                 },
               ],
             },
@@ -115,7 +119,7 @@ describe("getModelConfigDefaults", () => {
       "ec2",
       "us-east-1",
     );
-    expect(result[0].fields[0].defaultValue).toBe("region-space");
+    expect(result[0].defaultValue).toBe("region-space");
   });
 
   it("throws a combined error if both calls fail", async ({ expect }) => {

--- a/src/store/middleware/source/model-config-defaults.ts
+++ b/src/store/middleware/source/model-config-defaults.ts
@@ -6,8 +6,8 @@ import { toSerializableSourceError } from "store/util";
 import { hasConnections } from "../connection/util";
 import { createSourceInstance } from "../source-middleware";
 
-import type { CategoryDefinition } from "./types";
-import { generateCategoryDefinitions } from "./util";
+import type { ConfigFieldEntry } from "./types";
+import { generateFieldEntries } from "./util";
 
 export const NOT_AUTHENTICATED_ERROR = "not authenticated with controller";
 export const NO_MODEL_MANAGER_FACADE =
@@ -20,7 +20,7 @@ export async function getModelConfigDefaults(
   cloudTag: string,
   providerType: string,
   selectedRegion?: string,
-): Promise<CategoryDefinition[]> {
+): Promise<ConfigFieldEntry[]> {
   if (!connection.facades.modelManager) {
     throw new Error(NO_MODEL_MANAGER_FACADE);
   }
@@ -64,7 +64,7 @@ export async function getModelConfigDefaults(
     );
   }
 
-  return generateCategoryDefinitions(
+  return generateFieldEntries(
     schemaResult.value.schema,
     defaultsResult.value.results[0]?.config,
     selectedRegion,
@@ -78,7 +78,7 @@ export default createSourceInstance<
     providerType: string;
     selectedRegion?: string;
   },
-  CategoryDefinition[]
+  ConfigFieldEntry[]
 >(
   "model-config-defaults",
   ({ wsControllerURL: _, cloudTag, providerType, selectedRegion, meta }) => {

--- a/src/store/middleware/source/types.ts
+++ b/src/store/middleware/source/types.ts
@@ -19,8 +19,9 @@ export type CategoryDefinitionField = {
   valueType?: ValueType;
 };
 
-export type CategoryDefinition = {
+export type ConfigFieldEntry = {
   // `null` indicates no meaningful grouping (e.g. schema data from the facade).
   category: null | string;
-  fields: CategoryDefinitionField[];
-};
+  value: ConfigFieldValue;
+  arrayIndex: number;
+} & CategoryDefinitionField;

--- a/src/store/middleware/source/util.test.ts
+++ b/src/store/middleware/source/util.test.ts
@@ -4,25 +4,46 @@ import { BOOLEAN_OPTIONS } from "consts";
 import { InputType, ValueType } from "pages/AddModel/ConfigsConstraints/types";
 import { modelConfigSchemaFieldFactory } from "testing/factories/juju/CloudV8";
 
-import { generateCategoryDefinitions } from "./util";
+import { generateFieldEntries } from "./util";
 
-describe("generateCategoryDefinitions", () => {
-  it("returns a single null category (no grouping)", () => {
-    const result = generateCategoryDefinitions({}, {});
-    expect(result).toHaveLength(1);
+describe("generateFieldEntries", () => {
+  it("returns an empty array for an empty schema", () => {
+    const result = generateFieldEntries({}, {});
+    expect(result).toHaveLength(0);
+  });
+
+  it.each(["name", "type", "uuid"])(
+    'skips the reserved "%s" field',
+    (label) => {
+      const result = generateFieldEntries(
+        {
+          [label]: modelConfigSchemaFieldFactory.build(),
+          "default-space": modelConfigSchemaFieldFactory.build(),
+        },
+        {},
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].label).toBe("default-space");
+    },
+  );
+
+  it("returns null category for all entries when API provides no grouping", () => {
+    const result = generateFieldEntries(
+      { "default-space": modelConfigSchemaFieldFactory.build() },
+      {},
+    );
     expect(result[0].category).toBeNull();
   });
 
-  it("returns an empty fields array for an empty schema", () => {
-    const result = generateCategoryDefinitions({}, {});
-    expect(result[0].fields).toHaveLength(0);
-  });
-
-  it("handles multiple fields in the schema", () => {
+  it("stamps arrayIndex and value on each entry", () => {
     const config: ModelDefaultsResult["config"] = {
-      "default-space": { default: { value: "my-space" } },
+      "default-space": {
+        // The API types these values as `AdditionalProperties` but they are
+        // plain primitives at runtime.
+        default: "my-space" as unknown as Record<string, unknown>,
+      },
     };
-    const result = generateCategoryDefinitions(
+    const result = generateFieldEntries(
       {
         "default-space": modelConfigSchemaFieldFactory.build({
           type: "string",
@@ -37,73 +58,94 @@ describe("generateCategoryDefinitions", () => {
       },
       config,
     );
-    expect(result[0].fields).toHaveLength(3);
-    expect(result[0].fields[0].label).toBe("default-space");
-    expect(result[0].fields[0].description).toBe("The default network space");
-    expect(result[0].fields[0].defaultValue).toBe("my-space");
-    expect(result[0].fields[1].valueType).toBe(ValueType.BOOLEAN);
-    expect(result[0].fields[2].valueType).toBe(ValueType.NUMBER);
+    expect(result).toHaveLength(3);
+    expect(result[0]).toMatchObject({
+      label: "default-space",
+      description: "The default network space",
+      defaultValue: "my-space",
+      value: "my-space",
+      arrayIndex: 0,
+    });
+    expect(result[1]).toMatchObject({
+      valueType: ValueType.BOOLEAN,
+      arrayIndex: 1,
+    });
+    expect(result[2]).toMatchObject({
+      valueType: ValueType.NUMBER,
+      arrayIndex: 2,
+    });
   });
 
-  it("leaves defaultValue undefined when field has no default", () => {
-    const result = generateCategoryDefinitions(
+  it("leaves defaultValue undefined and value '' when field has no default", () => {
+    const result = generateFieldEntries(
       { "default-space": modelConfigSchemaFieldFactory.build() },
       {},
     );
-    expect(result[0].fields[0].defaultValue).toBeUndefined();
+    expect(result[0].defaultValue).toBeUndefined();
+    expect(result[0].value).toBe("");
   });
 
   it("prefers controller override over other defaults", () => {
     const config: ModelDefaultsResult["config"] = {
       "default-space": {
-        default: { value: "default-space" },
-        controller: { value: "controller-space" },
+        // The API types these values as `AdditionalProperties` but they are
+        // plain primitives at runtime.
+        default: "default-space" as unknown as Record<string, unknown>,
+        controller: "controller-space" as unknown as Record<string, unknown>,
         regions: [
-          { "region-name": "us-east-1", value: { value: "us-east-space" } },
+          {
+            "region-name": "us-east-1",
+            value: "us-east-space" as unknown as Record<string, unknown>,
+          },
         ],
       },
     };
-    const result = generateCategoryDefinitions(
+    const result = generateFieldEntries(
       { "default-space": modelConfigSchemaFieldFactory.build() },
       config,
     );
-    expect(result[0].fields[0].defaultValue).toBe("controller-space");
+    expect(result[0].defaultValue).toBe("controller-space");
+    expect(result[0].value).toBe("controller-space");
   });
 
   it("applies region default when region is provided and controller defaults are absent", () => {
     const config: ModelDefaultsResult["config"] = {
       "default-space": {
-        default: { value: "global-default" },
+        // The API types these values as `AdditionalProperties` but they are
+        // plain primitives at runtime.
+        default: "global-default" as unknown as Record<string, unknown>,
         regions: [
-          { "region-name": "us-east-1", value: { value: "us-east-space" } },
+          {
+            "region-name": "us-east-1",
+            value: "us-east-space" as unknown as Record<string, unknown>,
+          },
         ],
       },
     };
-    const result = generateCategoryDefinitions(
+    const result = generateFieldEntries(
       { "default-space": modelConfigSchemaFieldFactory.build() },
       config,
       "us-east-1",
     );
-    expect(result[0].fields[0].defaultValue).toBe("us-east-space");
+    expect(result[0].defaultValue).toBe("us-east-space");
   });
 
   it("falls back to juju-wide default when other defaults are absent", () => {
-    const result = generateCategoryDefinitions(
+    const result = generateFieldEntries(
       { "default-space": modelConfigSchemaFieldFactory.build() },
       {
         "default-space": {
-          default: { value: "global-default" },
-          regions: [
-            { "region-name": "us-east-1", value: { value: "us-east-space" } },
-          ],
+          // The API types these values as `AdditionalProperties` but they are
+          // plain primitives at runtime.
+          default: "global-default" as unknown as Record<string, unknown>,
         },
       },
     );
-    expect(result[0].fields[0].defaultValue).toBe("global-default");
+    expect(result[0].defaultValue).toBe("global-default");
   });
 
   it("handles bool type properly", () => {
-    const result = generateCategoryDefinitions(
+    const result = generateFieldEntries(
       {
         "disable-network-management": modelConfigSchemaFieldFactory.build({
           type: "bool",
@@ -111,34 +153,34 @@ describe("generateCategoryDefinitions", () => {
       },
       {},
     );
-    expect(result[0].fields[0].valueType).toBe(ValueType.BOOLEAN);
-    expect(result[0].fields[0].input?.type).toBe(InputType.SELECT);
-    expect(result[0].fields[0].input?.options).toEqual(BOOLEAN_OPTIONS);
+    expect(result[0].valueType).toBe(ValueType.BOOLEAN);
+    expect(result[0].input?.type).toBe(InputType.SELECT);
+    expect(result[0].input?.options).toEqual(BOOLEAN_OPTIONS);
   });
 
   it.each(["int", "float"])("handles %s type properly", (type) => {
-    const result = generateCategoryDefinitions(
+    const result = generateFieldEntries(
       { "some-field": modelConfigSchemaFieldFactory.build({ type }) },
       {},
     );
-    expect(result[0].fields[0].valueType).toBe(ValueType.NUMBER);
-    expect(result[0].fields[0].input).toBeUndefined();
+    expect(result[0].valueType).toBe(ValueType.NUMBER);
+    expect(result[0].input).toBeUndefined();
   });
 
   it("sets a select input with options when values are present", () => {
-    const result = generateCategoryDefinitions(
+    const result = generateFieldEntries(
       {
         "firewall-mode": modelConfigSchemaFieldFactory.build({
           type: "string",
           // Values are typed as `object[]` by Juju but are plain primitives
-          //  at runtime, which is why we cast here to reflect the real shape.
+          // at runtime, which is why we cast here to reflect the real shape.
           values: ["instance", "global", "none"] as unknown as object[],
         }),
       },
       {},
     );
-    expect(result[0].fields[0].input?.type).toBe(InputType.SELECT);
-    expect(result[0].fields[0].input?.options).toEqual([
+    expect(result[0].input?.type).toBe(InputType.SELECT);
+    expect(result[0].input?.options).toEqual([
       { label: "instance", value: "instance" },
       { label: "global", value: "global" },
       { label: "none", value: "none" },
@@ -146,18 +188,18 @@ describe("generateCategoryDefinitions", () => {
   });
 
   it("filters out values that do not match the declared field type", () => {
-    const result = generateCategoryDefinitions(
+    const result = generateFieldEntries(
       {
         "firewall-mode": modelConfigSchemaFieldFactory.build({
           type: "string",
           // Values are typed as `object[]` by Juju but are plain primitives
-          //  at runtime, which is why we cast here to reflect the real shape.
+          // at runtime, which is why we cast here to reflect the real shape.
           values: ["instance", 42, null, "global"] as unknown as object[],
         }),
       },
       {},
     );
-    expect(result[0].fields[0].input?.options).toEqual([
+    expect(result[0].input?.options).toEqual([
       { label: "instance", value: "instance" },
       { label: "global", value: "global" },
     ]);

--- a/src/store/middleware/source/util.ts
+++ b/src/store/middleware/source/util.ts
@@ -7,8 +7,7 @@ import type {
 import { BOOLEAN_OPTIONS } from "consts";
 
 import {
-  type CategoryDefinition,
-  type CategoryDefinitionField,
+  type ConfigFieldEntry,
   type ConfigFieldValue,
   InputType,
   ValueType,
@@ -30,51 +29,62 @@ const resolveFieldDefault = (
   }
 
   const { controller, regions, default: jujuDefaults } = defaults;
+  let fieldDefault = jujuDefaults;
 
-  if (controller) {
-    return Object.values(controller)[0];
+  if (controller !== undefined) {
+    fieldDefault = controller;
   }
 
   if (selectedRegion && regions) {
-    const regionDefaults = regions.find(
+    const regionDefault = regions.find(
       (region) => region["region-name"] === selectedRegion,
     )?.value;
-    if (regionDefaults) {
-      return Object.values(regionDefaults)[0];
+    if (regionDefault !== undefined) {
+      fieldDefault = regionDefault;
     }
   }
 
-  return Object.values(jujuDefaults ?? {})[0];
+  return fieldDefault as ConfigFieldValue;
 };
 
 /**
   Converts modelConfigSchema and modelDefaultsForClouds API responses into a
-  CategoryDefinition array.
+  ConfigFieldEntry array.
 */
-export const generateCategoryDefinitions = (
+export const generateFieldEntries = (
   schema: ModelConfigSchemaResult["schema"],
   defaultsConfig: ModelDefaultsResult["config"],
   selectedRegion?: string,
-): CategoryDefinition[] => {
-  const fields: CategoryDefinitionField[] = Object.entries(schema ?? {}).map(
-    ([label, field]) => {
+): ConfigFieldEntry[] => {
+  return Object.entries(schema ?? {}).reduce<ConfigFieldEntry[]>(
+    (acc, [label, field]) => {
+      // Skip fields that are not user-editable or are handled elsewhere in the UI.
+      if (["name", "type", "uuid"].includes(label)) {
+        return acc;
+      }
+
       const isNumeric = field.type === "int" || field.type === "float";
 
       // The response schema types `values` as `object[]`, but the underlying
-      //  Go type is `[]any` which serializes enum values as primitives on
-      //  the wire. We validate each entry matches the declared field type
-      //  to guard against unexpected API responses.
+      // Go type is `[]any` which serializes enum values as primitives on
+      // the wire. We validate each entry matches the declared field type
+      // to guard against unexpected API responses.
       const fieldValues = (field.values ?? []).filter(
         (fieldValue) => typeof fieldValue === field.type,
       );
 
-      const entry: CategoryDefinitionField = {
+      const defaultValue = resolveFieldDefault(
+        defaultsConfig[label],
+        selectedRegion,
+      );
+
+      const entry: ConfigFieldEntry = {
         label,
         description: field.description,
-        defaultValue: resolveFieldDefault(
-          defaultsConfig[label],
-          selectedRegion,
-        ),
+        defaultValue,
+        category: null,
+        value: defaultValue ?? "",
+        arrayIndex: acc.length,
       };
 
       if (field.type === "bool") {
@@ -92,9 +102,9 @@ export const generateCategoryDefinitions = (
         };
       }
 
-      return entry;
+      acc.push(entry);
+      return acc;
     },
+    [],
   );
-
-  return [{ category: null, fields }];
 };


### PR DESCRIPTION
## Done

- Restructured `configCatalog` and `constraintsCatalog` to support usage of an array type field
- Updated all utils to work on this restructured data
- This is the primary set of changes required for the eventual wiring of configs and their defaults with the UI. If left unchanged, Formik throws an error in console stating an uncontrolled value was changed to controlled due to the dynamic nature of incoming fields.

Note: I haven't used `FieldArray` here as it is only needed when you're dynamically adding/removing items from a Formik array. This might be a future requirement but it would be unused presently.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Make sure the entire add-model flow works correctly with no errors or bugs

