### PR TITLE
chore: expose model selection state

### DIFF
--- a/src/components/DataTable/DataTable.test.tsx
+++ b/src/components/DataTable/DataTable.test.tsx
@@ -188,6 +188,43 @@ describe("DataTable", () => {
       ).not.toBeInTheDocument();
     });
   });
+
+  describe("onSelectionChange", () => {
+    it("calls onSelectionChange with the selected key when a row is toggled", async () => {
+      const onSelectionChange = vi.fn();
+      renderComponent(
+        <DataTable {...initialProps} onSelectionChange={onSelectionChange} />,
+      );
+      await userEvent.click(
+        screen.getByRole("checkbox", { name: "Deselect 1" }),
+      );
+      expect(onSelectionChange).toHaveBeenCalledWith(["1"]);
+    });
+
+    it("calls onSelectionChange with all keys when select-all is toggled", async () => {
+      const onSelectionChange = vi.fn();
+      renderComponent(
+        <DataTable {...initialProps} onSelectionChange={onSelectionChange} />,
+      );
+      await userEvent.click(
+        screen.getByRole("checkbox", { name: "Select all" }),
+      );
+      expect(onSelectionChange).toHaveBeenCalledWith(["1", "2"]);
+    });
+
+    it("calls onSelectionChange with an empty array when the last selected row is deselected", async () => {
+      const onSelectionChange = vi.fn();
+      renderComponent(
+        <DataTable {...initialProps} onSelectionChange={onSelectionChange} />,
+      );
+      // Select row 1 then deselect it.
+      await userEvent.click(
+        screen.getByRole("checkbox", { name: "Deselect 1" }),
+      );
+      await userEvent.click(screen.getByRole("checkbox", { name: "Select 1" }));
+      expect(onSelectionChange).toHaveBeenLastCalledWith([]);
+    });
+  });
 });
 
 describe("DataTable.columnBuilder", () => {

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -32,6 +32,7 @@ export default function DataTable<
   isRowDisabled,
   isRowLoading,
   noRowsMessage = "No rows",
+  onSelectionChange,
 }: DataTableProps<TRow, TKeyValue, TValues>): JSX.Element {
   const { sort, toggleSort } = useSortState<keyof TValues>();
 
@@ -77,7 +78,7 @@ export default function DataTable<
         .map(({ key }) => key),
     [keyedRows, isRowDisabled, isRowLoading],
   );
-  const select = useToggleSelect(rowKeys);
+  const select = useToggleSelect(rowKeys, onSelectionChange);
 
   // Render rows.
   const fullRows = useRows({

--- a/src/components/DataTable/types.ts
+++ b/src/components/DataTable/types.ts
@@ -88,6 +88,11 @@ export type DataTableProps<
    * Optional message to display when there are no rows.
    */
   noRowsMessage?: string;
+  /**
+   * Optional callback fired whenever the set of selected row keys changes.
+   * Receives the current array of selected keys (empty when nothing is selected).
+   */
+  onSelectionChange?: (selectedKeys: TKeyValue[]) => void;
 };
 
 /**

--- a/src/components/DataTable/useToggleSelect.ts
+++ b/src/components/DataTable/useToggleSelect.ts
@@ -30,9 +30,13 @@ export type ToggleSelectReturn<T> = {
 
 /**
  * Track selection over a collection of `keys`.
+ *
+ * @param onChange - Optional callback fired synchronously whenever the
+ * selection changes, receiving the new selected keys array.
  */
 export default function useToggleSelect<T>(
   keys: readonly T[],
+  onChange?: (selected: T[]) => void,
 ): ToggleSelectReturn<T> {
   const [selected, setSelected] = useState<T[]>([]);
 
@@ -70,8 +74,13 @@ export default function useToggleSelect<T>(
         }
         return filtered;
       });
+      onChange?.(
+        selected.includes(key)
+          ? selected.filter((value) => key !== value)
+          : [...selected, key],
+      );
     },
-    [keys],
+    [keys, onChange, selected],
   );
 
   const toggleAll = useCallback(() => {
@@ -79,14 +88,10 @@ export default function useToggleSelect<T>(
       return;
     }
 
-    setSelected((previous) => {
-      if (previous.length === keys.length) {
-        return [];
-      }
-
-      return [...keys];
-    });
-  }, [keys]);
+    const next = selected.length === keys.length ? [] : [...keys];
+    setSelected(next);
+    onChange?.(next);
+  }, [keys, onChange, selected]);
 
   return { selected, state, toggle, toggleAll };
 }

--- a/src/components/ModelTable/ModelTable.tsx
+++ b/src/components/ModelTable/ModelTable.tsx
@@ -30,9 +30,14 @@ import { getCredential, getRegion } from "./shared";
 type Props = {
   models: ModelData[];
   groupBy?: "cloud" | "owner" | "status";
+  onSelectionChange?: (selectedUUIDs: string[]) => void;
 };
 
