### PR TITLE
fix: remove extra space from YAML view

### DIFF
--- a/src/pages/AddModel/ConfigsConstraints/CategoriesListing/CategoriesListing.tsx
+++ b/src/pages/AddModel/ConfigsConstraints/CategoriesListing/CategoriesListing.tsx
@@ -112,7 +112,12 @@ const CategoriesListing = ({
 
   return (
     <section
-      className="p-section u-no-padding--bottom categories-listing"
+      className={classNames(
+        "p-section u-no-padding--bottom categories-listing",
+        {
+          "categories-listing--list-view": isListMode,
+        },
+      )}
       aria-labelledby={`title-${id}`}
     >
       <h5 id={`title-${id}`} className="u-no-padding--top u-no-margin--bottom">

--- a/src/pages/AddModel/ConfigsConstraints/CategoriesListing/_categories-listing.scss
+++ b/src/pages/AddModel/ConfigsConstraints/CategoriesListing/_categories-listing.scss
@@ -1,9 +1,12 @@
 .categories-listing {
   display: flex;
   flex-direction: column;
-  height: 55vh;
-  max-height: 70vh;
-  min-height: 20rem;
+
+  &--list-view {
+    height: 55vh;
+    max-height: 70vh;
+    min-height: 20rem;
+  }
 
   .categories__form-scroll {
     flex: 1;


### PR DESCRIPTION
## Done

- Fixed a visual issue where there was extra space under the textbox in YAML view

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- View the ConfigsConstraints tab on AddModel page
- There should be no extra space under textbox in YAML view for both configs and constraints
- The list view should be unaffected

## Details

https://warthogs.atlassian.net/browse/JUJU-10185

## Screenshots

BEFORE

https://github.com/user-attachments/assets/4ddce33c-5359-4b63-a6c4-47c1e5b8c730

AFTER

<img width="1352" height="627" alt="Screenshot 2026-07-24 at 9 22 09 AM" src="https://github.com/user-attachments/assets/08d90b9d-31eb-4972-840b-d2d31dc81b4d" />

