### PR TITLE
fix: model table interactions

### DIFF
--- a/src/components/DataTable/DataTable.test.tsx
+++ b/src/components/DataTable/DataTable.test.tsx
@@ -1,0 +1,140 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { renderComponent } from "testing/utils";
+
+import DataTable from "./DataTable";
+import type { DataTableProps } from "./types";
+
+describe("DataTable", () => {
+  let initialProps: DataTableProps<
+    { id: string; name: string; age: number },
+    string,
+    Record<string, number | string>
+  >;
+
+  beforeEach(() => {
+    initialProps = {
+      getKey: ({ id }): string => id,
+      columns: {
+        name: { header: "Name", map: ({ name }): string => name },
+        age: { header: "Age", map: ({ age }): number => age },
+      },
+      data: [
+        { id: "1", name: "Alice", age: 30 },
+        { id: "2", name: "Bob", age: 25 },
+      ],
+    };
+  });
+
+  it("renders properly with column headers and row data", () => {
+    renderComponent(<DataTable {...initialProps} />);
+    expect(
+      screen.getByRole("columnheader", { name: "Name" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Age" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("cell", { name: "Alice" })).toBeInTheDocument();
+    expect(screen.getByRole("cell", { name: "Bob" })).toBeInTheDocument();
+  });
+
+  it("renders the no rows message when data is empty", () => {
+    renderComponent(<DataTable {...initialProps} data={[]} />);
+    expect(screen.getByText("No rows")).toBeInTheDocument();
+  });
+
+  it("renders a custom no rows message", () => {
+    renderComponent(
+      <DataTable {...initialProps} data={[]} noRowsMessage="Nothing here" />,
+    );
+    expect(screen.getByText("Nothing here")).toBeInTheDocument();
+  });
+
+  describe("selectable", () => {
+    it("renders the select-all checkbox when the rows are selectable", () => {
+      renderComponent(<DataTable {...initialProps} />);
+      expect(
+        screen.getByRole("checkbox", { name: "Select all" }),
+      ).toBeInTheDocument();
+    });
+
+    it("does not render the select-all checkbox when selectable=false", () => {
+      renderComponent(<DataTable {...initialProps} selectable={false} />);
+      expect(
+        screen.queryByRole("checkbox", { name: "Select all" }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows 'Deselect all' label when all rows are selected", async () => {
+      renderComponent(<DataTable {...initialProps} />);
+      const selectAll = screen.getByRole("checkbox", { name: "Select all" });
+      await userEvent.click(selectAll);
+      expect(
+        screen.getByRole("checkbox", { name: "Deselect all" }),
+      ).toBeInTheDocument();
+    });
+
+    it("shows indeterminate state when some rows are selected", async () => {
+      renderComponent(<DataTable {...initialProps} />);
+      const rowCheckboxes = screen.getAllByRole("checkbox", {
+        name: /Select|Deselect/,
+      });
+      // Click a single row checkbox (skip the select-all at index 0)
+      await userEvent.click(rowCheckboxes[1]);
+      const selectAll = screen.getByRole("checkbox", { name: "Select all" });
+      expect((selectAll as HTMLInputElement).indeterminate).toBe(true);
+    });
+  });
+
+  describe("isRowDisabled", () => {
+    it("marks a row as disabled", () => {
+      renderComponent(
+        <DataTable {...initialProps} isRowDisabled={(row) => row.id === "1"} />,
+      );
+      const tableRows = screen.getAllByRole("row");
+      const aliceRow = tableRows.find((row) =>
+        row.textContent?.includes("Alice"),
+      );
+      const bobRow = tableRows.find((row) => row.textContent?.includes("Bob"));
+      expect(aliceRow).toHaveAttribute("aria-disabled", "true");
+      expect(bobRow).not.toHaveAttribute("aria-disabled", "true");
+    });
+
+    it("excludes disabled rows from select all", async () => {
+      renderComponent(
+        <DataTable {...initialProps} isRowDisabled={(row) => row.id === "1"} />,
+      );
+      const selectAll = screen.getByRole("checkbox", { name: "Select all" });
+      await userEvent.click(selectAll);
+      expect(screen.getByRole("checkbox", { name: "Select 2" })).toBeChecked();
+      expect(
+        screen.queryByRole("checkbox", { name: "Select 1" }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("isRowLoading", () => {
+    it("excludes loading rows from select all", async () => {
+      renderComponent(
+        <DataTable {...initialProps} isRowLoading={(row) => row.id === "1"} />,
+      );
+      const selectAll = screen.getByRole("checkbox", { name: "Select all" });
+      await userEvent.click(selectAll);
+      expect(screen.getByRole("checkbox", { name: "Select 2" })).toBeChecked();
+    });
+  });
+});
+
+describe("DataTable.columnBuilder", () => {
+  it("returns a column definition unchanged", () => {
+    const builder = DataTable.columnBuilder<{
+      id: string;
+      name: string;
+      age: number;
+    }>();
+    const col = builder({ header: "Name", map: (row) => row.name });
+    expect(col.header).toBe("Name");
+    expect(col.map({ id: "1", name: "Alice", age: 30 })).toBe("Alice");
+  });
+});

--- a/src/components/DataTable/DataTable.test.tsx
+++ b/src/components/DataTable/DataTable.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { renderComponent } from "testing/utils";
@@ -68,8 +68,9 @@ describe("DataTable", () => {
 
     it("shows 'Deselect all' label when all rows are selected", async () => {
       renderComponent(<DataTable {...initialProps} />);
-      const selectAll = screen.getByRole("checkbox", { name: "Select all" });
-      await userEvent.click(selectAll);
+      await userEvent.click(
+        screen.getByRole("checkbox", { name: "Select all" }),
+      );
       expect(
         screen.getByRole("checkbox", { name: "Deselect all" }),
       ).toBeInTheDocument();
@@ -77,13 +78,72 @@ describe("DataTable", () => {
 
     it("shows indeterminate state when some rows are selected", async () => {
       renderComponent(<DataTable {...initialProps} />);
-      const rowCheckboxes = screen.getAllByRole("checkbox", {
-        name: /Select|Deselect/,
-      });
-      // Click a single row checkbox (skip the select-all at index 0)
-      await userEvent.click(rowCheckboxes[1]);
+      // Click a single row checkbox — initially unchecked rows have "Deselect <key>" label.
+      await userEvent.click(
+        screen.getByRole("checkbox", { name: "Deselect 1" }),
+      );
       const selectAll = screen.getByRole("checkbox", { name: "Select all" });
       expect((selectAll as HTMLInputElement).indeterminate).toBe(true);
+    });
+
+    it("clearing select-all does not affect a disabled row's checkbox", async () => {
+      renderComponent(
+        <DataTable {...initialProps} isRowDisabled={(row) => row.id === "1"} />,
+      );
+      // Select all selectable rows (only row 2).
+      await userEvent.click(
+        screen.getByRole("checkbox", { name: "Select all" }),
+      );
+      expect(screen.getByRole("checkbox", { name: "Select 2" })).toBeChecked();
+
+      // Now deselect all — row 1's checkbox should still be unchecked, unchanged.
+      await userEvent.click(
+        screen.getByRole("checkbox", { name: "Deselect all" }),
+      );
+      expect(
+        screen.getByRole("checkbox", { name: "Deselect 2" }),
+      ).not.toBeChecked();
+      expect(
+        screen.getByRole("checkbox", { name: "Deselect 1" }),
+      ).not.toBeChecked();
+    });
+
+    it("'Select all' does nothing when all rows are disabled", async () => {
+      renderComponent(
+        <DataTable {...initialProps} isRowDisabled={() => true} />,
+      );
+      // Clicking it does nothing — both row checkboxes remain unchecked.
+      await userEvent.click(
+        screen.getByRole("checkbox", {
+          name: "Select all",
+        }),
+      );
+      expect(
+        screen.getByRole("checkbox", { name: "Select all" }),
+      ).toBeInTheDocument();
+      const rowCheckboxes = screen.getAllByRole("checkbox", {
+        name: /Deselect [^a]/,
+      });
+      rowCheckboxes.forEach((checkbox) => expect(checkbox).not.toBeChecked());
+    });
+
+    it("deselects a previously selected row when it becomes disabled", async () => {
+      const { rerender } = render(
+        <DataTable {...initialProps} isRowDisabled={() => false} />,
+      );
+      // Select row 1.
+      await userEvent.click(
+        screen.getByRole("checkbox", { name: "Deselect 1" }),
+      );
+      expect(screen.getByRole("checkbox", { name: "Select 1" })).toBeChecked();
+
+      // Now disable row 1 — it should be removed from the selection.
+      rerender(
+        <DataTable {...initialProps} isRowDisabled={(row) => row.id === "1"} />,
+      );
+      expect(
+        screen.getByRole("checkbox", { name: "Deselect 1" }),
+      ).not.toBeChecked();
     });
   });
 
@@ -122,6 +182,10 @@ describe("DataTable", () => {
       const selectAll = screen.getByRole("checkbox", { name: "Select all" });
       await userEvent.click(selectAll);
       expect(screen.getByRole("checkbox", { name: "Select 2" })).toBeChecked();
+      // Loading rows show a spinner instead of a checkbox, so no checkbox exists for row 1.
+      expect(
+        screen.queryByRole("checkbox", { name: /1$/ }),
+      ).not.toBeInTheDocument();
     });
   });
 });
@@ -133,8 +197,11 @@ describe("DataTable.columnBuilder", () => {
       name: string;
       age: number;
     }>();
-    const col = builder({ header: "Name", map: (row) => row.name });
-    expect(col.header).toBe("Name");
-    expect(col.map({ id: "1", name: "Alice", age: 30 })).toBe("Alice");
+    const colRaw = {
+      header: "Name",
+      map: (row: { id: string; name: string; age: number }): string => row.name,
+    };
+    const col = builder(colRaw);
+    expect(col).toBe(colRaw);
   });
 });

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -29,6 +29,8 @@ export default function DataTable<
   data,
   selectable = true,
   groupBy,
+  isRowDisabled,
+  isRowLoading,
   noRowsMessage = "No rows",
 }: DataTableProps<TRow, TKeyValue, TValues>): JSX.Element {
   const { sort, toggleSort } = useSortState<keyof TValues>();
@@ -64,8 +66,17 @@ export default function DataTable<
     }));
   }, [data, flatColumns, getKey]);
 
-  // Build selection state off of the rows.
-  const rowKeys = useMemo(() => keyedRows.map(({ key }) => key), [keyedRows]);
+  // Build selection state off of the rows, excluding disabled and loading rows
+  // so that "select all" and aggregate state only account for selectable rows.
+  const rowKeys = useMemo(
+    () =>
+      keyedRows
+        .filter(
+          ({ data: row }) => !isRowDisabled?.(row) && !isRowLoading?.(row),
+        )
+        .map(({ key }) => key),
+    [keyedRows, isRowDisabled, isRowLoading],
+  );
   const select = useToggleSelect(rowKeys);
 
   // Render rows.
@@ -76,6 +87,8 @@ export default function DataTable<
     sort,
     select,
     selectable,
+    isRowDisabled,
+    isRowLoading,
   });
 
   const columnCount = useMemo(
@@ -90,16 +103,16 @@ export default function DataTable<
     <Table>
       <Table.Header>
         {prefixHeader}
-        {selectable ? (
-          <Table.Header.Cell collapse>
+        <Table.Header.Cell className="icon-column icon-column-header">
+          {selectable ? (
             <InlineCheckbox
               label={select.state === "all" ? "Deselect all" : "Select all"}
               checked={select.state === "all"}
               indeterminate={select.state === "partial"}
               onChange={select.toggleAll}
             />
-          </Table.Header.Cell>
-        ) : null}
+          ) : null}
+        </Table.Header.Cell>
         {orderedHeaders}
       </Table.Header>
       <Table.Body>

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -100,7 +100,7 @@ export default function DataTable<
   );
 
   return (
-    <Table>
+    <Table className="data-table">
       <Table.Header>
         {prefixHeader}
         <Table.Header.Cell className="icon-column icon-column-header">

--- a/src/components/DataTable/_data-table.scss
+++ b/src/components/DataTable/_data-table.scss
@@ -10,13 +10,7 @@
     padding-top: 0.9rem;
   }
 