-export default function ModelTable({ models, groupBy }: Props): JSX.Element {
+export default function ModelTable({
+  models,
+  groupBy,
+  onSelectionChange,
+}: Props): JSX.Element {
   const controllers = useAppSelector(getControllerData);
   const destructionState = useAppSelector(getDestructionState);
   const modelUpgrades = useAppSelector(getModelUpgrades);
@@ -79,13 +84,14 @@ export default function ModelTable({ models, groupBy }: Props): JSX.Element {
 
   return (
     <DataTable
-      selectable={false}
+      selectable
       getKey={(row) => row.uuid}
       groupBy={groupBy}
       data={tableData}
       isRowDisabled={({ uuid }) => isDying(uuid)}
       isRowLoading={({ uuid }) => isDying(uuid) || !!getUpgrade(uuid)}
       noRowsMessage="No models"
+      onSelectionChange={onSelectionChange}
       columns={{
         name: column({
           header: "Model",

--- a/src/pages/ModelsIndex/ModelsIndex.test.tsx
+++ b/src/pages/ModelsIndex/ModelsIndex.test.tsx
@@ -238,4 +238,48 @@ describe("Models Index page", () => {
     await userEvent.click(addButton);
     expect(router.state.location.pathname).toEqual(urls.models.addModel);
   });
+
+  describe("Review & destroy button", () => {
+    it("is disabled when no models are selected", () => {
+      renderComponent(<ModelsIndex />, { state });
+      const button = screen.getByRole("button", {
+        name: `${Label.REVIEW_AND_DESTROY} 0 models`,
+      });
+      expect(button).toHaveAttribute("aria-disabled", "true");
+    });
+
+    it("shows count after selecting a model", async () => {
+      renderComponent(<ModelsIndex />, { state });
+      // Select the first row checkbox.
+      const checkboxes = screen.getAllByRole("checkbox", {
+        name: /Deselect /,
+      });
+      await userEvent.click(checkboxes[0]);
+      expect(
+        screen.getByRole("button", {
+          name: `${Label.REVIEW_AND_DESTROY} 1 model`,
+        }),
+      ).toBeInTheDocument();
+    });
+
+    it("updates count as more models are selected", async () => {
+      renderComponent(<ModelsIndex />, { state });
+      const checkboxes = screen.getAllByRole("checkbox", {
+        name: /Deselect /,
+      });
+      await userEvent.click(checkboxes[0]);
+      expect(
+        screen.getByRole("button", {
+          name: `${Label.REVIEW_AND_DESTROY} 1 model`,
+        }),
+      ).toBeInTheDocument();
+
+      await userEvent.click(checkboxes[1]);
+      expect(
+        screen.getByRole("button", {
+          name: `${Label.REVIEW_AND_DESTROY} 2 models`,
+        }),
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/src/pages/ModelsIndex/ModelsIndex.tsx
+++ b/src/pages/ModelsIndex/ModelsIndex.tsx
@@ -7,7 +7,7 @@ import {
 import type { SearchAndFilterChip } from "@canonical/react-components/dist/components/SearchAndFilter/types";
 import classNames from "classnames";
 import type { JSX, ReactNode } from "react";
-import { useId, useMemo } from "react";
+import { useId, useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router";
 
 import ChipGroup from "components/ChipGroup";
@@ -45,6 +45,7 @@ import { Label, TestId } from "./types";
 export default function Models(): JSX.Element {
   useWindowTitle("Models");
   const navigate = useNavigate();
+  const [selectedModelUUIDs, setSelectedModelUUIDs] = useState<string[]>([]);
 
   const [queryParams, setQueryParams] = useQueryParams<{
     groupedby: string;
@@ -228,7 +229,11 @@ export default function Models(): JSX.Element {
         </span>
         <div className={classNames("models", `${groupBy}-group`)}>
           <ChipGroup chips={{ blocked, alert, running }} />
-          <ModelTable models={models} groupBy={groupBy} />
+          <ModelTable
+            models={models}
+            groupBy={groupBy}
+            onSelectionChange={setSelectedModelUUIDs}
+          />
         </div>
       </>
     );
@@ -243,16 +248,29 @@ export default function Models(): JSX.Element {
           <span className="u-show--large">
             {modelCount} {pluralize(modelCount, "model")}
           </span>
-          <Button
-            appearance="positive"
-            className="u-no-margin--bottom"
-            hasIcon
-            disabled={!canCreateModels}
-            onClick={() => void navigate(urls.models.addModel)}
-          >
-            <Icon name="plus" light />
-            <span>Add model</span>
-          </Button>
+          <span>
+            <Button
+              appearance="secondary"
+              className="u-no-margin--bottom"
+              hasIcon
+              disabled
+            >
+              <Icon name="delete" />
+              <span>
+                {`${Label.REVIEW_AND_DESTROY} ${selectedModelUUIDs.length} ${pluralize(selectedModelUUIDs.length, "model")}`}
+              </span>
+            </Button>
+            <Button
+              appearance="positive"
+              className="u-no-margin--bottom"
+              hasIcon
+              disabled={!canCreateModels}
+              onClick={() => void navigate(urls.models.addModel)}
+            >
+              <Icon name="plus" light />
+              <span>Add model</span>
+            </Button>
+          </span>
         </div>
       }
       titleComponent="div"

--- a/src/pages/ModelsIndex/types.ts
+++ b/src/pages/ModelsIndex/types.ts
@@ -1,5 +1,6 @@
 export enum Label {
   NOT_FOUND = "No models found",
+  REVIEW_AND_DESTROY = "Review & destroy",
 }
 
 export enum TestId {


### PR DESCRIPTION
## Done

- Introduced a button to review and destroy models on models index
- Exposed a prop from `DataTable` to allow custom callbacks on selection change
- Wired it to `ModelsIndex` to allow changing the label for `Review & Destroy x models` button

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- View the /models page
- Checking rows in the model table updates the label on "Review & Destroy" button
- Button label shows the count of selected models
- Note: The button is currently forced to stay disabled as no `onClick` is configured

## Details

https://warthogs.atlassian.net/browse/JUJU-10308
