### PR TITLE
feat: introduce confirmation modal for switch while loading

### DIFF
--- a/src/pages/AddModel/ConfigsConstraints/CategoriesListing/CategoriesListing.test.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/CategoriesListing/CategoriesListing.test.tsx
@@ -113,11 +113,36 @@ describe("CategoriesListing", () => {
 
     // Skeleton placeholders are shown instead of inputs.
     expect(screen.getAllByTestId("placeholder").length).toBeGreaterThan(0);
-    // Switch to YAML mode — the textarea is also disabled.
-    await userEvent.click(screen.getByRole("radio", { name: InputMode.YAML }));
-    expect(
-      screen.getByPlaceholderText(Label.MODEL_CONFIG_PLACEHOLDER),
-    ).toBeDisabled();
+  });
+
+  it("renders loading mode for YAML view properly", async () => {
+    const onSwitchWhileLoading = vi.fn();
+    render(
+      <Formik
+        initialValues={{
+          ...initialValues,
+          [FieldName.CONFIG_INPUT_MODE]: InputMode.YAML,
+        }}
+        onSubmit={vi.fn()}
+      >
+        <CategoriesListing
+          {...defaultProps}
+          isLoading
+          onSwitchWhileLoading={onSwitchWhileLoading}
+        />
+      </Formik>,
+    );
+
+    // The YAML textarea should accept input from user
+    const textarea = screen.getByPlaceholderText(
+      Label.MODEL_CONFIG_PLACEHOLDER,
+    ) as HTMLTextAreaElement;
+    await userEvent.type(textarea, "default-space: my-space");
+    expect(textarea.value).toBe("default-space: my-space");
+
+    // Switching back to list mode should trigger the confirmation callback.
+    await userEvent.click(screen.getByRole("radio", { name: InputMode.LIST }));
+    expect(onSwitchWhileLoading).toHaveBeenCalledOnce();
   });
 
   it("shows list mode content by default", () => {

--- a/src/pages/AddModel/ConfigsConstraints/CategoriesListing/CategoriesListing.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/CategoriesListing/CategoriesListing.tsx
@@ -42,6 +42,7 @@ const CategoriesListing = ({
   setYAMLErrors,
   yamlErrorLabel,
   isLoading = false,
+  onSwitchWhileLoading,
 }: Props): JSX.Element => {
   const id = useId();
   const { values, setFieldError, setFieldTouched, setFieldValue } =
@@ -129,6 +130,10 @@ const CategoriesListing = ({
             label={InputMode.LIST}
             name={`mode-${id}`}
             onChange={() => {
+              if (isLoading && values[yamlKey]) {
+                onSwitchWhileLoading?.();
+                return;
+              }
               handleModeChange(true);
             }}
             value={InputMode.LIST}
@@ -207,7 +212,6 @@ const CategoriesListing = ({
         <div className="row u-no-padding">
           <div className="col-6">
             <FormikField
-              disabled={isLoading}
               className="categories__yaml-input"
               component={Textarea}
               name={yamlKey}

--- a/src/pages/AddModel/ConfigsConstraints/CategoriesListing/types.ts
+++ b/src/pages/AddModel/ConfigsConstraints/CategoriesListing/types.ts
@@ -16,4 +16,5 @@ export type Props = {
   setYAMLErrors: (state: YAMLErrorsModalState) => void;
   yamlErrorLabel: string;
   isLoading?: boolean;
+  onSwitchWhileLoading?: () => void;
 };

--- a/src/pages/AddModel/ConfigsConstraints/ConfigsConstraints.test.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/ConfigsConstraints.test.tsx
@@ -371,13 +371,19 @@ describe("ConfigsConstraints", () => {
     );
 
     const dialog = screen.getByRole("dialog", {
-      name: "YAML inputs will be lost",
+      name: "YAML configuration will be lost",
     });
     expect(dialog).toBeInTheDocument();
     await userEvent.click(
       screen.getByRole("button", { name: "Keep editing in YAML" }),
     );
     expect(dialog).not.toBeInTheDocument();
+    expect(
+      within(configsSection).getByRole("radio", { name: InputMode.YAML }),
+    ).toBeChecked();
+    expect(within(configsSection).getByRole("textbox")).toHaveValue(
+      "default-space: my-space",
+    );
   });
 
   it("does not show the confirmation modal on switching to list mode if no inputs were made", async () => {
@@ -413,7 +419,7 @@ describe("ConfigsConstraints", () => {
 
     expect(
       screen.queryByRole("dialog", {
-        name: "YAML inputs will be lost",
+        name: "YAML configuration will be lost",
       }),
     ).not.toBeInTheDocument();
     expect(
@@ -453,7 +459,7 @@ describe("ConfigsConstraints", () => {
     );
 
     const dialog = screen.getByRole("dialog", {
-      name: "YAML inputs will be lost",
+      name: "YAML configuration will be lost",
     });
     expect(dialog).toBeInTheDocument();
     await userEvent.click(

--- a/src/pages/AddModel/ConfigsConstraints/ConfigsConstraints.test.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/ConfigsConstraints.test.tsx
@@ -338,4 +338,135 @@ describe("ConfigsConstraints", () => {
     ) as HTMLInputElement;
     expect(defaultSpaceInput.value).toBe("my-space");
   });
+
+  it("shows the confirmation modal when switching to list mode while configs are loading", async () => {
+    const state = rootStateFactory.withGeneralConfig().build({
+      juju: jujuStateFactory.build({
+        modelConfigDefaults: {
+          defaults: {},
+          errors: null,
+          loading: true,
+        },
+      }),
+    });
+    renderComponent(
+      <Formik
+        initialValues={{
+          ...initialValues,
+          [FieldName.CONFIG_INPUT_MODE]: InputMode.YAML,
+          [FieldName.CONFIG_YAML]: "default-space: my-space",
+        }}
+        onSubmit={vi.fn()}
+      >
+        <ConfigsConstraints />
+      </Formik>,
+      { state },
+    );
+
+    const configsSection = screen.getByRole("region", {
+      name: Label.CONFIGS_TITLE,
+    });
+    await userEvent.click(
+      within(configsSection).getByRole("radio", { name: InputMode.LIST }),
+    );
+
+    const dialog = screen.getByRole("dialog", {
+      name: "YAML inputs will be lost",
+    });
+    expect(dialog).toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Keep editing in YAML" }),
+    );
+    expect(dialog).not.toBeInTheDocument();
+  });
+
+  it("does not show the confirmation modal on switching to list mode if no inputs were made", async () => {
+    const state = rootStateFactory.withGeneralConfig().build({
+      juju: jujuStateFactory.build({
+        modelConfigDefaults: {
+          defaults: {},
+          errors: null,
+          loading: true,
+        },
+      }),
+    });
+    renderComponent(
+      <Formik
+        initialValues={{
+          ...initialValues,
+          [FieldName.CONFIG_INPUT_MODE]: InputMode.YAML,
+          [FieldName.CONFIG_YAML]: "",
+        }}
+        onSubmit={vi.fn()}
+      >
+        <ConfigsConstraints />
+      </Formik>,
+      { state },
+    );
+
+    const configsSection = screen.getByRole("region", {
+      name: Label.CONFIGS_TITLE,
+    });
+    await userEvent.click(
+      within(configsSection).getByRole("radio", { name: InputMode.LIST }),
+    );
+
+    expect(
+      screen.queryByRole("dialog", {
+        name: "YAML inputs will be lost",
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      within(configsSection).getByRole("radio", { name: InputMode.LIST }),
+    ).toBeChecked();
+  });
+
+  it("wipes YAML entries when switching to list mode forcefully while loading", async () => {
+    const state = rootStateFactory.withGeneralConfig().build({
+      juju: jujuStateFactory.build({
+        modelConfigDefaults: {
+          defaults: {},
+          errors: null,
+          loading: true,
+        },
+      }),
+    });
+    renderComponent(
+      <Formik
+        initialValues={{
+          ...initialValues,
+          [FieldName.CONFIG_INPUT_MODE]: InputMode.YAML,
+          [FieldName.CONFIG_YAML]: "default-space: my-space",
+        }}
+        onSubmit={vi.fn()}
+      >
+        <ConfigsConstraints />
+      </Formik>,
+      { state },
+    );
+
+    const configsSection = screen.getByRole("region", {
+      name: Label.CONFIGS_TITLE,
+    });
+    await userEvent.click(
+      within(configsSection).getByRole("radio", { name: InputMode.LIST }),
+    );
+
+    const dialog = screen.getByRole("dialog", {
+      name: "YAML inputs will be lost",
+    });
+    expect(dialog).toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Discard and switch" }),
+    );
+    expect(
+      within(configsSection).getByRole("radio", { name: InputMode.LIST }),
+    ).toBeChecked();
+
+    // Skeleton placeholders are shown instead of real inputs while loading.
+    expect(
+      within(configsSection).getAllByTestId("placeholder").length,
+    ).toBeGreaterThan(0);
+    expect(within(configsSection).queryAllByRole("textbox")).toHaveLength(0);
+  });
 });

--- a/src/pages/AddModel/ConfigsConstraints/ConfigsConstraints.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/ConfigsConstraints.tsx
@@ -14,6 +14,7 @@ import type { AddModelFormState } from "../types";
 import { InputMode } from "../types";
 
 import CategoriesListing from "./CategoriesListing";
+import ConfirmSwitchModal from "./ConfirmSwitchModal";
 import TruncatedCommands from "./TruncatedCommands";
 import YAMLErrorsModal from "./YAMLErrorsModal";
 import type { YAMLErrorsModalState } from "./YAMLErrorsModal/types";
@@ -28,7 +29,7 @@ const ConfigsConstraints = (): JSX.Element => {
   const modelConfigDefaults = useAppSelector(getModelConfigDefaultsState);
   const [yamlErrorsModalState, setYAMLErrors] =
     useState<null | YAMLErrorsModalState>(null);
-  const [isConfigLoading, setIsConfigLoading] = useState(true);
+  const [showConfirmSwitchModal, setShowConfirmSwitchModal] = useState(false);
 
   const providerType = values.cloud
     ? cloudInfo?.[values.cloud]?.type
@@ -38,14 +39,6 @@ const ConfigsConstraints = (): JSX.Element => {
   const liveEntries = providerType
     ? (modelConfigDefaults.defaults[providerType] ?? null)
     : null;
-
-  useEffect(() => {
-    if (modelConfigDefaults.loading) {
-      setIsConfigLoading(true);
-    } else {
-      setIsConfigLoading(false);
-    }
-  }, [modelConfigDefaults.loading]);
 
   useEffect(() => {
     if (!liveEntries || liveEntries.length === 0) {
@@ -71,8 +64,15 @@ const ConfigsConstraints = (): JSX.Element => {
           }}
         />
       ) : null}
+      {showConfirmSwitchModal ? (
+        <ConfirmSwitchModal
+          onClose={() => {
+            setShowConfirmSwitchModal(false);
+          }}
+        />
+      ) : null}
       <CategoriesListing
-        isLoading={isConfigLoading}
+        isLoading={modelConfigDefaults.loading}
         title={Label.CONFIGS_TITLE}
         arrayName={FieldName.CONFIG_FIELDS}
         inputMode={FieldName.CONFIG_INPUT_MODE}
@@ -86,6 +86,9 @@ const ConfigsConstraints = (): JSX.Element => {
         searchName="configSearch"
         setYAMLErrors={setYAMLErrors}
         yamlErrorLabel={Label.INCORRECT_YAML_CONFIGURATION_ERROR}
+        onSwitchWhileLoading={() => {
+          setShowConfirmSwitchModal(true);
+        }}
       />
       <CategoriesListing
         title={Label.CONSTRAINTS_TITLE}

--- a/src/pages/AddModel/ConfigsConstraints/ConfirmSwitchModal/ConfirmSwitchModal.test.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/ConfirmSwitchModal/ConfirmSwitchModal.test.tsx
@@ -1,0 +1,79 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Formik } from "formik";
+
+import { InputMode } from "pages/AddModel/types";
+import { renderComponent } from "testing/utils";
+
+import { FieldName } from "../types";
+
+import ConfirmSwitchModal from "./ConfirmSwitchModal";
+
+describe("ConfirmSwitchModal", () => {
+  let initialValues: {
+    [FieldName.CONFIG_YAML]: string;
+    [FieldName.CONFIG_INPUT_MODE]: InputMode;
+  };
+
+  beforeEach(() => {
+    initialValues = {
+      [FieldName.CONFIG_YAML]: "",
+      [FieldName.CONFIG_INPUT_MODE]: InputMode.YAML,
+    };
+  });
+
+  it("renders the modal with correct labels", () => {
+    renderComponent(
+      <Formik initialValues={initialValues} onSubmit={vi.fn()}>
+        <ConfirmSwitchModal onClose={vi.fn()} />
+      </Formik>,
+    );
+    expect(screen.getByText("YAML inputs will be lost")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Keep editing in YAML" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Discard and switch" }),
+    ).toBeInTheDocument();
+  });
+
+  it("calls onClose when cancel button is clicked", async () => {
+    const onClose = vi.fn();
+    renderComponent(
+      <Formik initialValues={initialValues} onSubmit={vi.fn()}>
+        <ConfirmSwitchModal onClose={onClose} />
+      </Formik>,
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Keep editing in YAML" }),
+    );
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("clears YAML and switches to list mode when confirm button is clicked", async () => {
+    const onClose = vi.fn();
+    let formValues = null;
+    renderComponent(
+      <Formik
+        initialValues={{
+          ...initialValues,
+          [FieldName.CONFIG_YAML]: "default-space: my-space",
+        }}
+        onSubmit={vi.fn()}
+      >
+        {({ values }) => {
+          formValues = values;
+          return <ConfirmSwitchModal onClose={onClose} />;
+        }}
+      </Formik>,
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Discard and switch" }),
+    );
+    expect(onClose).toHaveBeenCalledOnce();
+    expect(formValues?.[FieldName.CONFIG_YAML]).toBe("");
+    expect(formValues?.[FieldName.CONFIG_INPUT_MODE]).toBe(InputMode.LIST);
+  });
+});

--- a/src/pages/AddModel/ConfigsConstraints/ConfirmSwitchModal/ConfirmSwitchModal.test.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/ConfirmSwitchModal/ConfirmSwitchModal.test.tsx
@@ -28,7 +28,9 @@ describe("ConfirmSwitchModal", () => {
         <ConfirmSwitchModal onClose={vi.fn()} />
       </Formik>,
     );
-    expect(screen.getByText("YAML inputs will be lost")).toBeInTheDocument();
+    expect(
+      screen.getByText("YAML configuration will be lost"),
+    ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Keep editing in YAML" }),
     ).toBeInTheDocument();
@@ -39,9 +41,19 @@ describe("ConfirmSwitchModal", () => {
 
   it("calls onClose when cancel button is clicked", async () => {
     const onClose = vi.fn();
+    let formValues = null;
     renderComponent(
-      <Formik initialValues={initialValues} onSubmit={vi.fn()}>
-        <ConfirmSwitchModal onClose={onClose} />
+      <Formik
+        initialValues={{
+          ...initialValues,
+          [FieldName.CONFIG_YAML]: "default-space: my-space",
+        }}
+        onSubmit={vi.fn()}
+      >
+        {({ values }) => {
+          formValues = values;
+          return <ConfirmSwitchModal onClose={onClose} />;
+        }}
       </Formik>,
     );
 
@@ -49,6 +61,8 @@ describe("ConfirmSwitchModal", () => {
       screen.getByRole("button", { name: "Keep editing in YAML" }),
     );
     expect(onClose).toHaveBeenCalledOnce();
+    expect(formValues?.[FieldName.CONFIG_YAML]).toBe("default-space: my-space");
+    expect(formValues?.[FieldName.CONFIG_INPUT_MODE]).toBe(InputMode.YAML);
   });
 
   it("clears YAML and switches to list mode when confirm button is clicked", async () => {

--- a/src/pages/AddModel/ConfigsConstraints/ConfirmSwitchModal/ConfirmSwitchModal.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/ConfirmSwitchModal/ConfirmSwitchModal.tsx
@@ -1,0 +1,40 @@
+import { ConfirmationModal, usePortal } from "@canonical/react-components";
+import { useFormikContext } from "formik";
+import type { JSX } from "react";
+
+import { InputMode } from "../../types";
+import { FieldName, type FormFields } from "../types";
+
+import type { ConfirmSwitchModalProps } from "./types";
+
+const ConfirmSwitchModal = ({
+  onClose,
+}: ConfirmSwitchModalProps): JSX.Element => {
+  const { setFieldValue } = useFormikContext<FormFields>();
+  const { Portal } = usePortal();
+
+  return (
+    <Portal>
+      <ConfirmationModal
+        title="YAML inputs will be lost"
+        cancelButtonLabel="Keep editing in YAML"
+        confirmButtonLabel="Discard and switch"
+        confirmButtonAppearance="primary"
+        onConfirm={() => {
+          void setFieldValue(FieldName.CONFIG_YAML, "");
+          void setFieldValue(FieldName.CONFIG_INPUT_MODE, InputMode.LIST);
+          onClose();
+        }}
+        close={onClose}
+      >
+        <p>
+          List view fields are not ready yet. If you switch now, you will lose
+          your current YAML inputs. You can still create a model in the YAML
+          view.
+        </p>
+      </ConfirmationModal>
+    </Portal>
+  );
+};
+
+export default ConfirmSwitchModal;

--- a/src/pages/AddModel/ConfigsConstraints/ConfirmSwitchModal/ConfirmSwitchModal.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/ConfirmSwitchModal/ConfirmSwitchModal.tsx
@@ -16,7 +16,7 @@ const ConfirmSwitchModal = ({
   return (
     <Portal>
       <ConfirmationModal
-        title="YAML inputs will be lost"
+        title="YAML configuration will be lost"
         cancelButtonLabel="Keep editing in YAML"
         confirmButtonLabel="Discard and switch"
         confirmButtonAppearance="primary"
@@ -28,9 +28,9 @@ const ConfirmSwitchModal = ({
         close={onClose}
       >
         <p>
-          List view fields are not ready yet. If you switch now, you will lose
-          your current YAML inputs. You can still create a model in the YAML
-          view.
+          Model configuration data has not been loaded. Returning to list view
+          will discard the current YAML configuration. You can still create a
+          model in the YAML view.
         </p>
       </ConfirmationModal>
     </Portal>

--- a/src/pages/AddModel/ConfigsConstraints/ConfirmSwitchModal/index.ts
+++ b/src/pages/AddModel/ConfigsConstraints/ConfirmSwitchModal/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./ConfirmSwitchModal";
+export * from "./types";

--- a/src/pages/AddModel/ConfigsConstraints/ConfirmSwitchModal/types.ts
+++ b/src/pages/AddModel/ConfigsConstraints/ConfirmSwitchModal/types.ts
@@ -1,0 +1,3 @@
+export type ConfirmSwitchModalProps = {
+  onClose: () => void;
+};

--- a/src/pages/AddModel/ConfigsConstraints/StackList/StackList.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/StackList/StackList.tsx
@@ -47,7 +47,6 @@ const StackList = ({
                   {entry.label}
                 </>
               }
-              disabled={isLoading}
               aria-label={entry.label}
               name={fieldName}
               help={entry.description}


### PR DESCRIPTION
## Done

- Enabled YAML textarea for inputs when the configs are still loading
- Introduced a new confirmation modal for when the user tries to switch back to list view

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- View the add model flow at Juju > v4.0.12
- Switch to a slower network and try viewing the ConfigsConstraints tab
- The loading mode should be visible with skeletons in list view for configurations
- On switching to YAML view, you should see the input field enabled
- Currently, you can freely switch between list and yaml views
- Try entering something in the input field and then attempt to switch to list view
- You should see a confirmation modal with appropriate message

## Details

https://warthogs.atlassian.net/browse/JUJU-10185