-  .is-row-disabled {
+  [inert] > * {
     opacity: 0.5;
-  }
-
-  // Apply to interactive elements within a disabled row via renderCell.
-  .is-disabled {
-    pointer-events: none;
-    user-select: none;
   }
 }

--- a/src/components/DataTable/_data-table.scss
+++ b/src/components/DataTable/_data-table.scss
@@ -1,0 +1,22 @@
+.data-table {
+  .icon-column {
+    padding-bottom: 1rem;
+    padding-top: 0.5rem;
+    vertical-align: top;
+    width: 2rem;
+  }
+
+  .icon-column-header {
+    padding-top: 0.9rem;
+  }
+
+  .is-row-disabled {
+    opacity: 0.5;
+  }
+
+  // Apply to interactive elements within a disabled row via renderCell.
+  .is-disabled {
+    pointer-events: none;
+    user-select: none;
+  }
+}

--- a/src/components/DataTable/types.ts
+++ b/src/components/DataTable/types.ts
@@ -53,6 +53,17 @@ export type DataTableProps<
    */
   getKey: (row: TRow) => TKeyValue;
   /**
+   * Optional function returning `true` for rows that should be disabled.
+   * Disabled rows are rendered with `aria-disabled="true"` and a
+   * `is-disabled` CSS class, and their interactive content is inert.
+   */
+  isRowDisabled?: (row: TRow) => boolean;
+  /**
+   * Optional function returning `true` for rows that should be in loading state.
+   * Loading rows are rendered with a loading indicator.
+   */
+  isRowLoading?: (row: TRow) => boolean;
+  /**
    * If `true`, a column of checkboxes will be rendered for each row.
    */
   selectable?: boolean;

