### PR TITLE
Revert breaking permission changes on release workflows

### DIFF
--- a/.github/workflows/create-cut-pr.yml
+++ b/.github/workflows/create-cut-pr.yml
@@ -9,7 +9,6 @@ on:
 
 permissions:
   pull-requests: write
-  contents: write
 
 jobs:
   create-cut-pr:
@@ -18,6 +17,8 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.merged == true
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/create-cut-pr
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-cut-pr.yml
+++ b/.github/workflows/create-cut-pr.yml
@@ -1,14 +1,13 @@
 name: Create cut PR
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
     branches:
       - main
 
-permissions:
-  pull-requests: write
+permissions: write-all
 
 jobs:
   create-cut-pr:
@@ -17,8 +16,6 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.merged == true
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          persist-credentials: false
       - uses: ./.github/actions/create-cut-pr
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -9,7 +9,6 @@ on:
 
 permissions:
   pull-requests: write
-  contents: write
 
 jobs:
   create-release-pr:
@@ -20,6 +19,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.base_ref }}
+          persist-credentials: false
       - uses: ./.github/actions/create-release-pr
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,14 +1,13 @@
 name: Create release PR
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
     branches:
       - release/*
 
-permissions:
-  pull-requests: write
+permissions: write-all
 
 jobs:
   create-release-pr:
@@ -19,7 +18,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.base_ref }}
-          persist-credentials: false
       - uses: ./.github/actions/create-release-pr
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,9 @@ jobs:
   release:
     name: "Release Juju Dashboard"
     runs-on: ubuntu-24.04
+    permissions:
+      packages: write
+      actions: write
 
     needs: [pre-release]
 
@@ -215,7 +218,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-tags: true
-          persist-credentials: false
       - name: Tag commits
         id: tags
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,9 +90,6 @@ jobs:
   release:
     name: "Release Juju Dashboard"
     runs-on: ubuntu-24.04
-    permissions:
-      packages: write
-      actions: write
 
     needs: [pre-release]
 


### PR DESCRIPTION
## Done

- Reverted changes made to `create-cut-pr` and `create-release-pr` in [this](https://github.com/canonical/juju-dashboard/pull/2435/changes#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34) PR
