### PR TITLE
fix(ModelTable): keep cloud/region logo and text on one line

### DIFF
--- a/src/components/ModelTable/CloudCell/CloudCell.test.tsx
+++ b/src/components/ModelTable/CloudCell/CloudCell.test.tsx
@@ -17,6 +17,22 @@ describe("CloudCell", () => {
     expect(screen.queryByRole("img")).not.toBeInTheDocument();
   });
 
+  it("wraps the logo and region text in a single-line cell", () => {
+    const { container } = render(
+      <CloudCell
+        model={modelDataFactory.build({
+          info: modelInfoFactory.build({
+            "provider-type": "ec2",
+          }),
+        })}
+      />,
+    );
+    const cell = container.querySelector(".models__cloud-cell");
+    expect(cell).not.toBeNull();
+    expect(cell?.querySelector("img.p-table__logo")).not.toBeNull();
+    expect(cell?.querySelector(".truncated-tooltip")).not.toBeNull();
+  });
+
   it("can generate an AWS logo", () => {
     render(
       <CloudCell

--- a/src/components/ModelTable/CloudCell/CloudCell.tsx
+++ b/src/components/ModelTable/CloudCell/CloudCell.tsx
@@ -47,7 +47,7 @@ const CloudCell: FC<Props> = ({ model }: Props) => {
     return generateCloudAndRegion(model);
   }, [model]);
   return (
-    <>
+    <span className="models__cloud-cell">
       {src && alt ? (
         <img
           src={src}
@@ -58,7 +58,7 @@ const CloudCell: FC<Props> = ({ model }: Props) => {
       ) : null}
 
       <TruncatedTooltip message={regionText}>{regionText}</TruncatedTooltip>
-    </>
+    </span>
   );
 };
 

--- a/src/components/ModelTable/_model-table.scss
+++ b/src/components/ModelTable/_model-table.scss
@@ -21,6 +21,28 @@
     margin-left: $sph--small;
   }
 
+  // Logo + region text on one line: the truncated-tooltip wrapper is a block
+  // div, without this flex row it drops under the provider logo when the
+  // cloud/region column is narrow (juju-dashboard#2455).
+  .models__cloud-cell {
+    display: inline-flex;
+    align-items: center;
+    gap: $sph--small;
+
+    .p-table__logo {
+      flex-shrink: 0;
+    }
+
+    .truncated-tooltip {
+      flex: 1;
+      min-width: 0;
+    }
+  }
+
+  .models__version {
+    margin-left: $sph--small;
+  }
+
   .lrg-screen-access-cell {
     button {
       margin-left: auto;

--- a/src/components/ModelTable/_model-table.scss
+++ b/src/components/ModelTable/_model-table.scss
@@ -25,8 +25,8 @@
   // div, without this flex row it drops under the provider logo when the
   // cloud/region column is narrow (juju-dashboard#2455).
   .models__cloud-cell {
-    display: inline-flex;
     align-items: center;
+    display: inline-flex;
     gap: $sph--small;
 
     .p-table__logo {


### PR DESCRIPTION
Fixes #2455.

The truncated-tooltip wrapper inside the cloud/region cell is a block-level div, so as soon as the column gets narrow the region text dropped to the next line under the provider logo (see the screenshot in the issue).

The cell now wraps the logo and the tooltip in an inline-flex row:

- `models__cloud-cell` (in `_model-table.scss`): inline flex with a small gap, logo set to `flex-shrink: 0`
- the `.truncated-tooltip` child gets `flex: 1; min-width: 0`, so the existing `u-truncate` ellipsis still engages when the column is narrow
- no provider logo (no icon case): same wrapper, harmless

Regression test added in `CloudCell.test.tsx`: the cell must contain both the logo and the truncated-tooltip wrapper. ModelTable suite 21/21, eslint/prettier/stylelint clean.

Repro before the change: /models with cloud/region rendered with icons, narrow viewport column: text wraps under the logo. After: logo and text stay on one line, long region names ellipsis inside the tooltip element.
