### PR TITLE
chore: disable list view for constraints

### DIFF
--- a/e2e/base/add-model.spec.ts
+++ b/e2e/base/add-model.spec.ts
@@ -107,14 +107,10 @@ test.describe("Add model", () => {
       name: ConfigsConstraintsLabel.CONSTRAINTS_TITLE,
     });
     await constraintsSection
-      .getByRole("searchbox", { name: "Search constraints" })
-      .fill("arch");
-    await expect(
-      constraintsSection.locator('select[aria-label="arch"]'),
-    ).toBeVisible();
-    await constraintsSection
-      .locator('select[aria-label="arch"]')
-      .selectOption(architecture);
+      .getByRole("textbox", {
+        name: ConfigsConstraintsLabel.MODEL_CONSTRAINT_PLACEHOLDER,
+      })
+      .fill(`arch: ${architecture}`);
 
     // Create the model
     await page

--- a/src/pages/AddModel/ConfigsConstraints/CategoriesListing/CategoriesListing.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/CategoriesListing/CategoriesListing.tsx
@@ -53,7 +53,7 @@ const CategoriesListing = ({
 
   const entries: ConfigFieldEntry[] = values[arrayName];
 
-  const isListMode = values[inputMode] === InputMode.LIST;
+  const isListMode = !listModeDisabled && values[inputMode] === InputMode.LIST;
   const handleModeChange = (isListModeSelected: boolean): void => {
     if (!isListModeSelected) {
       void setFieldValue(yamlKey, buildYAML(entries));
@@ -159,7 +159,7 @@ const CategoriesListing = ({
           </div>
         </div>
       )}
-      {!listModeDisabled && isListMode ? (
+      {isListMode ? (
         <>
           <div className="row u-no-padding">
             <div className="col-4">

--- a/src/pages/AddModel/ConfigsConstraints/CategoriesListing/CategoriesListing.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/CategoriesListing/CategoriesListing.tsx
@@ -42,6 +42,7 @@ const CategoriesListing = ({
   setYAMLErrors,
   yamlErrorLabel,
   isLoading = false,
+  listModeDisabled = false,
   onSwitchWhileLoading,
 }: Props): JSX.Element => {
   const id = useId();
@@ -128,35 +129,37 @@ const CategoriesListing = ({
           {docsLabel}
         </a>
       </p>
-      <div className="u-flex u-flex--gap">
-        <div>
-          <RadioInput
-            checked={isListMode}
-            label={InputMode.LIST}
-            name={`mode-${id}`}
-            onChange={() => {
-              if (isLoading && values[yamlKey]) {
-                onSwitchWhileLoading?.();
-                return;
-              }
-              handleModeChange(true);
-            }}
-            value={InputMode.LIST}
-          />
+      {!listModeDisabled && (
+        <div className="u-flex u-flex--gap">
+          <div>
+            <RadioInput
+              checked={isListMode}
+              label={InputMode.LIST}
+              name={`mode-${id}`}
+              onChange={() => {
+                if (isLoading && values[yamlKey]) {
+                  onSwitchWhileLoading?.();
+                  return;
+                }
+                handleModeChange(true);
+              }}
+              value={InputMode.LIST}
+            />
+          </div>
+          <div>
+            <RadioInput
+              checked={!isListMode}
+              label={InputMode.YAML}
+              name={`mode-${id}`}
+              onChange={() => {
+                handleModeChange(false);
+              }}
+              value={InputMode.YAML}
+            />
+          </div>
         </div>
-        <div>
-          <RadioInput
-            checked={!isListMode}
-            label={InputMode.YAML}
-            name={`mode-${id}`}
-            onChange={() => {
-              handleModeChange(false);
-            }}
-            value={InputMode.YAML}
-          />
-        </div>
-      </div>
-      {isListMode ? (
+      )}
+      {!listModeDisabled && isListMode ? (
         <>
           <div className="row u-no-padding">
             <div className="col-4">

--- a/src/pages/AddModel/ConfigsConstraints/CategoriesListing/types.ts
+++ b/src/pages/AddModel/ConfigsConstraints/CategoriesListing/types.ts
@@ -16,5 +16,6 @@ export type Props = {
   setYAMLErrors: (state: YAMLErrorsModalState) => void;
   yamlErrorLabel: string;
   isLoading?: boolean;
+  listModeDisabled?: boolean;
   onSwitchWhileLoading?: () => void;
 };

--- a/src/pages/AddModel/ConfigsConstraints/ConfigsConstraints.test.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/ConfigsConstraints.test.tsx
@@ -1,10 +1,4 @@
-import {
-  act,
-  fireEvent,
-  screen,
-  waitFor,
-  within,
-} from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 
@@ -147,71 +141,10 @@ describe("ConfigsConstraints", () => {
       name: Label.CONSTRAINTS_TITLE,
     });
     expect(
-      within(constraintsSection).getByRole("radio", {
-        name: InputMode.LIST,
-      }),
-    ).toBeChecked();
-    expect(
-      within(constraintsSection).getByLabelText(Label.CHANGED_CONSTRAINTS_ONLY),
+      within(constraintsSection).getByPlaceholderText(
+        Label.MODEL_CONSTRAINT_PLACEHOLDER,
+      ),
     ).toBeInTheDocument();
-  });
-
-  it("keeps config and constraint searches independent", async () => {
-    vi.useFakeTimers();
-    renderComponent(
-      <Formik initialValues={initialValues} onSubmit={vi.fn()}>
-        <ConfigsConstraints />
-      </Formik>,
-    );
-
-    const configsSection = screen.getByRole("region", {
-      name: Label.CONFIGS_TITLE,
-    });
-    expect(
-      within(configsSection).getByLabelText("default-space"),
-    ).toBeInTheDocument();
-    expect(
-      within(configsSection).getByLabelText("container-networking-method"),
-    ).toBeInTheDocument();
-
-    const constraintsSection = screen.getByRole("region", {
-      name: Label.CONSTRAINTS_TITLE,
-    });
-    expect(
-      within(constraintsSection).getByLabelText("cores"),
-    ).toBeInTheDocument();
-    expect(
-      within(constraintsSection).getByLabelText("zones"),
-    ).toBeInTheDocument();
-
-    const configsSearchInput = within(configsSection).getByRole("searchbox");
-    const constraintsSearchInput =
-      within(constraintsSection).getByRole("searchbox");
-
-    fireEvent.change(configsSearchInput, {
-      target: { value: "default-space" },
-    });
-    fireEvent.change(constraintsSearchInput, {
-      target: { value: "cores" },
-    });
-    act(() => {
-      vi.advanceTimersByTime(500);
-    });
-
-    expect(
-      within(configsSection).getByLabelText("default-space"),
-    ).toBeInTheDocument();
-    expect(
-      within(configsSection).queryByLabelText("container-networking-method"),
-    ).not.toBeInTheDocument();
-
-    expect(
-      within(constraintsSection).getByLabelText("cores"),
-    ).toBeInTheDocument();
-    expect(
-      within(constraintsSection).queryByLabelText("zones"),
-    ).not.toBeInTheDocument();
-    vi.useRealTimers();
   });
 
   it("renders disabled command options with 'none' selected by default", () => {

--- a/src/pages/AddModel/ConfigsConstraints/ConfigsConstraints.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/ConfigsConstraints.tsx
@@ -104,6 +104,7 @@ const ConfigsConstraints = (): JSX.Element => {
         searchName="constraintSearch"
         setYAMLErrors={setYAMLErrors}
         yamlErrorLabel={Label.INCORRECT_YAML_CONSTRAINT_ERROR}
+        listModeDisabled
       />
       <h5 className="u-no-padding--top u-no-margin--bottom">
         {Label.DISABLED_COMMANDS}

--- a/src/pages/AddModel/ConfigsConstraints/constraintsCatalog.ts
+++ b/src/pages/AddModel/ConfigsConstraints/constraintsCatalog.ts
@@ -1,9 +1,4 @@
-/* eslint-disable @cspell/spellchecker -- This file contains values as they come from Juju */
-
-import { BOOLEAN_OPTIONS } from "consts";
-
 import type { ConfigFieldEntry } from "./types";
-import { InputType, ValueType } from "./types";
 
 export enum ConstraintCategory {
   COMPUTE = "Compute",
@@ -13,116 +8,10 @@ export enum ConstraintCategory {
   IDENTITY = "Identity & Tagging",
 }
 
-const EMPTY_OPTION = { label: "Unset", value: "" };
-
+// This file is a placeholder for the constraints catalog.
+// This is done since there is no way to fetch the constraints catalog from Juju currently.
+// Once the constraints catalog is available, this file can be removed.
 export const CONSTRAINT_DEFINITIONS: Omit<
   ConfigFieldEntry,
   "arrayIndex" | "value"
->[] = [
-  {
-    label: "cores",
-    description: "Number of effective CPU cores (alias: cpu-cores)",
-    valueType: ValueType.NUMBER,
-    category: ConstraintCategory.COMPUTE,
-  },
-  {
-    label: "cpu-power",
-    description: "Abstract CPU power (100 units ≈ 1 Amazon vCPU)",
-    valueType: ValueType.NUMBER,
-    category: ConstraintCategory.COMPUTE,
-  },
-  {
-    label: "mem",
-    description: "Memory in MiB (supports M/G/T/P suffixes)",
-    category: ConstraintCategory.COMPUTE,
-  },
-  {
-    label: "instance-type",
-    description: "Cloud-specific instance type name (e.g. m6i.large)",
-    category: ConstraintCategory.COMPUTE,
-  },
-  {
-    label: "spaces",
-    description:
-      "A comma-delimited list of Juju network space names that a unit or machine needs access to",
-    category: ConstraintCategory.NETWORKING,
-  },
-  {
-    label: "zones",
-    description:
-      "A list of availability zones. Multiple values present a range of zones that a machine must be created within",
-    category: ConstraintCategory.NETWORKING,
-  },
-  {
-    label: "allocate-public-ip",
-    description:
-      "Supplying this constraint will determine whether machines are issued an IP address accessible outside of the cloud’s virtual network",
-    valueType: ValueType.BOOLEAN,
-    input: {
-      type: InputType.SELECT,
-      options: [EMPTY_OPTION, ...BOOLEAN_OPTIONS],
-    },
-    category: ConstraintCategory.NETWORKING,
-  },
-  {
-    label: "arch",
-    description: "CPU architecture (amd64, arm64, ppc64el, s390x, riscv64)",
-    input: {
-      type: InputType.SELECT,
-      options: [
-        EMPTY_OPTION,
-        { label: "amd64", value: "amd64" },
-        { label: "arm64", value: "arm64" },
-        { label: "ppc64el", value: "ppc64el" },
-        { label: "s390x", value: "s390x" },
-        { label: "riscv64", value: "riscv64" },
-      ],
-    },
-    category: ConstraintCategory.PLATFORM,
-  },
-  {
-    label: "virt-type",
-    description: "Virtualisation type (LXD, OpenStack only)",
-    category: ConstraintCategory.PLATFORM,
-  },
-  {
-    label: "container",
-    description:
-      "Indicates that a machine must be the specified container type",
-    input: {
-      type: InputType.SELECT,
-      options: [
-        EMPTY_OPTION,
-        { label: "LXD", value: "lxd" },
-        { label: "KVM", value: "kvm" },
-      ],
-    },
-    category: ConstraintCategory.PLATFORM,
-  },
-  {
-    label: "image-id",
-    description: "Indicates that a machine must use the specified image",
-    category: ConstraintCategory.PLATFORM,
-  },
-  {
-    label: "root-disk",
-    description: "Disk space on root drive in MiB (supports M/G/T/P suffixes)",
-    category: ConstraintCategory.STORAGE,
-  },
-  {
-    label: "root-disk-source",
-    description: "Name of storage pool or location the root disk is from",
-    category: ConstraintCategory.STORAGE,
-  },
-  {
-    label: "instance-role",
-    description:
-      "Cloud IAM role/profile (AWS instance profiles, Azure managed identities)",
-    category: ConstraintCategory.IDENTITY,
-  },
-  {
-    label: "tags",
-    description: "Comma-delimited tags assigned to the machine",
-    category: ConstraintCategory.IDENTITY,
-  },
-];
+>[] = [];

--- a/src/pages/AddModel/utils.test.ts
+++ b/src/pages/AddModel/utils.test.ts
@@ -19,9 +19,8 @@ describe("AddModel utils", () => {
   describe("getBooleanSchema", () => {
     it("returns an entry for every boolean field in the catalog", () => {
       const schema = getBooleanSchema();
-      // Spot-check a known boolean field from each catalog
+      // Spot-check a known boolean field
       expect(schema).toHaveProperty("disable-network-management");
-      expect(schema).toHaveProperty("allocate-public-ip");
     });
 
     it("does not include non-boolean fields", () => {


### PR DESCRIPTION
## Done

- Introduced a prop to hide list view in `CategoriesListing`
- Updated e2e and unit tests accordingly
- Fixed a visual issue where there was extra space under the textbox in YAML view

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- View the ConfigsConstraints tab on AddModel page
- The constraints section should not have list view
- There should be no extra space under textbox in YAML view for both configs and constraints
- All tests should pass
- Please add the `e2e` label once the fix is merged to main and the PR is rebased

## Details

https://warthogs.atlassian.net/browse/JUJU-10185

## Screenshots

[if relevant, include a screenshot]
