### PR TITLE
feat: use configs and defaults in UI from the facades

### DIFF
--- a/src/pages/AddModel/ConfigsConstraints/CategoriesListing/CategoriesListing.test.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/CategoriesListing/CategoriesListing.test.tsx
@@ -98,6 +98,32 @@ describe("CategoriesListing", () => {
     expect(screen.getByRole("radio", { name: InputMode.LIST })).toBeChecked();
   });
 
+  it("renders loading mode properly", async () => {
+    render(
+      <Formik
+        initialValues={{
+          ...initialValues,
+          [FieldName.CONFIG_INPUT_MODE]: InputMode.LIST,
+        }}
+        onSubmit={vi.fn()}
+      >
+        <CategoriesListing {...defaultProps} isLoading />
+      </Formik>,
+    );
+
+    // Warning banner is visible.
+    expect(screen.getByText("Fetching configurations.")).toBeInTheDocument();
+    // All list-mode inputs are disabled.
+    screen.getAllByRole("textbox").forEach((input) => {
+      expect(input).toBeDisabled();
+    });
+    // Switch to YAML mode — the textarea is also disabled.
+    await userEvent.click(screen.getByRole("radio", { name: InputMode.YAML }));
+    expect(
+      screen.getByPlaceholderText(Label.MODEL_CONFIG_PLACEHOLDER),
+    ).toBeDisabled();
+  });
+
   it("shows list mode content by default", () => {
     render(
       <Formik initialValues={initialValues} onSubmit={vi.fn()}>

--- a/src/pages/AddModel/ConfigsConstraints/CategoriesListing/CategoriesListing.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/CategoriesListing/CategoriesListing.tsx
@@ -1,6 +1,7 @@
 import {
   Col,
   FormikField,
+  Icon,
   RadioInput,
   Row,
   SearchBox,
@@ -41,6 +42,7 @@ const CategoriesListing = ({
   searchName,
   setYAMLErrors,
   yamlErrorLabel,
+  isLoading = false,
 }: Props): JSX.Element => {
   const id = useId();
   const { values, setFieldError, setFieldTouched, setFieldValue } =
@@ -116,6 +118,14 @@ const CategoriesListing = ({
       <h5 id={`title-${id}`} className="u-no-padding--top u-no-margin--bottom">
         {title}
       </h5>
+      {isLoading ? (
+        <span className="categories__warning-text">
+          <Icon name="warning" />
+          <p className="u-no-margin--bottom p-text--small">
+            Fetching configurations.
+          </p>
+        </span>
+      ) : null}
       <p className="u-no-margin--bottom p-text--small">
         <a href={docsLink} target="_blank">
           {docsLabel}
@@ -171,24 +181,32 @@ const CategoriesListing = ({
           )}
           <div className="categories__form-scroll u-sv-1--top">
             {visibleGroups.length > 0 ? (
-              visibleGroups.map(({ category, fields }, index) => (
-                <Row
-                  key={category}
-                  className={classNames("u-no-padding", {
-                    "u-sv1--top": index !== 0,
-                  })}
-                >
-                  <Col size={3}>
-                    <h5>{category}</h5>
-                  </Col>
-                  <Col size={9}>
-                    <StackList visibleFields={fields} arrayName={arrayName} />
-                  </Col>
-                  {index < visibleGroups.length - 1 ? (
-                    <hr className="p-rule--muted" />
-                  ) : null}
-                </Row>
-              ))
+              visibleGroups.map(({ category, fields }, index) => {
+                const ungrouped = category === null;
+                return (
+                  <Row
+                    key={category ?? "__ungrouped__"}
+                    className={classNames("u-no-padding", {
+                      "u-sv1--top": index !== 0,
+                    })}
+                  >
+                    <Col size={ungrouped ? 2 : 3}>
+                      {ungrouped ? null : <h5>{category}</h5>}
+                    </Col>
+                    <Col size={ungrouped ? 10 : 9}>
+                      <StackList
+                        isLoading={isLoading}
+                        visibleFields={fields}
+                        arrayName={arrayName}
+                        stackedLabelColumns={ungrouped ? 6 : 5}
+                      />
+                    </Col>
+                    {index < visibleGroups.length - 1 ? (
+                      <hr className="p-rule--muted" />
+                    ) : null}
+                  </Row>
+                );
+              })
             ) : (
               <h5>No results found for {`"${searchQuery}"`}</h5>
             )}
@@ -198,6 +216,7 @@ const CategoriesListing = ({
         <div className="row u-no-padding">
           <div className="col-6">
             <FormikField
+              disabled={isLoading}
               className="categories__yaml-input"
               component={Textarea}
               name={yamlKey}

--- a/src/pages/AddModel/ConfigsConstraints/CategoriesListing/_categories-listing.scss
+++ b/src/pages/AddModel/ConfigsConstraints/CategoriesListing/_categories-listing.scss
@@ -5,6 +5,13 @@
   max-height: 70vh;
   min-height: 20rem;
 
+  .categories__warning-text {
+    align-items: center;
+    color: $color-caution;
+    display: flex;
+    gap: $sph--x-small;
+  }
+
   .categories__form-scroll {
     flex: 1;
     margin-bottom: 1rem;

--- a/src/pages/AddModel/ConfigsConstraints/CategoriesListing/types.ts
+++ b/src/pages/AddModel/ConfigsConstraints/CategoriesListing/types.ts
@@ -15,4 +15,5 @@ export type Props = {
   searchName: string;
   setYAMLErrors: (state: YAMLErrorsModalState) => void;
   yamlErrorLabel: string;
+  isLoading?: boolean;
 };

--- a/src/pages/AddModel/ConfigsConstraints/ConfigsConstraints.test.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/ConfigsConstraints.test.tsx
@@ -1,8 +1,18 @@
-import { act, fireEvent, screen, within } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
-import { vi } from "vitest";
 
+import {
+  cloudInfoStateFactory,
+  jujuStateFactory,
+} from "testing/factories/juju/juju";
+import { rootStateFactory } from "testing/factories/root";
 import { renderComponent } from "testing/utils";
 import { externalURLs } from "urls";
 
@@ -35,6 +45,41 @@ describe("ConfigsConstraints", () => {
       [FieldName.CONSTRAINT_YAML]: "",
       [FieldName.DISABLED_COMMANDS]: DisableType.NONE,
     };
+  });
+
+  it("replaces configFields with live entries when store data arrives", async () => {
+    const liveEntry = {
+      label: "live-field",
+      value: "live-value",
+      defaultValue: "live-value",
+      category: null,
+      arrayIndex: 0,
+    };
+    const state = rootStateFactory.withGeneralConfig().build({
+      juju: jujuStateFactory.build({
+        cloudInfo: cloudInfoStateFactory.build({
+          clouds: { "cloud-aws": { type: "ec2" } },
+        }),
+        modelConfigDefaults: {
+          errors: null,
+          loading: false,
+          defaults: { ec2: [liveEntry] },
+        },
+      }),
+    });
+    renderComponent(
+      <Formik
+        initialValues={{ ...initialValues, cloud: "cloud-aws" }}
+        onSubmit={vi.fn()}
+      >
+        <ConfigsConstraints />
+      </Formik>,
+      { state },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("live-field")).toBeInTheDocument();
+    });
   });
 
   it("renders properly", () => {

--- a/src/pages/AddModel/ConfigsConstraints/ConfigsConstraints.test.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/ConfigsConstraints.test.tsx
@@ -8,8 +8,10 @@ import {
 import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 
+import { actions as jujuActions } from "store/juju/slice";
 import {
   cloudInfoStateFactory,
+  configFieldEntryFactory,
   jujuStateFactory,
 } from "testing/factories/juju/juju";
 import { rootStateFactory } from "testing/factories/root";
@@ -27,17 +29,18 @@ describe("ConfigsConstraints", () => {
   beforeEach(() => {
     initialValues = {
       [FieldName.CONFIG_FIELDS]: [
-        { label: "default-space", value: "", category: null, arrayIndex: 0 },
-        {
+        configFieldEntryFactory.build({
+          label: "default-space",
+          arrayIndex: 0,
+        }),
+        configFieldEntryFactory.build({
           label: "container-networking-method",
-          value: "",
-          category: null,
           arrayIndex: 1,
-        },
+        }),
       ],
       [FieldName.CONSTRAINT_FIELDS]: [
-        { label: "cores", value: "", category: null, arrayIndex: 0 },
-        { label: "zones", value: "", category: null, arrayIndex: 1 },
+        configFieldEntryFactory.build({ label: "cores", arrayIndex: 0 }),
+        configFieldEntryFactory.build({ label: "zones", arrayIndex: 1 }),
       ],
       [FieldName.CONFIG_INPUT_MODE]: InputMode.LIST,
       [FieldName.CONSTRAINT_INPUT_MODE]: InputMode.LIST,
@@ -48,26 +51,19 @@ describe("ConfigsConstraints", () => {
   });
 
   it("replaces configFields with live entries when store data arrives", async () => {
-    const liveEntry = {
+    const liveEntry = configFieldEntryFactory.build({
       label: "live-field",
       value: "live-value",
       defaultValue: "live-value",
-      category: null,
-      arrayIndex: 0,
-    };
+    });
     const state = rootStateFactory.withGeneralConfig().build({
       juju: jujuStateFactory.build({
         cloudInfo: cloudInfoStateFactory.build({
           clouds: { "cloud-aws": { type: "ec2" } },
         }),
-        modelConfigDefaults: {
-          errors: null,
-          loading: false,
-          defaults: { ec2: [liveEntry] },
-        },
       }),
     });
-    renderComponent(
+    const { store } = renderComponent(
       <Formik
         initialValues={{ ...initialValues, cloud: "cloud-aws" }}
         onSubmit={vi.fn()}
@@ -76,9 +72,60 @@ describe("ConfigsConstraints", () => {
       </Formik>,
       { state },
     );
+    expect(screen.queryByLabelText("live-field")).not.toBeInTheDocument();
 
+    store.dispatch(
+      jujuActions.updateModelConfigDefaults({
+        providerType: "ec2",
+        update: { data: [liveEntry] },
+      }),
+    );
     await waitFor(() => {
       expect(screen.getByLabelText("live-field")).toBeInTheDocument();
+    });
+  });
+
+  it("shows a warning and disables config fields while the model config defaults are loading", async () => {
+    const state = rootStateFactory.withGeneralConfig().build({
+      juju: jujuStateFactory.build({
+        modelConfigDefaults: {
+          defaults: {},
+          errors: null,
+          loading: true,
+        },
+      }),
+    });
+    const { store } = renderComponent(
+      <Formik initialValues={initialValues} onSubmit={vi.fn()}>
+        <ConfigsConstraints />
+      </Formik>,
+      { state },
+    );
+
+    const configsSection = screen.getByRole("region", {
+      name: Label.CONFIGS_TITLE,
+    });
+    expect(
+      within(configsSection).getByText(/Fetching configurations./),
+    ).toBeInTheDocument();
+    // All config inputs should be disabled while defaults are loading so the
+    // user cannot enter values that will be overwritten on arrival.
+    within(configsSection)
+      .getAllByRole("textbox")
+      .forEach((input) => {
+        expect(input).toBeDisabled();
+      });
+
+    store.dispatch(
+      jujuActions.updateModelConfigDefaults({
+        providerType: "ec2",
+        update: { loading: false },
+      }),
+    );
+    await waitFor(() => {
+      expect(
+        within(configsSection).queryByText(/Fetching configurations./),
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/src/pages/AddModel/ConfigsConstraints/ConfigsConstraints.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/ConfigsConstraints.tsx
@@ -28,6 +28,7 @@ const ConfigsConstraints = (): JSX.Element => {
   const modelConfigDefaults = useAppSelector(getModelConfigDefaultsState);
   const [yamlErrorsModalState, setYAMLErrors] =
     useState<null | YAMLErrorsModalState>(null);
+  const [isConfigLoading, setIsConfigLoading] = useState(true);
 
   const providerType = values.cloud
     ? cloudInfo?.[values.cloud]?.type
@@ -37,6 +38,14 @@ const ConfigsConstraints = (): JSX.Element => {
   const liveEntries = providerType
     ? (modelConfigDefaults.defaults[providerType] ?? null)
     : null;
+
+  useEffect(() => {
+    if (modelConfigDefaults.loading) {
+      setIsConfigLoading(true);
+    } else {
+      setIsConfigLoading(false);
+    }
+  }, [modelConfigDefaults.loading]);
 
   useEffect(() => {
     if (!liveEntries || liveEntries.length === 0) {
@@ -63,6 +72,7 @@ const ConfigsConstraints = (): JSX.Element => {
         />
       ) : null}
       <CategoriesListing
+        isLoading={isConfigLoading}
         title={Label.CONFIGS_TITLE}
         arrayName={FieldName.CONFIG_FIELDS}
         inputMode={FieldName.CONFIG_INPUT_MODE}

--- a/src/pages/AddModel/ConfigsConstraints/ConfigsConstraints.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/ConfigsConstraints.tsx
@@ -1,10 +1,16 @@
 import { FormikField, List } from "@canonical/react-components";
 import { useFormikContext } from "formik";
-import { useState, type JSX } from "react";
+import { useEffect, useState, type JSX } from "react";
 
+import {
+  getCloudInfoState,
+  getModelConfigDefaultsState,
+} from "store/juju/selectors";
+import { useAppSelector } from "store/store";
 import { testId } from "testing/utils";
 import { externalURLs } from "urls";
 
+import type { AddModelFormState } from "../types";
 import { InputMode } from "../types";
 
 import CategoriesListing from "./CategoriesListing";
@@ -15,9 +21,29 @@ import { DISABLED_COMMAND_OPTIONS } from "./disabledCommandOptions";
 import { FieldName, type FormFields, Label, TestId } from "./types";
 
 const ConfigsConstraints = (): JSX.Element => {
-  const { setFieldValue } = useFormikContext<FormFields>();
+  const { values, setFieldValue } = useFormikContext<
+    AddModelFormState & FormFields
+  >();
+  const cloudInfo = useAppSelector(getCloudInfoState).clouds;
+  const modelConfigDefaults = useAppSelector(getModelConfigDefaultsState);
   const [yamlErrorsModalState, setYAMLErrors] =
     useState<null | YAMLErrorsModalState>(null);
+
+  const providerType = values.cloud
+    ? cloudInfo?.[values.cloud]?.type
+    : undefined;
+
+  // When live config fields arrive, atomically replace the configFields array.
+  const liveEntries = providerType
+    ? (modelConfigDefaults.defaults[providerType] ?? null)
+    : null;
+
+  useEffect(() => {
+    if (!liveEntries || liveEntries.length === 0) {
+      return;
+    }
+    void setFieldValue(FieldName.CONFIG_FIELDS, liveEntries, false);
+  }, [liveEntries, setFieldValue]);
 
   return (
     <div {...testId(TestId.CONFIGS_CONSTRAINTS_FORM)}>

--- a/src/pages/AddModel/ConfigsConstraints/StackList/StackList.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/StackList/StackList.tsx
@@ -1,4 +1,9 @@
-import { FormikField, Icon, Select } from "@canonical/react-components";
+import {
+  type ColSize,
+  FormikField,
+  Icon,
+  Select,
+} from "@canonical/react-components";
 import { Fragment, type JSX } from "react";
 
 import type { ConfigFieldEntry, FieldName } from "../types";
@@ -8,9 +13,16 @@ import { isConfigChanged } from "../utils";
 type Props = {
   visibleFields: ConfigFieldEntry[];
   arrayName: FieldName.CONFIG_FIELDS | FieldName.CONSTRAINT_FIELDS;
+  stackedLabelColumns?: ColSize;
+  isLoading?: boolean;
 };
 
-const StackList = ({ visibleFields, arrayName }: Props): JSX.Element => {
+const StackList = ({
+  visibleFields,
+  arrayName,
+  stackedLabelColumns,
+  isLoading = false,
+}: Props): JSX.Element => {
   return (
     <>
       {visibleFields.map((entry, index) => {
@@ -34,13 +46,14 @@ const StackList = ({ visibleFields, arrayName }: Props): JSX.Element => {
                   {entry.label}
                 </>
               }
+              disabled={isLoading}
               aria-label={entry.label}
               name={fieldName}
               help={entry.description}
               helpAfterLabel
               stacked
               stackedFieldColumns={4}
-              stackedLabelColumns={5}
+              stackedLabelColumns={stackedLabelColumns}
               labelClassName="u-no-padding--top u-no-margin--bottom u-sv1"
               helpClassName="u-no-margin--bottom"
               wrapperClassName="stack__list-row"

--- a/src/pages/AddModel/MandatoryDetails/MandatoryDetails.test.tsx
+++ b/src/pages/AddModel/MandatoryDetails/MandatoryDetails.test.tsx
@@ -248,7 +248,7 @@ describe("MandatoryDetails", () => {
       const starts = actions.filter(
         (dispatch) => dispatch.type === "source/model-config-defaults/start",
       );
-      expect(starts.length).toBeGreaterThanOrEqual(2);
+      expect(starts.length).toEqual(2);
       expect(starts[starts.length - 1]).toMatchObject({
         payload: { selectedRegion: "us-east-1" },
       });

--- a/src/pages/AddModel/MandatoryDetails/MandatoryDetails.test.tsx
+++ b/src/pages/AddModel/MandatoryDetails/MandatoryDetails.test.tsx
@@ -249,8 +249,20 @@ describe("MandatoryDetails", () => {
         (dispatch) => dispatch.type === "source/model-config-defaults/start",
       );
       expect(starts.length).toEqual(2);
-      expect(starts[starts.length - 1]).toMatchObject({
-        payload: { selectedRegion: "us-east-1" },
+      expect(starts[0]).toMatchObject({
+        payload: {
+          wsControllerURL: "wss://controller.example.com",
+          cloudTag: "cloud-aws",
+          providerType: "ec2",
+        },
+      });
+      expect(starts[1]).toMatchObject({
+        payload: {
+          wsControllerURL: "wss://controller.example.com",
+          cloudTag: "cloud-aws",
+          providerType: "ec2",
+          selectedRegion: "us-east-1",
+        },
       });
     });
   });

--- a/src/pages/AddModel/MandatoryDetails/MandatoryDetails.test.tsx
+++ b/src/pages/AddModel/MandatoryDetails/MandatoryDetails.test.tsx
@@ -135,7 +135,7 @@ describe("MandatoryDetails", () => {
     );
   });
 
-  it("fetches credentials on initial load when cloud is set", async () => {
+  it("fetches credentials and model config defaults on initial load when cloud is set", async () => {
     state.juju.userCredentials = userCredentialsStateFactory.build();
     const [store, actions] = createStore(state, { trackActions: true });
     renderComponent(
@@ -162,6 +162,17 @@ describe("MandatoryDetails", () => {
         payload: {
           wsControllerURL: "wss://controller.example.com",
           cloudTag: "cloud-aws",
+        },
+      });
+      expect(
+        actions.find(
+          (dispatch) => dispatch.type === "source/model-config-defaults/start",
+        ),
+      ).toMatchObject({
+        payload: {
+          wsControllerURL: "wss://controller.example.com",
+          cloudTag: "cloud-aws",
+          providerType: "ec2",
         },
       });
     });
@@ -211,7 +222,40 @@ describe("MandatoryDetails", () => {
     });
   });
 
-  it("stops credential updates on unmount", async () => {
+  it("fetches model config defaults on region change", async () => {
+    const [store, actions] = createStore(state, { trackActions: true });
+    renderComponent(
+      <Formik
+        initialValues={{
+          modelName: "",
+          cloud: "cloud-aws",
+          region: "",
+          credential: "",
+        }}
+        onSubmit={vi.fn()}
+      >
+        <MandatoryDetails />
+      </Formik>,
+      { store },
+    );
+
+    await userEvent.selectOptions(
+      screen.getByLabelText(Label.REGION),
+      "us-east-1",
+    );
+
+    await waitFor(() => {
+      const starts = actions.filter(
+        (dispatch) => dispatch.type === "source/model-config-defaults/start",
+      );
+      expect(starts.length).toBeGreaterThanOrEqual(2);
+      expect(starts[starts.length - 1]).toMatchObject({
+        payload: { selectedRegion: "us-east-1" },
+      });
+    });
+  });
+
+  it("stops credential and model config defaults updates on unmount", async () => {
     const [store, actions] = createStore(state, { trackActions: true });
     const { result } = renderComponent(
       <Formik
@@ -239,6 +283,17 @@ describe("MandatoryDetails", () => {
         payload: {
           wsControllerURL: "wss://controller.example.com",
           cloudTag: "cloud-gce",
+        },
+      });
+      expect(
+        actions.find(
+          (dispatch) => dispatch.type === "source/model-config-defaults/stop",
+        ),
+      ).toMatchObject({
+        payload: {
+          wsControllerURL: "wss://controller.example.com",
+          cloudTag: "cloud-gce",
+          providerType: "gce",
         },
       });
     });

--- a/src/pages/AddModel/MandatoryDetails/MandatoryDetails.tsx
+++ b/src/pages/AddModel/MandatoryDetails/MandatoryDetails.tsx
@@ -18,6 +18,7 @@ import {
   extractCloudName,
   extractCredentialName,
 } from "store/juju/utils/models";
+import modelConfigDefaultsSource from "store/middleware/source/model-config-defaults";
 import userCredentialsMiddleware from "store/middleware/source/user-credentials";
 import { useAppDispatch, useAppSelector } from "store/store";
 import { testId } from "testing/utils";
@@ -120,6 +121,35 @@ const MandatoryDetails = (): JSX.Element => {
       }
     };
   }, [dispatch, wsControllerURL, selectedCloud, userCredentials.credentials]);
+
+  // Start polling for live model config defaults when a cloud is selected.
+  const providerType = selectedCloud
+    ? cloudInfo?.[selectedCloud]?.type
+    : undefined;
+
+  useEffect(() => {
+    if (!wsControllerURL || !selectedCloud || !providerType) {
+      return;
+    }
+    dispatch(
+      modelConfigDefaultsSource.actions.start({
+        wsControllerURL,
+        cloudTag: selectedCloud,
+        providerType,
+        selectedRegion: values.region || undefined,
+      }),
+    );
+    return (): void => {
+      dispatch(
+        modelConfigDefaultsSource.actions.stop({
+          wsControllerURL,
+          cloudTag: selectedCloud,
+          providerType,
+          selectedRegion: values.region || undefined,
+        }),
+      );
+    };
+  }, [dispatch, wsControllerURL, selectedCloud, providerType, values.region]);
 
   const credentialsOptions = useMemo(
     () => toCredentialOptions(userCredentials.credentials[values.cloud] || []),

--- a/src/pages/AddModel/MandatoryDetails/MandatoryDetails.tsx
+++ b/src/pages/AddModel/MandatoryDetails/MandatoryDetails.tsx
@@ -131,23 +131,15 @@ const MandatoryDetails = (): JSX.Element => {
     if (!wsControllerURL || !selectedCloud || !providerType) {
       return;
     }
-    dispatch(
-      modelConfigDefaultsSource.actions.start({
-        wsControllerURL,
-        cloudTag: selectedCloud,
-        providerType,
-        selectedRegion: values.region || undefined,
-      }),
-    );
+    const param = {
+      wsControllerURL,
+      cloudTag: selectedCloud,
+      providerType,
+      selectedRegion: values.region || undefined,
+    };
+    dispatch(modelConfigDefaultsSource.actions.start(param));
     return (): void => {
-      dispatch(
-        modelConfigDefaultsSource.actions.stop({
-          wsControllerURL,
-          cloudTag: selectedCloud,
-          providerType,
-          selectedRegion: values.region || undefined,
-        }),
-      );
+      dispatch(modelConfigDefaultsSource.actions.stop(param));
     };
   }, [dispatch, wsControllerURL, selectedCloud, providerType, values.region]);
 

--- a/src/store/juju/selectors.test.ts
+++ b/src/store/juju/selectors.test.ts
@@ -48,6 +48,8 @@ import {
   modelUpgradeFactory,
   supportedJujuVersionsStateFactory,
   modelMigrationTargetsStateFactory,
+  modelConfigDefaultsStateFactory,
+  configFieldEntryFactory,
 } from "testing/factories/juju/juju";
 
 import {
@@ -3318,40 +3320,25 @@ describe("getCloudInfoState", () => {
 
 describe("getModelConfigDefaultsState", () => {
   it("gets the model config defaults slice", () => {
-    const state = rootStateFactory.withGeneralConfig().build({
-      juju: jujuStateFactory.build({
-        modelConfigDefaults: {
-          errors: null,
-          loading: false,
-          defaults: {
-            ec2: [
-              {
-                label: "firewall-mode",
-                category: null,
-                value: "instance",
-                defaultValue: "instance",
-                arrayIndex: 0,
-              },
-            ],
-          },
-        },
-      }),
-    });
-    expect(getModelConfigDefaultsState(state)).toStrictEqual({
-      errors: null,
-      loading: false,
+    const modelConfigDefaults = modelConfigDefaultsStateFactory.build({
       defaults: {
         ec2: [
-          {
+          configFieldEntryFactory.build({
             label: "firewall-mode",
-            category: null,
             value: "instance",
             defaultValue: "instance",
-            arrayIndex: 0,
-          },
+          }),
         ],
       },
     });
+    const state = rootStateFactory.withGeneralConfig().build({
+      juju: jujuStateFactory.build({
+        modelConfigDefaults,
+      }),
+    });
+    expect(getModelConfigDefaultsState(state)).toStrictEqual(
+      modelConfigDefaults,
+    );
   });
 });
 

--- a/src/store/juju/selectors.test.ts
+++ b/src/store/juju/selectors.test.ts
@@ -147,6 +147,7 @@ import {
   getSupportedJujuVersions,
   getCloudInfoState,
   getUserCredentialsState,
+  getModelConfigDefaultsState,
   getModelUpgrade,
   getModelMigrationTargets,
   getControllerByUUID,
@@ -3311,6 +3312,45 @@ describe("getCloudInfoState", () => {
       clouds: null,
       errors: null,
       loading: false,
+    });
+  });
+});
+
+describe("getModelConfigDefaultsState", () => {
+  it("gets the model config defaults slice", () => {
+    const state = rootStateFactory.withGeneralConfig().build({
+      juju: jujuStateFactory.build({
+        modelConfigDefaults: {
+          errors: null,
+          loading: false,
+          defaults: {
+            ec2: [
+              {
+                label: "firewall-mode",
+                category: null,
+                value: "instance",
+                defaultValue: "instance",
+                arrayIndex: 0,
+              },
+            ],
+          },
+        },
+      }),
+    });
+    expect(getModelConfigDefaultsState(state)).toStrictEqual({
+      errors: null,
+      loading: false,
+      defaults: {
+        ec2: [
+          {
+            label: "firewall-mode",
+            category: null,
+            value: "instance",
+            defaultValue: "instance",
+            arrayIndex: 0,
+          },
+        ],
+      },
     });
   });
 });

--- a/src/store/juju/selectors.ts
+++ b/src/store/juju/selectors.ts
@@ -1613,3 +1613,11 @@ export const getAddModelState = createSelector(
   [slice],
   (sliceState) => sliceState.addModelState,
 );
+
+/**
+Fetches the model config defaults state.
+*/
+export const getModelConfigDefaultsState = createSelector(
+  [slice],
+  (sliceState) => sliceState.modelConfigDefaults,
+);

--- a/src/store/middleware/check-auth.ts
+++ b/src/store/middleware/check-auth.ts
@@ -110,6 +110,7 @@ export const checkAuthMiddleware: Middleware<
       jujuActions.updateModelMigrationTargets.type,
       jujuActions.updateUserCredentials.type,
       jujuActions.updateCloudInfo.type,
+      jujuActions.updateModelConfigDefaults.type,
     ];
 
     const thunkAllowlist = [

--- a/src/testing/factories/juju/juju.ts
+++ b/src/testing/factories/juju/juju.ts
@@ -21,10 +21,11 @@ import type {
   ModelUpgrade,
   ReBACState,
   SecretsState,
+  SecretsContent,
   SupportedJujuVersionsState,
   UserCredentialsState,
 } from "store/juju/types";
-import type { SecretsContent } from "store/juju/types";
+import type { ConfigFieldEntry } from "store/middleware/source/types";
 
 import { modelStatusInfoFactory } from "./ClientV8";
 import { modelInfoFactory } from "./ModelManagerV11";
@@ -130,6 +131,14 @@ export const cloudInfoStateFactory = Factory.define<CloudState>(() => ({
   clouds: null,
   errors: null,
   loading: false,
+}));
+
+export const configFieldEntryFactory = Factory.define<ConfigFieldEntry>(() => ({
+  label: "",
+  category: null,
+  value: "",
+  defaultValue: "",
+  arrayIndex: 0,
 }));
 
 export const modelConfigDefaultsStateFactory =


### PR DESCRIPTION
Depends on https://github.com/canonical/juju-dashboard/pull/2394

## Done

- Wired the middleware to fetch and store model config schema and defaults to the UI.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Try viewing the add model flow at Juju 4.0.12 (live) and any other version before that (static)
- The configs and constraints tab should work fine either way and the model should be added succesfully
- A simple way to distinguish between values from the facade and the static ones is the configuration `fan-config`. This was deprecated in Juju v4.0 so the facade will not return it.

## Details

https://warthogs.atlassian.net/browse/JUJU-10098