### PR TITLE
fix(ci): fix docker and machine charm E2E tests

### DIFF
--- a/charms/k8s-charm/src/config.py
+++ b/charms/k8s-charm/src/config.py
@@ -23,7 +23,7 @@ class Config:
         dashboard_root: str,
         analytics_enabled: bool,
         port: int,
-        base_app_url: str | None = None,
+        base_app_url: str,
         config_file_name: str | None = None,
         has_external_controller_url=False,
     ):
@@ -36,7 +36,8 @@ class Config:
         self._analytics_enabled = analytics_enabled
         self._port = port
         self._has_external_controller_url = has_external_controller_url
-        self._base_app_url = base_app_url
+        # Treat `/` as equivalent to an empty string, so templates don't end up with `//`.
+        self._base_app_url = "" if base_app_url == "/" else base_app_url
 
     def generate(self):
         env = Environment(loader=FileSystemLoader(self._config_dir))
@@ -113,6 +114,7 @@ if __name__ == "__main__":
             ),
             dashboard_root=os.environ.get("DASHBOARD_ROOT", "/srv"),
             port=int(os.environ.get("DASHBOARD_PORT", 8080)),
+            base_app_url=os.environ.get("DASHBOARD_BASE_APP_URL", ""),
             has_external_controller_url=to_bool(
                 os.environ.get("HAS_EXTERNAL_CONTROLLER_URL", False)
             ),

--- a/entrypoint
+++ b/entrypoint
@@ -10,6 +10,7 @@
 # DASHBOARD_IS_JUJU - equivalent to the charm's is-juju config option.
 # DASHBOARD_ANALYTICS_ENABLED - equivalent to the charm's analytics-enabled config option.
 # DASHBOARD_PORT - equivalent to the charm's port config option.
+# DASHBOARD_BASE_APP_URL - base URL that the dashboard is hosted at, useful if it's behind a reverse proxy.
 
 python3 /srv/config.py
 

--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
+    <base href="/" />
     <meta charset="utf-8" />
     <link rel="shortcut icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
- Add `<base href="/" />` to `index.html`: With the inclusion of `base` in `vite.config.ts` (b19a8246), vite now generates relative paths for all assets. This change ensures relative assets are still pulled from the root.
- Default `app_base_url` to `""`: ensures proper NGINX template expansion when running as a docker container (similar to #2411).