### PR TITLE
chore(security): package cooldown

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
+  - package-ecosystem: "pip"
+    directories: "/charms/*-charm"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -3,3 +3,6 @@ nodeLinker: node-modules
 npmMinimalAgeGate: 7
 
 yarnPath: .yarn/releases/yarn-4.18.0.cjs
+
+# Don't allow packages to run scripts at install time.
+enableScripts: false

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "dependencyDashboard": true,
   "extends": ["github>canonical/renovate-apps"],
+  "minimumReleaseAge": "7 days",
   "packageRules": [
     {
       "matchDatasources": ["docker"],


### PR DESCRIPTION
## Done

- Set a minimum age of dependency updates to limit supply-chain attacks.
- Disable install time scripts for npm packages.
