### PR TITLE
feat: add destroy models panel

### DIFF
--- a/src/components/DataTable/useToggleSelect.test.ts
+++ b/src/components/DataTable/useToggleSelect.test.ts
@@ -137,6 +137,58 @@ describe("useToggleSelect", () => {
     });
   });
 
+  describe("onChange callback", () => {
+    it("is called with the new selection when a key is toggled on", ({
+      expect,
+    }) => {
+      const onChange = vi.fn();
+      const { result } = renderHook(() => useToggleSelect(KEYS, onChange));
+      act(() => {
+        result.current.toggle("one");
+      });
+      expect(onChange).toHaveBeenCalledWith(["one"]);
+    });
+
+    it("is called with the new selection when a key is toggled off", ({
+      expect,
+    }) => {
+      const onChange = vi.fn();
+      const { result } = renderHook(() => useToggleSelect(KEYS, onChange));
+      act(() => {
+        result.current.toggle("one");
+      });
+      act(() => {
+        result.current.toggle("one");
+      });
+      expect(onChange).toHaveBeenLastCalledWith([]);
+    });
+
+    it("is called with all keys when toggleAll selects all", ({ expect }) => {
+      const onChange = vi.fn();
+      const { result } = renderHook(() => useToggleSelect(KEYS, onChange));
+      act(() => {
+        result.current.toggleAll();
+      });
+      expect(onChange).toHaveBeenCalledWith([...KEYS]);
+    });
+
+    it("is called with an empty array when toggleAll deselects all", ({
+      expect,
+    }) => {
+      const onChange = vi.fn();
+      const { result } = renderHook(() => useToggleSelect(KEYS, onChange));
+      act(() => {
+        for (const key of KEYS) {
+          result.current.toggle(key);
+        }
+      });
+      act(() => {
+        result.current.toggleAll();
+      });
+      expect(onChange).toHaveBeenLastCalledWith([]);
+    });
+  });
+
   it("survives rerender", ({ expect }) => {
     const { result, rerender } = renderHook((keys) => useToggleSelect(keys), {
       initialProps: KEYS,

--- a/src/pages/ModelsIndex/ModelsIndex.test.tsx
+++ b/src/pages/ModelsIndex/ModelsIndex.test.tsx
@@ -2,6 +2,7 @@ import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
 
+import { DestroyModelDialogTestId } from "components/DestroyModelDialog";
 import { LoadingSpinnerTestId } from "components/LoadingSpinner";
 import type { RootState } from "store/store";
 import { configFactory, generalStateFactory } from "testing/factories/general";
@@ -280,6 +281,38 @@ describe("Models Index page", () => {
           name: `${Label.REVIEW_AND_DESTROY} 2 models`,
         }),
       ).toBeInTheDocument();
+    });
+
+    it("opens DestroyModelDialog when exactly one model is selected and button is clicked", async () => {
+      renderComponent(<ModelsIndex />, { state });
+      const checkboxes = screen.getAllByRole("checkbox", {
+        name: /Deselect /,
+      });
+      await userEvent.click(checkboxes[0]);
+      await userEvent.click(
+        screen.getByRole("button", {
+          name: `${Label.REVIEW_AND_DESTROY} 1 model`,
+        }),
+      );
+      expect(
+        screen.getByTestId(DestroyModelDialogTestId.DIALOG),
+      ).toBeInTheDocument();
+    });
+
+    it("sets the panel query param when multiple models are selected and button is clicked", async () => {
+      const { router } = renderComponent(<ModelsIndex />, { state });
+      const checkboxes = screen.getAllByRole("checkbox", {
+        name: /Deselect /,
+      });
+      await userEvent.click(checkboxes[0]);
+      await userEvent.click(checkboxes[1]);
+      await userEvent.click(
+        screen.getByRole("button", {
+          name: `${Label.REVIEW_AND_DESTROY} 2 models`,
+        }),
+      );
+      const params = new URLSearchParams(router.state.location.search);
+      expect(params.get("panel")).toBe("destroy-models");
     });
   });
 });

