### PR TITLE
fix: ensure applications are selectable without search

### DIFF
--- a/src/pages/EntityDetails/Model/ApplicationsTab/LocalAppsTable/LocalAppsTable.test.tsx
+++ b/src/pages/EntityDetails/Model/ApplicationsTab/LocalAppsTable/LocalAppsTable.test.tsx
@@ -101,20 +101,20 @@ describe("LocalAppsTable", () => {
     expect(screen.queryAllByRole("row")).toHaveLength(8);
   });
 
-  it.each([
-    { url: url },
-    { url: searchURL }
-  ])("shows the select column regardless of search", ({ url }) => {
-    renderComponent(
-      <LocalAppsTable
-        applications={state.juju.modelData?.test123.applications}
-      />,
-      { path, url, state },
-    );
-    expect(
-      screen.queryAllByRole("columnheader")[0].querySelector("input"),
-    ).toBeInTheDocument();
-  });
+  it.each([{ url: url }, { url: searchURL }])(
+    "shows the select column regardless of search",
+    ({ url: targetUrl }) => {
+      renderComponent(
+        <LocalAppsTable
+          applications={state.juju.modelData?.test123.applications}
+        />,
+        { path, url: targetUrl, state },
+      );
+      expect(
+        screen.queryAllByRole("columnheader")[0].querySelector("input"),
+      ).toBeInTheDocument();
+    },
+  );
 
   it("does not show the select column when the user only has read permissions", () => {
     state.juju.modelData.test123.info = modelInfoFactory.build({
@@ -287,20 +287,20 @@ describe("LocalAppsTable", () => {
     expect(screen.getByTestId(TestId.SELECT_ALL)).not.toBeChecked();
   });
 
-  it.each([
-    { url: url },
-    { url: searchURL }
-  ])("shows the run action button regardless of search", ({ url }) => {
-    renderComponent(
-      <LocalAppsTable
-        applications={state.juju.modelData?.test123.applications}
-      />,
-      { path, url, state },
-    );
-    expect(
-      screen.queryByRole("button", { name: /run action/i }),
-    ).toBeInTheDocument();
-  })
+  it.each([{ url: url }, { url: searchURL }])(
+    "shows the run action button regardless of search",
+    ({ url: targetUrl }) => {
+      renderComponent(
+        <LocalAppsTable
+          applications={state.juju.modelData?.test123.applications}
+        />,
+        { path, url: targetUrl, state },
+      );
+      expect(
+        screen.queryByRole("button", { name: /run action/i }),
+      ).toBeInTheDocument();
+    },
+  );
 
   it("does not show the run action button when the user only has read permissions", () => {
     state.juju.modelData.test123.info = modelInfoFactory.build({

--- a/src/pages/EntityDetails/Model/ApplicationsTab/LocalAppsTable/LocalAppsTable.test.tsx
+++ b/src/pages/EntityDetails/Model/ApplicationsTab/LocalAppsTable/LocalAppsTable.test.tsx
@@ -101,31 +101,16 @@ describe("LocalAppsTable", () => {
     expect(screen.queryAllByRole("row")).toHaveLength(8);
   });
 
-  it("doesn't show the select column when there is no search", () => {
+  it.each([
+    { url: url },
+    { url: searchURL }
+  ])("shows the select column regardless of search", ({ url }) => {
     renderComponent(
       <LocalAppsTable
         applications={state.juju.modelData?.test123.applications}
       />,
       { path, url, state },
     );
-    // first column not to be a checkbox
-    expect(
-      screen.queryAllByRole("columnheader")[0].querySelector("input"),
-    ).not.toBeInTheDocument();
-  });
-
-  it("shows the select column when there is a search", () => {
-    renderComponent(
-      <LocalAppsTable
-        applications={state.juju.modelData?.test123.applications}
-      />,
-      {
-        path,
-        url: searchURL,
-        state,
-      },
-    );
-    // first column to be a checkbox
     expect(
       screen.queryAllByRole("columnheader")[0].querySelector("input"),
     ).toBeInTheDocument();
@@ -302,7 +287,10 @@ describe("LocalAppsTable", () => {
     expect(screen.getByTestId(TestId.SELECT_ALL)).not.toBeChecked();
   });
 
-  it("doesn't show the run action button when there is no search", () => {
+  it.each([
+    { url: url },
+    { url: searchURL }
+  ])("shows the run action button regardless of search", ({ url }) => {
     renderComponent(
       <LocalAppsTable
         applications={state.juju.modelData?.test123.applications}
@@ -311,24 +299,8 @@ describe("LocalAppsTable", () => {
     );
     expect(
       screen.queryByRole("button", { name: /run action/i }),
-    ).not.toBeInTheDocument();
-  });
-
-  it("shows the run action button when there is a search", () => {
-    renderComponent(
-      <LocalAppsTable
-        applications={state.juju.modelData?.test123.applications}
-      />,
-      {
-        path,
-        url: searchURL,
-        state,
-      },
-    );
-    expect(
-      screen.queryByRole("button", { name: /run action/i }),
     ).toBeInTheDocument();
-  });
+  })
 
   it("does not show the run action button when the user only has read permissions", () => {
     state.juju.modelData.test123.info = modelInfoFactory.build({

--- a/src/pages/EntityDetails/Model/ApplicationsTab/LocalAppsTable/LocalAppsTable.tsx
+++ b/src/pages/EntityDetails/Model/ApplicationsTab/LocalAppsTable/LocalAppsTable.tsx
@@ -60,8 +60,7 @@ const LocalAppsTable: FC<Props> = ({ applications }: Props) => {
   const { handleSelect, handleSelectAll, selectAll } = useTableSelect(
     applications ?? {},
   );
-  const selectable =
-    queryParams.filterQuery && applications && canConfigureModel;
+  const selectable = applications && canConfigureModel;
 
   let headers: Header | MainTableCell[] =
     generateLocalApplicationTableHeaders();


### PR DESCRIPTION
Closes #2403

## Done

- Removed `queryParams.filterQuery` as a requirement for setting `selectable` to `true` in `LocalAppsTable.tsx`
    - `selectable` is what determines whether the "Run Action" and the checkboxes are visible.
- Modified tests in `LocalAppsTable.test.tsx` to fit new behavior.

## QA

- Navigate to a model with multiple applications and ensure behavior matches the screenshots of the **After** row below.
- Ensure `yarn lint` succeeds
- Ensure `yarn test` succeeds
    - This covers the new behavior introduced in this diff and regression tests with user permissions.

## Screenshots

|        | Without search | With search |
| ------ | :------------: | :---------: |
| Before | <img width="2879" height="1588" alt="image" src="https://github.com/user-attachments/assets/3d895660-8029-4318-a84a-947e532dede2" /> |  <img width="2879" height="1588" alt="image" src="https://github.com/user-attachments/assets/fbafee19-3442-45fc-8dff-1a91b18629c7" /> |
| After  | <img width="2879" height="1588" alt="image" src="https://github.com/user-attachments/assets/ed347a33-e159-426c-aa9b-3c1d66b703dd" /> |   <img width="2879" height="1588" alt="image" src="https://github.com/user-attachments/assets/cbab2678-e741-47c2-8f69-c22bc56839a7" /> |

## Details

For more context, the behavior this diff modifies was introduced in #1629 and might have been an explicit decision made a while ago, but this leads to an awkward flow where we need a dummy query select applications and run actions on them.