--- a/src/components/DataTable/types.ts
+++ b/src/components/DataTable/types.ts
@@ -54,8 +54,6 @@ export type DataTableProps<
   getKey: (row: TRow) => TKeyValue;
   /**
    * Optional function returning `true` for rows that should be disabled.
-   * Disabled rows are rendered with `aria-disabled="true"` and a
-   * `is-disabled` CSS class, and their interactive content is inert.
    */
   isRowDisabled?: (row: TRow) => boolean;
   /**

--- a/src/components/DataTable/useRows.test.tsx
+++ b/src/components/DataTable/useRows.test.tsx
@@ -137,7 +137,7 @@ describe("useRows", () => {
       const row = result.current[0] as React.ReactElement<{
         children: React.ReactNode[];
       }>;
-      const [, childSelectable] = row.props.children;
+      const [_unused, childSelectable] = row.props.children;
       const [checkbox, spinner] = (
         childSelectable as React.ReactElement<{ children: React.ReactNode[] }>
       ).props.children;

--- a/src/components/DataTable/useRows.test.tsx
+++ b/src/components/DataTable/useRows.test.tsx
@@ -1,3 +1,4 @@
+import { Spinner } from "@canonical/react-components";
 import type { RenderHookResult } from "@testing-library/react";
 import { renderHook } from "@testing-library/react";
 
@@ -103,21 +104,59 @@ describe("useRows", () => {
     }>;
     const [childPrefix, childSelectable, _cells] = row.props.children;
     expect(childPrefix).toEqual(null);
+    expect(childSelectable).toEqual(
+      expect.objectContaining({ type: Table.Cell }),
+    );
+    const [checkbox] = (
+      childSelectable as React.ReactElement<{ children: React.ReactNode[] }>
+    ).props.children;
     if (selectable) {
-      expect(childSelectable).toEqual(
-        expect.objectContaining({
-          type: Table.Cell,
-          props: expect.objectContaining({
-            children: expect.objectContaining({
-              type: InlineCheckbox,
-            }),
-          }),
-        }),
+      expect(checkbox).toEqual(
+        expect.objectContaining({ type: InlineCheckbox }),
       );
     } else {
-      expect(childSelectable).toEqual(null);
+      expect(checkbox).toEqual(null);
     }
   });
+
+  it.for([
+    ["shows", true, true],
+    ["shows", true, false],
+    ["doesn't show", false, true],
+    ["doesn't show", false, false],
+  ] as const)(
+    "%s spinner when loading=%s selectable=%s",
+    ([_, loading, selectable], { expect }) => {
+      const { result } = renderUseRowsHook(
+        createProps([{ key: "abc123", value: 123, otherValue: true }], {
+          selectable,
+          isRowLoading: () => loading,
+        }),
+      );
+
+      const row = result.current[0] as React.ReactElement<{
+        children: React.ReactNode[];
+      }>;
+      const [, childSelectable] = row.props.children;
+      const [checkbox, spinner] = (
+        childSelectable as React.ReactElement<{ children: React.ReactNode[] }>
+      ).props.children;
+
+      if (loading) {
+        expect(spinner).toEqual(expect.objectContaining({ type: Spinner }));
+        expect(checkbox).toEqual(null);
+      } else {
+        expect(spinner).toEqual(null);
+        if (selectable) {
+          expect(checkbox).toEqual(
+            expect.objectContaining({ type: InlineCheckbox }),
+          );
+        } else {
+          expect(checkbox).toEqual(null);
+        }
+      }
+    },
+  );
 
   it("moves group column to prefix", ({ expect }) => {
     const { result } = renderUseRowsHook(
@@ -146,6 +185,12 @@ describe("useRows", () => {
         }),
       }),
     );
-    expect(childSelectable).toEqual(null);
+    expect(childSelectable).toEqual(
+      expect.objectContaining({ type: Table.Cell }),
+    );
+    const [checkbox] = (
+      childSelectable as React.ReactElement<{ children: React.ReactNode[] }>
+    ).props.children;
+    expect(checkbox).toEqual(null);
   });
 });

--- a/src/components/DataTable/useRows.tsx
+++ b/src/components/DataTable/useRows.tsx
@@ -140,7 +140,7 @@ export default function useRows<TRow, TKey extends React.Key, TValues>({
           <Table.Row
             key={key}
             aria-disabled={disabled || undefined}
-            className={classNames({ "is-disabled": disabled })}
+            className={classNames({ "is-row-disabled": disabled })}
           >
             {prefixColumn}
             <Table.Cell className="icon-column">

--- a/src/components/DataTable/useRows.tsx
+++ b/src/components/DataTable/useRows.tsx
@@ -1,3 +1,5 @@
+import { Spinner } from "@canonical/react-components";
+import classNames from "classnames";
 import fastDeepEqual from "fast-deep-equal/es6";
 import type { ReactNode } from "react";
 import React, { useMemo } from "react";
@@ -9,14 +11,7 @@ import type { Cell, FlatTableColumn, Sort } from "./types";
 import type { ToggleSelectReturn } from "./useToggleSelect";
 import { calculateSpanSize, compareRow } from "./util";
 
-export default function useRows<TRow, TKey extends React.Key, TValues>({
-  rows,
-  columns,
-  groupBy,
-  sort,
-  select,
-  selectable,
-}: {
+type UseRowsParams<TRow, TKey extends React.Key, TValues> = {
   rows: {
     key: TKey;
     values: Cell<keyof TValues, TValues[keyof TValues]>[];
@@ -27,10 +22,25 @@ export default function useRows<TRow, TKey extends React.Key, TValues>({
   sort: Sort<keyof TValues>;
   select: ToggleSelectReturn<TKey>;
   selectable: boolean;
-}): ReactNode[] {
+  isRowDisabled?: (row: TRow) => boolean;
+  isRowLoading?: (row: TRow) => boolean;
+};
+
+export default function useRows<TRow, TKey extends React.Key, TValues>({
+  rows,
+  columns,
+  groupBy,
+  sort,
+  select,
+  selectable,
+  isRowDisabled = (): boolean => false,
+  isRowLoading = (): boolean => false,
+}: UseRowsParams<TRow, TKey, TValues>): ReactNode[] {
   // Render cells individually.
   const renderedRows = useMemo(() => {
     return rows.map((row) => ({
+      disabled: isRowDisabled(row.data),
+      loading: isRowLoading(row.data),
       key: row.key,
       cells: columns.map((column, columnI) => {
         const { value } = row.values[columnI];
@@ -48,7 +58,7 @@ export default function useRows<TRow, TKey extends React.Key, TValues>({
         };
       }),
     }));
-  }, [columns, rows]);
+  }, [columns, rows, isRowDisabled, isRowLoading]);
 
   // Sort rows.
   const sortedRows = useMemo(() => {
@@ -95,7 +105,8 @@ export default function useRows<TRow, TKey extends React.Key, TValues>({
   const fullRows = useMemo(
     () =>
       sortedRows.map((row, i) => {
-        const checked = select.selected.includes(row.key);
+        const { disabled, loading, key } = row;
+        const checked = select.selected.includes(key);
 
         let prefixColumn = null;
 
@@ -123,22 +134,27 @@ export default function useRows<TRow, TKey extends React.Key, TValues>({
           }
         }
 
-        const label = checked ? `Select ${row.key}` : `Deselect ${row.key}`;
+        const label = checked ? `Select ${key}` : `Deselect ${key}`;
 
         return (
-          <Table.Row key={row.key}>
+          <Table.Row
+            key={key}
+            aria-disabled={disabled || undefined}
+            className={classNames({ "is-disabled": disabled })}
+          >
             {prefixColumn}
-            {selectable ? (
-              <Table.Cell>
+            <Table.Cell className="icon-column">
+              {selectable && !loading ? (
                 <InlineCheckbox
                   label={label}
                   checked={checked}
                   onChange={() => {
-                    select.toggle(row.key);
+                    select.toggle(key);
                   }}
                 />
-              </Table.Cell>
-            ) : null}
+              ) : null}
+              {loading ? <Spinner /> : null}
+            </Table.Cell>
             {row.cells
               .filter(({ column }) => groupBy !== column)
               .map(({ column, collapse, className, rendered, align }) => (

--- a/src/components/DataTable/useRows.tsx
+++ b/src/components/DataTable/useRows.tsx
@@ -1,5 +1,4 @@
 import { Spinner } from "@canonical/react-components";
-import classNames from "classnames";
 import fastDeepEqual from "fast-deep-equal/es6";
 import type { ReactNode } from "react";
 import React, { useMemo } from "react";
@@ -39,9 +38,8 @@ export default function useRows<TRow, TKey extends React.Key, TValues>({
   // Render cells individually.
   const renderedRows = useMemo(() => {
     return rows.map((row) => ({
-      disabled: isRowDisabled(row.data),
-      loading: isRowLoading(row.data),
       key: row.key,
+      data: row.data,
       cells: columns.map((column, columnI) => {
         const { value } = row.values[columnI];
 
@@ -58,7 +56,7 @@ export default function useRows<TRow, TKey extends React.Key, TValues>({
         };
       }),
     }));
-  }, [columns, rows, isRowDisabled, isRowLoading]);
+  }, [columns, rows]);
 
   // Sort rows.
   const sortedRows = useMemo(() => {
@@ -105,7 +103,9 @@ export default function useRows<TRow, TKey extends React.Key, TValues>({
   const fullRows = useMemo(
     () =>
       sortedRows.map((row, i) => {
-        const { disabled, loading, key } = row;
+        const { key, data } = row;
+        const disabled = isRowDisabled(data);
+        const loading = isRowLoading(data);
         const checked = select.selected.includes(key);
 
         let prefixColumn = null;
@@ -140,7 +140,7 @@ export default function useRows<TRow, TKey extends React.Key, TValues>({
           <Table.Row
             key={key}
             aria-disabled={disabled || undefined}
-            className={classNames({ "is-row-disabled": disabled })}
+            inert={disabled || undefined}
           >
             {prefixColumn}
             <Table.Cell className="icon-column">
@@ -178,6 +178,8 @@ export default function useRows<TRow, TKey extends React.Key, TValues>({
       select,
       groupByColumnIndex,
       groupByValues,
+      isRowDisabled,
+      isRowLoading,
     ],
   );
 

--- a/src/components/InlineCheckbox/InlineCheckbox.tsx
+++ b/src/components/InlineCheckbox/InlineCheckbox.tsx
@@ -33,7 +33,7 @@ export default function InlineCheckbox<L extends string>({
   }, [indeterminate]);
 
   return (
-    <label className="p-checkbox">
+    <label className="p-checkbox u-no-padding--top">
       <input
         {...props}
         ref={input}

--- a/src/components/ModelActions/ModelActions.test.tsx
+++ b/src/components/ModelActions/ModelActions.test.tsx
@@ -120,6 +120,21 @@ describe("ModelActions", () => {
     ).toBeInTheDocument();
   });
 
+  it("displays the actions menu in disabled state", () => {
+    renderComponent(
+      <ModelActions
+        qualifier="eggman@external"
+        modelUUID="abc123"
+        modelName="test-model"
+        disabled
+      />,
+    );
+    expect(screen.getByRole("button", { name: Label.TOGGLE })).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+  });
+
   it("shows option to manage access if user has permission", async () => {
     renderComponent(
       <ModelActions

--- a/src/components/ModelActions/ModelActions.tsx
+++ b/src/components/ModelActions/ModelActions.tsx
@@ -140,6 +140,7 @@ const generateLinks = (
 const ModelActions: FC<Props> = ({
   modelName,
   modelUUID,
+  disabled = false,
   redirectOnDestroy,
   position,
   qualifier,
@@ -204,6 +205,7 @@ const ModelActions: FC<Props> = ({
         toggleProps={{
           hasIcon: true,
           "aria-label": Label.TOGGLE,
+          disabled,
         }}
         onToggleMenu={setFetchUpgrades}
         children={(handleClose) =>

--- a/src/components/ModelActions/types.ts
+++ b/src/components/ModelActions/types.ts
@@ -7,6 +7,7 @@ import type { PropsWithChildren } from "react";
 export type Props = {
   modelName: string;
   modelUUID: string;
+  disabled?: boolean;
   position?: ContextualMenuProps<void>["position"];
   redirectOnDestroy?: boolean;
   qualifier: string;

--- a/src/components/ModelTable/ModelSummary/ModelSummary.tsx
+++ b/src/components/ModelTable/ModelSummary/ModelSummary.tsx
@@ -1,5 +1,6 @@
 import { Icon, Tooltip } from "@canonical/react-components";
 import type { FC } from "react";
+import classNames from "classnames";
 
 import ModelDetailsLink from "components/ModelDetailsLink";
 import type { ModelData } from "store/juju/types";
@@ -10,9 +11,14 @@ import { Label } from "./types";
 type Props = {
   modelData: ModelData;
   qualifier?: null | string;
+  className?: string;
 };
 
-const ModelSummary: FC<Props> = ({ modelData, qualifier }: Props) => {
+const ModelSummary: FC<Props> = ({
+  modelData,
+  qualifier,
+  className,
+}: Props) => {
   const applicationKeys = Object.keys(modelData.applications);
   const applicationCount = applicationKeys.length;
   const machineCount = Object.keys(modelData.machines).length;
@@ -21,7 +27,7 @@ const ModelSummary: FC<Props> = ({ modelData, qualifier }: Props) => {
     return prev + Object.keys(units).length;
   }, 0);
   return (
-    <div className="u-flex">
+    <div className={classNames("u-flex", className)}>
       <Tooltip
         message="See applications"
         position="top-center"

--- a/src/components/ModelTable/ModelSummary/ModelSummary.tsx
+++ b/src/components/ModelTable/ModelSummary/ModelSummary.tsx
@@ -1,6 +1,5 @@
 import { Icon, Tooltip } from "@canonical/react-components";
 import type { FC } from "react";
-import classNames from "classnames";
 
 import ModelDetailsLink from "components/ModelDetailsLink";
 import type { ModelData } from "store/juju/types";
@@ -11,14 +10,9 @@ import { Label } from "./types";
 type Props = {
   modelData: ModelData;
   qualifier?: null | string;
-  className?: string;
 };
 
-const ModelSummary: FC<Props> = ({
-  modelData,
-  qualifier,
-  className,
-}: Props) => {
+const ModelSummary: FC<Props> = ({ modelData, qualifier }: Props) => {
   const applicationKeys = Object.keys(modelData.applications);
   const applicationCount = applicationKeys.length;
   const machineCount = Object.keys(modelData.machines).length;
@@ -27,7 +21,7 @@ const ModelSummary: FC<Props> = ({
     return prev + Object.keys(units).length;
   }, 0);
   return (
-    <div className={classNames("u-flex", className)}>
+    <div className="u-flex">
       <Tooltip
         message="See applications"
         position="top-center"

--- a/src/components/ModelTable/ModelTable.tsx
+++ b/src/components/ModelTable/ModelTable.tsx
@@ -1,6 +1,5 @@
 import { Chip } from "@canonical/react-components";
-import { useMemo } from "react";
-import type { JSX } from "react";
+import { useMemo, type JSX } from "react";
 
 import DataTable from "components/DataTable";
 import ModelActions from "components/ModelActions";
@@ -27,7 +26,6 @@ import CloudCell from "./CloudCell";
 import ModelSummary from "./ModelSummary";
 import WarningMessage from "./WarningMessage";
 import { getCredential, getRegion } from "./shared";
-import classNames from "classnames";
 
 type Props = {
   models: ModelData[];
@@ -105,14 +103,9 @@ export default function ModelTable({ models, groupBy }: Props): JSX.Element {
 
             return (
               <>
-                <TruncatedTooltip
-                  message={name}
-                  className={classNames({
-                    "is-disabled": isDying(uuid) || !!getUpgrade(uuid),
-                  })}
-                >
+                <TruncatedTooltip message={`${name} (${model.model.version})`}>
                   <ModelDetailsLink modelName={name} qualifier={qualifier}>
-                    {model.model.name}
+                    {name}
                   </ModelDetailsLink>
                   {isUpgrading ? null : (
                     <ModelVersion
@@ -148,18 +141,9 @@ export default function ModelTable({ models, groupBy }: Props): JSX.Element {
         summary: column({
           header: "Configuration",
           className: "summary",
-          map: ({ uuid, qualifier }) => ({
-            uuid,
-            qualifier,
-          }),
-          renderCell: ({ uuid, qualifier }, { model }) => (
-            <ModelSummary
-              modelData={model}
-              qualifier={qualifier}
-              className={classNames({
-                "is-disabled": isDying(uuid) || !!getUpgrade(uuid),
-              })}
-            />
+          map: ({ qualifier }) => ({ qualifier }),
+          renderCell: ({ qualifier }, { model }) => (
+            <ModelSummary modelData={model} qualifier={qualifier} />
           ),
         }),
         owner: column({

--- a/src/components/ModelTable/ModelTable.tsx
+++ b/src/components/ModelTable/ModelTable.tsx
@@ -1,5 +1,4 @@
-import { Chip, Spinner } from "@canonical/react-components";
-import classNames from "classnames";
+import { Chip } from "@canonical/react-components";
 import { useMemo } from "react";
 import type { JSX } from "react";
 
@@ -14,7 +13,7 @@ import {
   getDestructionState,
   getModelUpgrades,
 } from "store/juju/selectors";
-import type { ModelData } from "store/juju/types";
+import type { ModelData, ModelUpgrade } from "store/juju/types";
 import { getControllerByUUID } from "store/juju/utils/controllers";
 import {
   extractCloudName,
@@ -75,12 +74,18 @@ export default function ModelTable({ models, groupBy }: Props): JSX.Element {
     [],
   );
 
+  const isDying = (uuid: string): boolean => uuid in destructionState;
+  const getUpgrade = (uuid: string): ModelUpgrade | null =>
+    uuid in modelUpgrades ? modelUpgrades[uuid] : null;
+
   return (
     <DataTable
       selectable={false}
       getKey={(row) => row.uuid}
       groupBy={groupBy}
       data={tableData}
+      isRowDisabled={({ uuid }) => isDying(uuid)}
+      isRowLoading={({ uuid }) => isDying(uuid) || !!getUpgrade(uuid)}
       noRowsMessage="No models"
       columns={{
         name: column({
@@ -93,44 +98,27 @@ export default function ModelTable({ models, groupBy }: Props): JSX.Element {
             qualifier,
           }),
           renderCell: ({ uuid, name, qualifier }, { model }) => {
-            const isDying = uuid in destructionState;
-            const upgrade = uuid in modelUpgrades ? modelUpgrades[uuid] : null;
+            const isModelDying = isDying(uuid);
+            const upgrade = getUpgrade(uuid);
             const isUpgrading = !!upgrade;
 
             return (
               <>
-                <div className="model-name-column">
-                  {isDying ? (
-                    <span className="model-name-column__status u-truncate">
-                      Destroying&hellip;
-                    </span>
-                  ) : null}
-                  {isUpgrading ? (
-                    <span className="model-name-column__status">
-                      <Spinner />
-                    </span>
-                  ) : null}
-                  <div className="model-name-column__name">
-                    <TruncatedTooltip message={name}>
-                      <ModelDetailsLink
-                        className={classNames({
-                          "u-text--muted": isDying,
-                        })}
-                        modelName={name}
-                        qualifier={qualifier}
-                      >
-                        {model.model.name}
-                      </ModelDetailsLink>
-                      {isUpgrading ? null : (
-                        <ModelVersion
-                          className="models__version"
-                          modelName={name}
-                          qualifier={qualifier}
-                        />
-                      )}
-                    </TruncatedTooltip>
-                  </div>
-                </div>
+                <TruncatedTooltip message={name}>
+                  <ModelDetailsLink modelName={name} qualifier={qualifier}>
+                    {model.model.name}
+                  </ModelDetailsLink>
+                  {isUpgrading ? null : (
+                    <ModelVersion
+                      className="models__version"
+                      modelName={name}
+                      qualifier={qualifier}
+                    />
+                  )}
+                </TruncatedTooltip>
+                {isModelDying ? (
+                  <div className="p-text-small">Destroying model...</div>
+                ) : null}
                 {isUpgrading ? (
                   <>
                     <ModelVersion
@@ -271,6 +259,7 @@ export default function ModelTable({ models, groupBy }: Props): JSX.Element {
                 modelUUID={uuid}
                 modelName={name}
                 qualifier={qualifier}
+                disabled={!!getUpgrade(uuid)}
               />
             ) : null,
         }),

--- a/src/components/ModelTable/ModelTable.tsx
+++ b/src/components/ModelTable/ModelTable.tsx
@@ -27,6 +27,7 @@ import CloudCell from "./CloudCell";
 import ModelSummary from "./ModelSummary";
 import WarningMessage from "./WarningMessage";
 import { getCredential, getRegion } from "./shared";
+import classNames from "classnames";
 
 type Props = {
   models: ModelData[];
@@ -104,7 +105,12 @@ export default function ModelTable({ models, groupBy }: Props): JSX.Element {
 
             return (
               <>
-                <TruncatedTooltip message={name}>
+                <TruncatedTooltip
+                  message={name}
+                  className={classNames({
+                    "is-disabled": isDying(uuid) || !!getUpgrade(uuid),
+                  })}
+                >
                   <ModelDetailsLink modelName={name} qualifier={qualifier}>
                     {model.model.name}
                   </ModelDetailsLink>
@@ -142,11 +148,18 @@ export default function ModelTable({ models, groupBy }: Props): JSX.Element {
         summary: column({
           header: "Configuration",
           className: "summary",
-          map: ({ qualifier }) => ({
+          map: ({ uuid, qualifier }) => ({
+            uuid,
             qualifier,
           }),
-          renderCell: ({ qualifier }, { model }) => (
-            <ModelSummary modelData={model} qualifier={qualifier} />
+          renderCell: ({ uuid, qualifier }, { model }) => (
+            <ModelSummary
+              modelData={model}
+              qualifier={qualifier}
+              className={classNames({
+                "is-disabled": isDying(uuid) || !!getUpgrade(uuid),
+              })}
+            />
           ),
         }),
         owner: column({
@@ -259,7 +272,7 @@ export default function ModelTable({ models, groupBy }: Props): JSX.Element {
                 modelUUID={uuid}
                 modelName={name}
                 qualifier={qualifier}
-                disabled={!!getUpgrade(uuid)}
+                disabled={isDying(uuid) || !!getUpgrade(uuid)}
               />
             ) : null,
         }),

--- a/src/components/ModelTable/_model-table.scss
+++ b/src/components/ModelTable/_model-table.scss
@@ -13,19 +13,21 @@
 }
 
 .models {
-  .model-name-column {
-    display: flex;
-    overflow: hidden;
+  .icon-column {
+    padding-bottom: 1rem;
+    padding-top: 0.5rem;
+    vertical-align: top;
+    width: 2rem;
+  }
 
-    &__status {
-      flex-shrink: 0;
-      margin-right: $sph--small;
-    }
+  .icon-column-header {
+    padding-top: 0.9rem;
+  }
 
-    &__name {
-      flex-shrink: 1;
-      overflow: hidden;
-    }
+  tr.is-disabled {
+    opacity: 0.5;
+    pointer-events: none;
+    user-select: none;
   }
 
   caption {

--- a/src/components/ModelTable/_model-table.scss
+++ b/src/components/ModelTable/_model-table.scss
@@ -13,23 +13,6 @@
 }
 
 .models {
-  .icon-column {
-    padding-bottom: 1rem;
-    padding-top: 0.5rem;
-    vertical-align: top;
-    width: 2rem;
-  }
-
-  .icon-column-header {
-    padding-top: 0.9rem;
-  }
-
-  tr.is-disabled {
-    opacity: 0.5;
-    pointer-events: none;
-    user-select: none;
-  }
-
   caption {
     margin-top: 0.5rem;
   }

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -72,6 +72,7 @@ $color-navigation-background: $color-brand;
 @import "../components/Breadcrumb/breadcrumbs";
 @import "../components/ChipGroup/chip-group";
 @import "../components/ContentReveal/content-reveal";
+@import "../components/DataTable/data-table";
 @import "../components/DestroyModelDialog/destroy-model-dialog";
 @import "../components/DevBar/dev-bar";
 @import "../components/InfoPanel/info-panel";


### PR DESCRIPTION
## Done

- Added disabled and loading states to `DataTable` rows
- Added disabled state to `ModelActions` for when an upgrade is in progress
- Moved the spinner rendered during loading (upgrading) or disabling (destroying) to be shown in the checkbox column (as per the latest [screens](https://www.figma.com/design/Rs1v3IS0oY2RK4CU4yo4Ly/25.10-JAAS-model-management---Juju?node-id=452-44876&p=f&m=dev))
- Updated styles and tests accordingly
- Added tests to improve coverage

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- View the model table in selectable and non-selectable states
- Try deleting and upgrading models in each
- A spinner should appear under checkbox column in selectable state
- A spinner should appear in the hidden icon column in non-selectable state
- While destroying, the entire row should stay disabled
- While upgrading, the the model actions should stay disabled while the row is open to other interactions
- Try interacting with the select-all toggle when some rows are in destroying and upgrading states. It should ignore such rows.

## Details

Fixes https://github.com/canonical/juju-dashboard/issues/2404
Fixes https://warthogs.atlassian.net/browse/JUJU-10223

## Screenshots

BEFORE:
<img width="1131" height="260" alt="Screenshot 2026-08-12 at 5 58 34 PM" src="https://github.com/user-attachments/assets/e0029816-050c-4617-b126-384d1cf33a4e" />
<img width="1133" height="220" alt="Screenshot 2026-08-12 at 5 58 55 PM" src="https://github.com/user-attachments/assets/3200dd92-d8e2-44c8-8651-3ccc4356b727" />


AFTER:
<img width="1134" height="331" alt="Screenshot 2026-08-12 at 5 56 03 PM" src="https://github.com/user-attachments/assets/a2067395-fa96-4d01-85af-245057355976" />
<img width="1143" height="247" alt="Screenshot 2026-08-12 at 5 56 54 PM" src="https://github.com/user-attachments/assets/1d0a4d0d-981f-4488-bffb-3f04727189b3" />
<img width="1134" height="225" alt="Screenshot 2026-08-12 at 5 56 58 PM" src="https://github.com/user-attachments/assets/e36916e7-2d62-4125-b052-acf89ab7fda6" />

