### PR TITLE
fix: prevent action panel from closing during transition

### DIFF
--- a/src/panels/CharmsPanel/CharmsPanel.tsx
+++ b/src/panels/CharmsPanel/CharmsPanel.tsx
@@ -39,7 +39,9 @@ export default function CharmsPanel({
         <Button
           disabled={!selectedCharm}
           onClick={() => {
-            onCharmURLChange(selectedCharm);
+            setTimeout(() => {
+              onCharmURLChange(selectedCharm);
+            });
           }}
         >
           Next

--- a/src/panels/CharmsPanel/CharmsPanel.tsx
+++ b/src/panels/CharmsPanel/CharmsPanel.tsx
@@ -38,10 +38,9 @@ export default function CharmsPanel({
       drawer={
         <Button
           disabled={!selectedCharm}
-          onClick={() => {
-            setTimeout(() => {
-              onCharmURLChange(selectedCharm);
-            });
+          onClick={(ev) => {
+            ev.stopPropagation();
+            onCharmURLChange(selectedCharm);
           }}
         >
           Next


### PR DESCRIPTION
Closes #2407

## Done

- Prevent `onCharmURLChange(selectedCharm)` from `CharmsPanel.tsx:42` from propagating the event up to `Panel.tsx` (which causes the panel to close) using `ev.stopPropagation()`

## QA

- Go through the steps to replicate the issue (or follow the recording below):
  - Go to model page
  - Select multiple applications
  - Click 'Run action'
  - **See that panel doesn't close**
- Ensure yarn lint succeeds
- Ensure yarn test succeeds

## Recording

https://github.com/user-attachments/assets/bb233eee-365c-4142-ba3e-168e3a75fb01

## Details

The query param was indeed disappearing due to a `handleRemovePanelQueryParams({ panel: null })` call which is created from `CharmsAndActionsPanel.tsx:32-34`:

```ts
const defaultQueryParams: CharmsAndActionsQueryParams = {
  panel: null,
};
const [_queryParams, _setQueryParams, handleRemovePanelQueryParams] =
  usePanelQueryParams<CharmsAndActionsQueryParams>(defaultQueryParams);
```

This causes the panel to close since `handleRemovePanelQueryParams` eventually calls `useQueryParams` which clears params when provided with a `null` or `undefined` value.

The block of code that causes the problem is the function that a listener calls found in `Panel.tsx:40-58`:

```ts
  onClickOutside: (
    ev: React.MouseEvent,
    panelId: string,
    onRemovePanelQueryParams: () => void,
    startedInsidePanel: boolean,
    checkCanClose?: Props["checkCanClose"],
  ): void => {
    if (startedInsidePanel) {
      // If the click started inside the panel and then was dragged outside the panel then don't close it.
      return;
    }
    if (checkCanClose && !checkCanClose?.(ev)) {
      return;
    }
    const target = ev.target as HTMLElement;
    if (!target.closest(`#${panelId}`)) {
      onRemovePanelQueryParams();
    }
  },
```

When we click `Next` from the `CharmsAndActionsPanel`, it runs the `onCharmsURLChange` from `CharmsPanel.tsx:42` first which causes the active panel to change from the `CharmsPanel` to the `CharmActionsPanel`, **and then** it runs the `MouseEvent` listener in `Panel.tsx` that runs the snippet of code above. The problem here is that by the time we get here, the `CharmsPanel` is no longer in the DOM which then causes `onRemovePanelQueryParams()` to be called, finally causing the `panel` query param to be removed and close the existing panel.

This flow of events can be seen by adding `debugger;` statements before `CharmsPanel.tsx:42` and another one before `Panel.tsx:54`, then stepping through the code.