### PR TITLE
fix: permissions for release workflow

### DIFF
--- a/.github/workflows/create-cut-pr.yml
+++ b/.github/workflows/create-cut-pr.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   pull-requests: write
+  contents: write
 
 jobs:
   create-cut-pr:
@@ -17,8 +18,6 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.merged == true
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          persist-credentials: false
       - uses: ./.github/actions/create-cut-pr
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   pull-requests: write
+  contents: write
 
 jobs:
   create-release-pr:
@@ -19,7 +20,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.base_ref }}
-          persist-credentials: false
       - uses: ./.github/actions/create-release-pr
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,9 @@ jobs:
   release:
     name: "Release Juju Dashboard"
     runs-on: ubuntu-24.04
+    permissions:
+      packages: write
+      actions: write
 
     needs: [pre-release]
 


### PR DESCRIPTION
## Done

- Added `write` permissions to release workflow for uploading image and artifact (See https://github.com/canonical/juju-dashboard/actions/runs/33036248248/job/98400987117)
- Removed `persist-credentials: false` as it was stripping the job of the token that git needs to push the new release branch
- Added `write` permissions for pushing content onto the said branch
- See: https://github.com/canonical/juju-dashboard/actions/runs/33059296033/job/98473788407