--- a/src/pages/ModelsIndex/ModelsIndex.tsx
+++ b/src/pages/ModelsIndex/ModelsIndex.tsx
@@ -3,14 +3,16 @@ import {
   Icon,
   Notification as ReactNotification,
   SearchAndFilter,
+  usePortal,
 } from "@canonical/react-components";
 import type { SearchAndFilterChip } from "@canonical/react-components/dist/components/SearchAndFilter/types";
 import classNames from "classnames";
 import type { JSX, ReactNode } from "react";
-import { useId, useMemo, useState } from "react";
+import { useCallback, useId, useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router";
 
 import ChipGroup from "components/ChipGroup";
+import DestroyModelDialog from "components/DestroyModelDialog";
 import LoadingSpinner from "components/LoadingSpinner";
 import ModelTable from "components/ModelTable";
 import SegmentedControl from "components/SegmentedControl";
@@ -22,7 +24,11 @@ import useWindowTitle from "hooks/useWindowTitle";
 import { useCheckRelations } from "juju/api-hooks/permissions";
 import { JIMMRelation } from "juju/jimm/JIMMV4";
 import MainContent from "layout/MainContent";
-import { getControllerUserTag } from "store/general/selectors";
+import {
+  getControllerUserTag,
+  getWSControllerURL,
+} from "store/general/selectors";
+import { actions as jujuActions } from "store/juju";
 import {
   getFilteredModelData,
   getGroupedModelStatusCounts,
@@ -33,7 +39,7 @@ import {
   hasModels,
 } from "store/juju/selectors";
 import { pluralize } from "store/juju/utils/models";
-import { useAppSelector } from "store/store";
+import { useAppDispatch, useAppSelector } from "store/store";
 import { testId } from "testing/utils";
 import type { ModelsGroupedBy } from "urls";
 import urls, { externalURLs } from "urls";
@@ -45,7 +51,17 @@ import { Label, TestId } from "./types";
 export default function Models(): JSX.Element {
   useWindowTitle("Models");
   const navigate = useNavigate();
+  const dispatch = useAppDispatch();
   const [selectedModelUUIDs, setSelectedModelUUIDs] = useState<string[]>([]);
+  const [, setPanelQs] = useQueryParams<{ panel: null | string }>({
+    panel: null,
+  });
+  const {
+    openPortal,
+    closePortal,
+    isOpen: showDestroyDialog,
+    Portal,
+  } = usePortal();
 
   const [queryParams, setQueryParams] = useQueryParams<{
     groupedby: string;
@@ -74,6 +90,7 @@ export default function Models(): JSX.Element {
   const modelsLoaded = useAppSelector(getModelListLoaded);
   const hasSomeModels = useAppSelector(hasModels);
   const modelData = useAppSelector(getModelData);
+  const wsControllerURL = useAppSelector(getWSControllerURL);
   const filteredModelData = useAppSelector((state) =>
     getFilteredModelData(state, filters),
   );
@@ -100,6 +117,34 @@ export default function Models(): JSX.Element {
     () => Object.values(filteredModelData),
     [filteredModelData],
   );
+
+  const handleReviewAndDestroy = useCallback(() => {
+    if (selectedModelUUIDs.length === 1) {
+      // Single model: open the existing per-model dialog directly.
+      openPortal();
+    } else {
+      // Multiple models: seed the store and open the destroy models panel.
+      if (wsControllerURL) {
+        dispatch(
+          jujuActions.selectModelsForDestruction({
+            models: selectedModelUUIDs.map((modelUUID) => ({
+              modelUUID,
+              modelName: modelData[modelUUID]?.model.name ?? modelUUID,
+            })),
+            wsControllerURL,
+          }),
+        );
+      }
+      setPanelQs({ panel: "destroy-models" }, { replace: true });
+    }
+  }, [
+    selectedModelUUIDs,
+    openPortal,
+    dispatch,
+    setPanelQs,
+    wsControllerURL,
+    modelData,
+  ]);
   const groupBy: ModelsGroupedBy = useMemo(() => {
     if (
       (VALID_MODEL_GROUPINGS as readonly string[]).includes(
@@ -253,7 +298,8 @@ export default function Models(): JSX.Element {
               appearance="secondary"
               className="u-no-margin--bottom"
               hasIcon
-              disabled
+              disabled={selectedModelUUIDs.length === 0}
+              onClick={handleReviewAndDestroy}
             >
               <Icon name="delete" />
               <span>
@@ -276,6 +322,18 @@ export default function Models(): JSX.Element {
       titleComponent="div"
       titleClassName="u-no-max-width u-full-width"
     >
+      {showDestroyDialog && selectedModelUUIDs.length === 1 && (
+        <Portal>
+          <DestroyModelDialog
+            modelUUID={selectedModelUUIDs[0]}
+            modelName={
+              modelData[selectedModelUUIDs[0]]?.model.name ??
+              selectedModelUUIDs[0]
+            }
+            closePortal={closePortal}
+          />
+        </Portal>
+      )}
       {modelsError ? (
         <ReactNotification severity="negative" title="Error">
           {modelsError} Try{" "}

--- a/src/panels/DestroyModelsPanel/DestroyModelsPanel.test.tsx
+++ b/src/panels/DestroyModelsPanel/DestroyModelsPanel.test.tsx
@@ -7,6 +7,7 @@ import { configFactory, generalStateFactory } from "testing/factories/general";
 import {
   jujuStateFactory,
   modelListInfoFactory,
+  modelSelectionParamsFactory,
 } from "testing/factories/juju/juju";
 import { renderComponent } from "testing/utils";
 
@@ -35,8 +36,14 @@ describe("DestroyModelsPanel", () => {
           }),
         },
         modelsSelectedForDestruction: [
-          { modelUUID: "abc123", modelName: "test-model-1" },
-          { modelUUID: "def456", modelName: "test-model-2" },
+          modelSelectionParamsFactory.build({
+            modelUUID: "abc123",
+            modelName: "test-model-1",
+          }),
+          modelSelectionParamsFactory.build({
+            modelUUID: "def456",
+            modelName: "test-model-2",
+          }),
         ],
       }),
     });

--- a/src/panels/DestroyModelsPanel/DestroyModelsPanel.test.tsx
+++ b/src/panels/DestroyModelsPanel/DestroyModelsPanel.test.tsx
@@ -1,0 +1,77 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import type { RootState } from "store/store";
+import { rootStateFactory } from "testing/factories";
+import { configFactory, generalStateFactory } from "testing/factories/general";
+import {
+  jujuStateFactory,
+  modelListInfoFactory,
+} from "testing/factories/juju/juju";
+import { renderComponent } from "testing/utils";
+
+import DestroyModelsPanel from "./DestroyModelsPanel";
+
+describe("DestroyModelsPanel", () => {
+  let state: RootState;
+  const url = "/?panel=destroy-models";
+
+  beforeEach(() => {
+    state = rootStateFactory.build({
+      general: generalStateFactory.build({
+        config: configFactory.build({
+          controllerAPIEndpoint: "wss://example.com/api",
+        }),
+      }),
+      juju: jujuStateFactory.build({
+        models: {
+          abc123: modelListInfoFactory.build({
+            uuid: "abc123",
+            wsControllerURL: "wss://example.com/api",
+          }),
+          def456: modelListInfoFactory.build({
+            uuid: "def456",
+            wsControllerURL: "wss://example.com/api",
+          }),
+        },
+        modelsSelectedForDestruction: [
+          { modelUUID: "abc123", modelName: "test-model-1" },
+          { modelUUID: "def456", modelName: "test-model-2" },
+        ],
+      }),
+    });
+  });
+
+  it("renders properly", () => {
+    renderComponent(<DestroyModelsPanel />, { state, url });
+    expect(
+      screen.getByRole("heading", { name: "Review 2 models" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Complete review & destroy" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders an accordion section for each selected model", () => {
+    renderComponent(<DestroyModelsPanel />, { state, url });
+    expect(
+      screen.getByRole("heading", { name: "test-model-1" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "test-model-2" }),
+    ).toBeInTheDocument();
+  });
+
+  it("closes the panel and clears the store selection when Cancel is clicked", async () => {
+    const { router, store } = renderComponent(<DestroyModelsPanel />, {
+      state,
+      url,
+    });
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    const params = new URLSearchParams(router.state.location.search);
+    expect(params.get("panel")).toBeNull();
+    expect(store.getState().juju.modelsSelectedForDestruction).toStrictEqual(
+      [],
+    );
+  });
+});

--- a/src/panels/DestroyModelsPanel/DestroyModelsPanel.tsx
+++ b/src/panels/DestroyModelsPanel/DestroyModelsPanel.tsx
@@ -1,0 +1,77 @@
+import { Accordion, Button } from "@canonical/react-components";
+import type { FC } from "react";
+
+import Panel from "components/Panel";
+import { usePanelQueryParams } from "panels/hooks";
+import { actions as jujuActions } from "store/juju";
+import { getSelectedModelsForDestruction } from "store/juju/selectors";
+import { useAppDispatch, useAppSelector } from "store/store";
+
+const DestroyModelsPanel: FC = () => {
+  const dispatch = useAppDispatch();
+  const selectedModels = useAppSelector(getSelectedModelsForDestruction);
+  const [, , handleRemovePanelQueryParams] = usePanelQueryParams<{
+    panel: null | string;
+  }>({ panel: null });
+
+  const handleClose = (): void => {
+    dispatch(jujuActions.clearSelectedModelsForDestruction());
+    handleRemovePanelQueryParams();
+  };
+
+  const modelWord = selectedModels.length === 1 ? "model" : "models";
+
+  return (
+    <Panel
+      onRemovePanelQueryParams={handleClose}
+      title={`Review ${selectedModels.length} ${modelWord}`}
+      width="unset"
+      contentClassName="no-indent u-no-padding--bottom"
+      className="destroy-models-panel"
+      drawer={
+        <div className="destroy-models-panel__actions">
+          <div className="u-align--left">{`0 out of ${selectedModels.length} reviewed`}</div>
+          <span>
+            <Button
+              appearance="base"
+              className="u-no-margin--bottom"
+              type="button"
+              onClick={handleClose}
+            >
+              Cancel
+            </Button>
+            <Button
+              appearance="negative"
+              className="u-no-margin--bottom"
+              type="submit"
+              disabled
+            >
+              Complete review & destroy
+            </Button>
+          </span>
+        </div>
+      }
+    >
+      <div className="destroy-models-panel__review-warning">
+        By destroying {selectedModels.length} {modelWord} you will also be
+        destroying all applications, machines and storage within. Review before
+        continuing
+      </div>
+      <Accordion
+        className="destroy-models-panel__accordion"
+        expanded="model-0"
+        sections={selectedModels.map(({ modelName }, index) => ({
+          key: `model-${index}`,
+          title: modelName,
+          content: (
+            <p className="u-text--muted">
+              Reviewing <strong>{modelName}</strong> for destruction&hellip;
+            </p>
+          ),
+        }))}
+      />
+    </Panel>
+  );
+};
+
+export default DestroyModelsPanel;

--- a/src/panels/DestroyModelsPanel/_destroy-models-panel.scss
+++ b/src/panels/DestroyModelsPanel/_destroy-models-panel.scss
@@ -1,0 +1,17 @@
+.destroy-models-panel {
+  &__actions {
+    display: flex;
+    flex-direction: column;
+    gap: $spv--small;
+  }
+
+  &__review-warning {
+    margin-bottom: $spv--x-large;
+  }
+
+  &__accordion {
+    .p-accordion__tab {
+      padding-left: 0;
+    }
+  }
+}

--- a/src/panels/DestroyModelsPanel/index.ts
+++ b/src/panels/DestroyModelsPanel/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DestroyModelsPanel";

--- a/src/panels/Panels.tsx
+++ b/src/panels/Panels.tsx
@@ -13,6 +13,7 @@ import { useAppSelector } from "store/store";
 import AuditLogsFilterPanel from "./AuditLogsFilterPanel";
 import CharmsAndActionsPanel from "./CharmsAndActionsPanel/CharmsAndActionsPanel";
 import ConfigPanel from "./ConfigPanel/ConfigPanel";
+import DestroyModelsPanel from "./DestroyModelsPanel";
 import GrantSecretPanel from "./GrantSecretPanel";
 import RemoveSecretPanel from "./RemoveSecretPanel";
 import UpgradeModelPanel from "./UpgradeModelPanel";
@@ -47,6 +48,8 @@ export default function Panels(): JSX.Element {
         return canManageSecrets ? <RemoveSecretPanel /> : null;
       case "upgrade-model":
         return isJIMM && isJIMMControllerAdmin ? <UpgradeModelPanel /> : null;
+      case "destroy-models":
+        return <DestroyModelsPanel />;
       default:
         return null;
     }

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -109,6 +109,7 @@ $color-navigation-background: $color-brand;
 @import "../pages/EntityDetails/entity-details";
 @import "../pages/ModelsIndex/models";
 @import "../panels/ConfigPanel/config-panel";
+@import "../panels/DestroyModelsPanel/destroy-models-panel";
 @import "../panels/ShareModelPanel/share-model";
 @import "../panels/UpgradeModelPanel/UpgradeModelController/upgrade-model-controller";
 @import "../panels/UpgradeModelPanel/UpgradeModelVersion/RecommendedVersion/recommended-version";

--- a/src/store/juju/reducers.test.ts
+++ b/src/store/juju/reducers.test.ts
@@ -29,6 +29,7 @@ import {
   commandHistoryItem,
   userCredentialsStateFactory,
   modelUpgradeFactory,
+  modelSelectionParamsFactory,
 } from "testing/factories/juju/juju";
 
 import { actions, reducer } from "./slice";
@@ -440,6 +441,14 @@ describe("reducers", () => {
   });
 
   it("selectModelsForDestruction", () => {
+    const model1 = modelSelectionParamsFactory.build({
+      modelUUID: "abc123",
+      modelName: "test-model-1",
+    });
+    const model2 = modelSelectionParamsFactory.build({
+      modelUUID: "def456",
+      modelName: "test-model-2",
+    });
     const state = jujuStateFactory.build({
       modelsSelectedForDestruction: [],
     });
@@ -448,40 +457,50 @@ describe("reducers", () => {
         state,
         actions.selectModelsForDestruction({
           wsControllerURL: "wss://example.com",
-          models: [
-            { modelUUID: "abc123", modelName: "test-model-1" },
-            { modelUUID: "def456", modelName: "test-model-2" },
-          ],
+          models: [model1, model2],
         }),
       ),
     ).toStrictEqual({
       ...state,
-      modelsSelectedForDestruction: [
-        { modelUUID: "abc123", modelName: "test-model-1" },
-        { modelUUID: "def456", modelName: "test-model-2" },
-      ],
+      modelsSelectedForDestruction: [model1, model2],
     });
   });
 
   it("selectModelsForDestruction replaces previous selection", () => {
+    const oldModel = modelSelectionParamsFactory.build({
+      modelUUID: "old123",
+      modelName: "old-model",
+    });
+    const newModel = modelSelectionParamsFactory.build({
+      modelUUID: "new456",
+      modelName: "new-model",
+    });
     const state = jujuStateFactory.build({
-      modelsSelectedForDestruction: [
-        { modelUUID: "old123", modelName: "old-model" },
-      ],
+      modelsSelectedForDestruction: [oldModel],
     });
     expect(
       reducer(
         state,
         actions.selectModelsForDestruction({
           wsControllerURL: "wss://example.com",
-          models: [{ modelUUID: "new456", modelName: "new-model" }],
+          models: [newModel],
         }),
       ),
     ).toStrictEqual({
       ...state,
-      modelsSelectedForDestruction: [
-        { modelUUID: "new456", modelName: "new-model" },
-      ],
+      modelsSelectedForDestruction: [newModel],
+    });
+  });
+
+  it("clearSelectedModelsForDestruction", () => {
+    const state = jujuStateFactory.build({
+      modelsSelectedForDestruction: modelSelectionParamsFactory.buildList(2),
+    });
+    expect(
+      reducer(state, actions.clearSelectedModelsForDestruction()),
+    ).toStrictEqual({
+      ...state,
+      modelsSelectedForDestruction: [],
     });
   });
 

--- a/src/store/juju/reducers.test.ts
+++ b/src/store/juju/reducers.test.ts
@@ -439,6 +439,52 @@ describe("reducers", () => {
     });
   });
 
+  it("selectModelsForDestruction", () => {
+    const state = jujuStateFactory.build({
+      modelsSelectedForDestruction: [],
+    });
+    expect(
+      reducer(
+        state,
+        actions.selectModelsForDestruction({
+          wsControllerURL: "wss://example.com",
+          models: [
+            { modelUUID: "abc123", modelName: "test-model-1" },
+            { modelUUID: "def456", modelName: "test-model-2" },
+          ],
+        }),
+      ),
+    ).toStrictEqual({
+      ...state,
+      modelsSelectedForDestruction: [
+        { modelUUID: "abc123", modelName: "test-model-1" },
+        { modelUUID: "def456", modelName: "test-model-2" },
+      ],
+    });
+  });
+
+  it("selectModelsForDestruction replaces previous selection", () => {
+    const state = jujuStateFactory.build({
+      modelsSelectedForDestruction: [
+        { modelUUID: "old123", modelName: "old-model" },
+      ],
+    });
+    expect(
+      reducer(
+        state,
+        actions.selectModelsForDestruction({
+          wsControllerURL: "wss://example.com",
+          models: [{ modelUUID: "new456", modelName: "new-model" }],
+        }),
+      ),
+    ).toStrictEqual({
+      ...state,
+      modelsSelectedForDestruction: [
+        { modelUUID: "new456", modelName: "new-model" },
+      ],
+    });
+  });
+
   it("destroyModelErrors", () => {
     const state = jujuStateFactory.build({
       destroyModel: {

--- a/src/store/juju/selectors.test.ts
+++ b/src/store/juju/selectors.test.ts
@@ -33,6 +33,7 @@ import {
   jujuStateFactory,
   modelDataFactory,
   modelListInfoFactory,
+  modelSelectionParamsFactory,
   auditEventsStateFactory,
   crossModelQueryStateFactory,
   secretsStateFactory,
@@ -1191,8 +1192,14 @@ describe("selectors", () => {
 
   it("getSelectedModelsForDestruction", () => {
     const selectedModels = [
-      { modelUUID: "abc123", modelName: "test-model-1" },
-      { modelUUID: "def456", modelName: "test-model-2" },
+      modelSelectionParamsFactory.build({
+        modelUUID: "abc123",
+        modelName: "test-model-1",
+      }),
+      modelSelectionParamsFactory.build({
+        modelUUID: "def456",
+        modelName: "test-model-2",
+      }),
     ];
     expect(
       getSelectedModelsForDestruction(

--- a/src/store/juju/selectors.test.ts
+++ b/src/store/juju/selectors.test.ts
@@ -160,6 +160,7 @@ import {
   getModelUpgradeDataLoaded,
   getHighestSupportedVersion,
   getNextSupportedVersion,
+  getSelectedModelsForDestruction,
 } from "./selectors";
 
 describe("selectors", () => {
@@ -1186,6 +1187,22 @@ describe("selectors", () => {
         }),
       ),
     ).toStrictEqual(destroyModelData);
+  });
+
+  it("getSelectedModelsForDestruction", () => {
+    const selectedModels = [
+      { modelUUID: "abc123", modelName: "test-model-1" },
+      { modelUUID: "def456", modelName: "test-model-2" },
+    ];
+    expect(
+      getSelectedModelsForDestruction(
+        rootStateFactory.build({
+          juju: jujuStateFactory.build({
+            modelsSelectedForDestruction: selectedModels,
+          }),
+        }),
+      ),
+    ).toStrictEqual(selectedModels);
   });
 
   it("getModelUUID from model name", () => {

--- a/src/store/juju/selectors.ts
+++ b/src/store/juju/selectors.ts
@@ -789,6 +789,14 @@ export const getDestructionState = createSelector(
 );
 
 /**
+ * Returns the UUIDs of models currently staged for bulk destruction in the UI.
+ */
+export const getSelectedModelsForDestruction = createSelector(
+  [slice],
+  (sliceState) => sliceState.modelsSelectedForDestruction,
+);
+
+/**
   Gets the model UUID from the supplied name using a memoized selector
   Usage:
     const getModelUUIDMemo = useMemo(getModelUUID.bind(null, modelName), [

--- a/src/store/juju/slice.ts
+++ b/src/store/juju/slice.ts
@@ -37,6 +37,7 @@ import type {
   AddModel,
   BlockEntry,
   ModelDestructionParams,
+  ModelSelectionParams,
 } from "./types";
 import { getModelQualifier } from "./utils/models";
 
@@ -158,6 +159,7 @@ const slice = createSlice({
       loading: false,
     },
     selectedApplications: {},
+    modelsSelectedForDestruction: [],
     supportedJujuVersions: {
       data: null,
       error: null,
@@ -347,6 +349,17 @@ const slice = createSlice({
       >,
     ) => {
       delete state.destroyModel[action.payload.modelUUID];
+    },
+    selectModelsForDestruction: (
+      state,
+      action: PayloadAction<
+        { models: ModelSelectionParams[] } & WsControllerURLParam
+      >,
+    ) => {
+      state.modelsSelectedForDestruction = action.payload.models;
+    },
+    clearSelectedModelsForDestruction: (state) => {
+      state.modelsSelectedForDestruction = [];
     },
     destroyModelErrors: (
       state,

--- a/src/store/juju/types.ts
+++ b/src/store/juju/types.ts
@@ -192,10 +192,12 @@ export type BlockEntry = {
 
 export type BlockState = Record<string, BlockEntry>;
 
-export type ModelDestructionParams = {
+export type ModelSelectionParams = {
   modelUUID: string;
   modelName: string;
-} & DestroyModelParams;
+};
+
+export type ModelDestructionParams = DestroyModelParams & ModelSelectionParams;
 
 export type JujuState = {
   auditEvents: AuditEventsState;
@@ -218,6 +220,7 @@ export type JujuState = {
   userCredentials: UserCredentialsState;
   modelConfigDefaults: ModelConfigDefaultsState;
   selectedApplications: Record<string, ApplicationStatus>;
+  modelsSelectedForDestruction: ModelSelectionParams[];
   supportedJujuVersions: SupportedJujuVersionsState;
   addModelState: AddModelState;
   blockState: BlockState;

--- a/src/testing/factories/juju/juju.ts
+++ b/src/testing/factories/juju/juju.ts
@@ -17,6 +17,7 @@ import type {
   ModelFeaturesState,
   ModelListInfo,
   ModelMigrationTargetsState,
+  ModelSelectionParams,
   ModelSecrets,
   ModelUpgrade,
   ReBACState,
@@ -63,6 +64,14 @@ export const controllerInfoFactory = Factory.define<Controller>(() => ({
   username: "eggman@external",
   uuid: "def456",
 }));
+
+export const modelSelectionParamsFactory = Factory.define<ModelSelectionParams>(
+  () => ({
+    // spell-checker:disable-next-line
+    modelUUID: "84e872ff-9171-46be-829b-70f0ffake18d",
+    modelName: "test-model",
+  }),
+);
 
 export const modelListInfoFactory = Factory.define<ModelListInfo>(() => ({
   name: "test-model",

--- a/src/testing/factories/juju/juju.ts
+++ b/src/testing/factories/juju/juju.ts
@@ -206,6 +206,7 @@ export const jujuStateFactory = Factory.define<JujuState>(() => ({
   userCredentials: userCredentialsStateFactory.build(),
   modelConfigDefaults: modelConfigDefaultsStateFactory.build(),
   selectedApplications: {},
+  modelsSelectedForDestruction: [],
   supportedJujuVersions: supportedJujuVersionsStateFactory.build(),
   modelMigrationTargets: modelMigrationTargetsStateFactory.build(),
   addModelState: addModelStateFactory.build(),


### PR DESCRIPTION
Depends on https://github.com/canonical/juju-dashboard/pull/2466

## Done

- Introduced a new panel for bulk model destruction
- Introduced a store state for saving models selected for bulk destruction
- Added logic for switching experiences based on the number of models selected
  - If one selected, show single model destruction modal
  - If multiple selected, show the new flow with a side panel
- Added tests 

Note: The side panel is currently stubbed for configurations within the model. They will be added in https://warthogs.atlassian.net/browse/JUJU-10310

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- On the models list page, try interacting with the checkboxes in the table and beginning the destroy flow
- Do it 
  - with a single model
  - with multiple models
  - from model actions
  - using the `Review & Destroy` button
- Verify the information on the button, the labels in the side panel, etc.
- Verify that only the single destroy can be triggered

## Details

https://warthogs.atlassian.net/browse/JUJU-10309

## Screenshots

https://github.com/user-attachments/assets/182b7bf1-e0b0-473f-92ad-2935417e850a



