### PR TITLE
fix: flakey add-model e2e tests

### DIFF
--- a/e2e/base/add-model.spec.ts
+++ b/e2e/base/add-model.spec.ts
@@ -4,6 +4,7 @@ import { Label as ModelActionsLabel } from "components/ModelActions/types";
 import { Label as AccessManagementLabel } from "pages/AddModel/AccessManagement/types";
 import { Label as ConfigsConstraintsLabel } from "pages/AddModel/ConfigsConstraints/types";
 import { Label as AddModelLabel } from "pages/AddModel/types";
+import { ModelsError } from "store/middleware/types";
 import urls from "urls";
 
 import { JujuEnv, test } from "../fixtures/setup";
@@ -69,6 +70,10 @@ test.describe("Add model", () => {
     await page
       .getByRole("button", { name: AddModelLabel.CREATE_BUTTON })
       .click();
+    await expect(page).toHaveURL(urls.models.index);
+
+    // Reloading the page before checking fetches the updated list of models.
+    await owner.reloadDashboard(page);
     await expect(
       page
         .locator("tr", { hasText: currentModel.name })
@@ -120,6 +125,10 @@ test.describe("Add model", () => {
     await page
       .getByRole("button", { name: AddModelLabel.CREATE_BUTTON })
       .click();
+    await expect(page).toHaveURL(urls.models.index);
+
+    // Reloading the page before checking fetches the updated list of models.
+    await owner.reloadDashboard(page);
     await expect(
       page
         .locator("tr", { hasText: currentModel.name })
@@ -167,6 +176,19 @@ test.describe("Add model", () => {
       await page
         .getByRole("button", { name: AddModelLabel.CREATE_BUTTON })
         .click();
+      await expect(page).toHaveURL(urls.models.index);
+
+      // Sometimes after model creation, the models list fails to update and displays a
+      // "Unable to list or update models" error banner. In that case, reload the page to recover.
+      if (
+        await page
+          .locator('[role="alert"]', {
+            hasText: ModelsError.LIST_OR_UPDATE_MODELS,
+          })
+          .isVisible()
+      ) {
+        await owner.reloadDashboard(page);
+      }
 
       // Verify that the model was created and trigger destroy-model on it
       const modelRow = page
@@ -236,6 +258,19 @@ test.describe("Add model", () => {
     await page
       .getByRole("button", { name: AddModelLabel.CREATE_BUTTON })
       .click();
+    await expect(page).toHaveURL(urls.models.index);
+
+    // Sometimes after model creation, the models list fails to update and displays a
+    // "Unable to list or update models" error banner. In that case, reload the page to recover.
+    if (
+      await page
+        .locator('[role="alert"]', {
+          hasText: ModelsError.LIST_OR_UPDATE_MODELS,
+        })
+        .isVisible()
+    ) {
+      await owner.reloadDashboard(page);
+    }
 
     // Verify that the model was created
     const ownerModelRow = page


### PR DESCRIPTION
## Done

- Fixed flakey Add Model end-to-end tests
- Also corrected the base app url which needed updating after this change https://github.com/canonical/juju-dashboard/commit/b19a8246e847d03e6b9a8e3454ca2867f3dad026
- On some occasions, the list was not updated and a message to reload the dashboard was rendered even when the operation had succeeded (PFA the artefact from [one such flakey run](https://github.com/canonical/juju-dashboard/actions/runs/29991418005/job/89154948129?pr=2408#step:9:1008))
<img width="1280" height="720" alt="test-failed-1" src="https://github.com/user-attachments/assets/60cd7a8e-e953-4d90-920d-6249cefde591" />


## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- All e2e tests should pass with no flakey behaviour
- The JIMM Docker workflow should not fail with a 404 screen (https://github.com/canonical/juju-dashboard/actions/runs/29991418005/job/89228465921?pr=2408#step:14:7098)
