### PR TITLE
fix: flakey rollback for add-model

### DIFF
--- a/e2e/base/add-model.spec.ts
+++ b/e2e/base/add-model.spec.ts
@@ -8,7 +8,7 @@ import urls from "urls";
 
 import { JujuEnv, test } from "../fixtures/setup";
 import { ActionStack } from "../helpers/action";
-import { AddModel, GiveControllerAccess } from "../helpers/actions";
+import { GiveControllerAccess } from "../helpers/actions";
 import type { User } from "../helpers/auth";
 import { ControllerPermission, Model } from "../helpers/objects";
 import { exec, execIfModelExists, generateRandomName } from "../utils";
@@ -51,9 +51,10 @@ test.describe("Add model", () => {
       await jujuCLI.loginLocalCLIAdmin();
     }
 
-    const addModel = new AddModel(jujuCLI, owner, true);
-    addModel.model = currentModel;
-    await addModel.rollback();
+    await execIfModelExists(
+      `juju destroy-model ${currentModel.qualifiedName} --no-prompt --destroy-storage`,
+      currentModel.qualifiedName,
+    );
   });
 
   test.afterAll(async () => {


### PR DESCRIPTION
## Done

- Fixed flakey Add Model end-to-end tests
- The manual clean-up for Add Model suite was not waiting for the model to be completely removed before attempting to clean other resources up. Here is [one such flakey run](https://github.com/canonical/juju-dashboard/actions/runs/29991418005/job/89154948129?pr=2408#step:9:1008)

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- E2E tests shouldn't be flakey
