### PR TITLE
fix: end to end tests for add-model

### DIFF
--- a/e2e/base/add-model.spec.ts
+++ b/e2e/base/add-model.spec.ts
@@ -96,10 +96,10 @@ test.describe("Add model", () => {
       .getByRole("searchbox", { name: "Search configurations" })
       .fill("default-space");
     await expect(
-      configsSection.locator('input[name="default-space"]'),
+      configsSection.locator('input[aria-label="default-space"]'),
     ).toBeVisible();
     await configsSection
-      .locator('input[name="default-space"]')
+      .locator('input[aria-label="default-space"]')
       .fill(defaultSpace);
 
     // Set arch constraint
@@ -110,10 +110,10 @@ test.describe("Add model", () => {
       .getByRole("searchbox", { name: "Search constraints" })
       .fill("arch");
     await expect(
-      constraintsSection.locator('select[name="arch"]'),
+      constraintsSection.locator('select[aria-label="arch"]'),
     ).toBeVisible();
     await constraintsSection
-      .locator('select[name="arch"]')
+      .locator('select[aria-label="arch"]')
       .selectOption(architecture);
 
     // Create the model

--- a/src/pages/AddModel/ConfigsConstraints/StackList/StackList.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/StackList/StackList.tsx
@@ -34,6 +34,7 @@ const StackList = ({ visibleFields, arrayName }: Props): JSX.Element => {
                   {entry.label}
                 </>
               }
+              aria-label={entry.label}
               name={fieldName}
               help={entry.description}
               helpAfterLabel


### PR DESCRIPTION
## Done

- Fixed end to end tests after the latest refactor on Add Model
- The locator for configs+constraints needed updating
- Also added `aria-label` explicitly to `Stacklist` to allow easier location. Without setting it this way, it was being rendered as `aria-label="[object Object]"` which was inaccessible. 

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- All e2e tests should pass